### PR TITLE
feat: add CORS validation and configuration validation (#expose-api-via-gateway)

### DIFF
--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -27,9 +27,17 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		return nil, err
 	}
 
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	logger, err := provideLogger(cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(cfg.Server.AllowedOrigins) == 0 {
+		logger.Warn(ctx, "⚠️  CORS not configured, browser requests will fail")
 	}
 
 	db, err := rdb.New(ctx, cfg, logger)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,7 +138,7 @@ type ServerConfig struct {
 	IdleTimeout time.Duration `envconfig:"SERVER_IDLE_TIMEOUT" default:"3s"`
 
 	// Allowed CORS origins
-	AllowedOrigins []string `envconfig:"CORS_ALLOWED_ORIGINS" default:"http://localhost:9000"`
+	AllowedOrigins []string `envconfig:"CORS_ALLOWED_ORIGINS"`
 }
 
 // DatabaseConfig represents database-specific configuration.
@@ -299,6 +299,10 @@ func (c *Config) Validate() error {
 
 	if !valid {
 		return fmt.Errorf("invalid log format: %s", c.Logging.Format)
+	}
+
+	if !c.IsLocal() && len(c.Server.AllowedOrigins) == 0 {
+		return fmt.Errorf("CORS allowed origins are required for non-local environments")
 	}
 
 	if !c.IsLocal() && c.Database.InstanceConnectionName == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -34,7 +34,7 @@ func TestLoad(t *testing.T) {
 					ReadTimeout:       1 * time.Second,
 					HandlerTimeout:    5 * time.Second,
 					IdleTimeout:       3 * time.Second,
-					AllowedOrigins:    []string{"http://localhost:9000"},
+					AllowedOrigins:    nil,
 				},
 				Database: DatabaseConfig{
 					Host:            "localhost",
@@ -100,7 +100,7 @@ func TestLoad(t *testing.T) {
 					ReadTimeout:       2 * time.Second,
 					HandlerTimeout:    10 * time.Second,
 					IdleTimeout:       45 * time.Second,
-					AllowedOrigins:    []string{"http://localhost:9000"},
+					AllowedOrigins:    nil,
 				},
 				Database: DatabaseConfig{
 					Host:            "localhost",
@@ -166,7 +166,7 @@ func TestConfig_Validate(t *testing.T) {
 			name: "valid development config",
 			config: &Config{
 				Environment: "development",
-				Server:      ServerConfig{Port: 8080},
+				Server:      ServerConfig{Port: 8080, AllowedOrigins: []string{"http://localhost:9000"}},
 				Database: DatabaseConfig{
 					Port:                   5432,
 					InstanceConnectionName: "project:region:instance",
@@ -193,6 +193,19 @@ func TestConfig_Validate(t *testing.T) {
 					Issuer:              "https://test-issuer.com",
 					JWKSRefreshInterval: 15 * time.Minute,
 				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing allowed origins in development",
+			config: &Config{
+				Environment: "development",
+				Server:      ServerConfig{Port: 8080},
+				Database: DatabaseConfig{
+					Port:                   5432,
+					InstanceConnectionName: "project:region:instance",
+				},
+				Logging: LoggingConfig{Level: "info", Format: "json"},
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Refinining Gateway API exposure:
- Added CORS validation at startup in `internal/di/provider.go`.
- Added configuration options for `AllowedOrigins` in `pkg/config/config.go`.
- Updated tests.

Part of #expose-api-via-gateway