### PR TITLE
Fix: Use github-script for Gemini Dispatcher

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -6,11 +6,11 @@ on:
   pull_request_review:
     types: ['submitted']
   pull_request:
-    types: ['opened']
+    types: ['opened', 'reopened', 'synchronize']
   issue_comment:
     types: ['created']
   issues:
-    types: ['opened']
+    types: ['opened', 'reopened']
 
 permissions:
   contents: 'read'


### PR DESCRIPTION
The official router pattern uses  to parse commands. This PR refactors the dispatcher to follow that verified pattern and enables correct routing to  and  workflows.