### PR TITLE
feat: add artist discovery and follow functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.25.7-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -107,7 +107,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	// Auth - JWT Validator and Interceptor
 	jwtValidator, err := auth.NewJWTValidator(
 		cfg.JWT.Issuer,
-		cfg.JWT.Issuer+"/.well-known/jwks.json",
+		cfg.JWT.Issuer+"/oauth/v2/keys",
 		cfg.JWT.JWKSRefreshInterval,
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Bump Go from 1.25.5 to 1.25.7 in Dockerfile
- Fix JWKS endpoint path from `/.well-known/jwks.json` to `/oauth/v2/keys` in JWT validator initialization

## Test Plan

- [ ] Verify JWT authentication works with the corrected JWKS endpoint
- [ ] Verify Docker image builds with Go 1.25.7