### PR TITLE
fix(cors): add Authorization to allowed headers for bearer token auth

### DIFF
--- a/internal/infrastructure/server/cors.go
+++ b/internal/infrastructure/server/cors.go
@@ -14,10 +14,11 @@ func NewCORSHandler(mu http.Handler, allowedOrigins []string) http.Handler {
 
 // GetCorsOptions returns the rs/cors Options used by the handler.
 func GetCorsOptions(allowedOrigins []string) cors.Options {
+	allowedHeaders := append(connectcors.AllowedHeaders(), "Authorization")
 	return cors.Options{
 		AllowedOrigins: allowedOrigins,
 		AllowedMethods: connectcors.AllowedMethods(),
-		AllowedHeaders: connectcors.AllowedHeaders(),
+		AllowedHeaders: allowedHeaders,
 		ExposedHeaders: connectcors.ExposedHeaders(),
 	}
 }

--- a/internal/infrastructure/server/cors_test.go
+++ b/internal/infrastructure/server/cors_test.go
@@ -14,6 +14,7 @@ func TestGetCorsOptions(t *testing.T) {
 	assert.Equal(t, allowedOrigins, options.AllowedOrigins)
 	assert.Contains(t, options.AllowedMethods, http.MethodPost)
 	assert.Contains(t, options.AllowedHeaders, "Connect-Protocol-Version")
+	assert.Contains(t, options.AllowedHeaders, "Authorization")
 	assert.Contains(t, options.ExposedHeaders, "Grpc-Status")
 }
 


### PR DESCRIPTION
## Description

CORS の許可ヘッダーに `Authorization` が含まれていなかったため、認証済み API 呼び出し時のブラウザ preflight リクエストが失敗していた問題を修正します。

### 問題の詳細

フロントエンドは Connect-RPC リクエスト時に `Authorization: Bearer <token>` ヘッダーを付与します。ブラウザはこのヘッダーを含む preflight OPTIONS リクエストを送りますが、バックエンドの CORS 許可ヘッダーリストに `Authorization` がなかったため、preflight が拒否されていました。

**エラーメッセージ（ブラウザコンソール）:**
```
Access to fetch at 'https://api.dev.liverty-music.app/...'
from origin 'http://localhost:9000' has been blocked by CORS policy:
Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

### 原因

`rs/cors` v1.11.1 の `SortedSet.Accepts` は `Access-Control-Request-Headers` を検証する際、ヘッダー名が許可リストに含まれているかを確認します。`Authorization` が `connectcors.AllowedHeaders()` の戻り値に含まれていないため、全 preflight が失敗していました。

### 修正

`GetCorsOptions` で `connectcors.AllowedHeaders()` に `Authorization` を追加します。

## Type of Change

- [x] fix: A bug fix

## Verification

### Automated Tests
- [x] `go test ./...` passed

### Manual Verification

ローカルテストで確認済み：
```
--- Auth request: authorization,connect-protocol-version,content-type (sorted) ---
Status: 204, ACAO: "http://localhost:9000"  ✅
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings