### PR TITLE
fix(ci): fix docker build cache error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,9 @@ jobs:
 
       - name: Set Image URI
         run: echo "IMAGE_URI=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Added setup-buildx-action to support `type=gha` cache export.