### PR TITLE
Fix: Missing permissions in Gemini Dispatcher

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -12,6 +12,11 @@ on:
   issues:
     types: ['opened']
 
+permissions:
+  contents: 'read'
+  issues: 'write'
+  pull-requests: 'write'
+
 jobs:
   dispatch:
     if: github.event.sender.type != 'Bot'


### PR DESCRIPTION
Critical fix to enable the dispatcher to post comments and route events correctly.