### PR TITLE
Fix: Use run-gemini-cli@main for Dispatcher

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: 'Run Gemini Dispatcher'
         id: 'dispatch'
-        uses: 'google-github-actions/run-gemini-cli@v0.1.19'
+        uses: 'google-github-actions/run-gemini-cli@main'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           command: 'dispatch'

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -29,7 +29,7 @@ jobs:
         uses: 'actions/checkout@v4'
 
       - name: 'Run Gemini CLI'
-        uses: 'google-github-actions/run-gemini-cli@v0.1.19'
+        uses: 'google-github-actions/run-gemini-cli@main'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           prompt: '${{ inputs.prompt }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -24,7 +24,7 @@ jobs:
         uses: 'actions/checkout@v4'
 
       - name: 'Run Gemini CLI'
-        uses: 'google-github-actions/run-gemini-cli@v0.1.19'
+        uses: 'google-github-actions/run-gemini-cli@main'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           prompt: '/gemini-review'


### PR DESCRIPTION
The tag v0.1.19 does not support the  input. Switching to  enables the official router pattern.