### PR TITLE
ci: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'go.**'
+      - '**.go'
+      - 'Dockerfile'
+      - '.github/workflows/deploy.yml'
+
+env:
+  PROJECT_ID: liverty-music-dev
+  REGION: asia-northeast2
+  REPOSITORY: backend
+  IMAGE: server
+  WORKLOAD_IDENTITY_PROVIDER: projects/1058199000631/locations/global/workloadIdentityPools/external-providers/providers/github-provider
+  SERVICE_ACCOUNT: github-actions@liverty-music-dev.iam.gserviceaccount.com
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:latest,${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Description
This PR adds the CI/CD workflow to deploy the backend application.

### Changes
*   **CI/CD Workflow (`deploy.yml`):**
    *   Triggers on push to `main`.
    *   Authenticates via Workload Identity Federation (configured in `cloud-provisioning`).
    *   Builds the Docker image.
    *   Pushes the image to Google Artifact Registry (`asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server`).

## Verification
*   The workflow will trigger upon merge and should succeed if the infrastructure PR is merged first.
