### PR TITLE
fix(gemini): approve PR when no issues found on re-review

### DIFF
--- a/.gemini/commands/github-actions-review.toml
+++ b/.gemini/commands/github-actions-review.toml
@@ -43,20 +43,18 @@ Find defects or say nothing. If no critical issues: output ONLY "LGTM".
 - Find CRITICAL issues per Focus Areas
 - Skip issues from Step 2
 
-**Step 4: Post Comments**
-- Format: **[Critical]** `file:line` followed by Issue and Fix
-- Severity: Critical (security, crashes, data loss) | Warning (performance, leaks)
-- Call: `create_pending_pull_request_review` → `add_comment_to_pending_review` → `submit_pending_pull_request_review`
+**Step 4: Submit Review**
 
-## Output
-No issues found: `LGTM`
+**IF no issues found:**
+- Call `submit_pending_pull_request_review` with event `APPROVE` and empty body
+- Do NOT add any comment or body text
 
-Issues found:
-```
-**[Critical]** `file_path:line_number`
-Issue: [Brief explanation]
-Fix: [Actionable solution]
-```
+**IF issues found:**
+- Call `create_pending_pull_request_review` with event `REQUEST_CHANGES`
+- For each issue: call `add_comment_to_pending_review`
+  - Format: **[Critical]** `file:line` followed by Issue and Fix
+  - Severity: Critical (security, crashes, data loss) | Warning (performance, leaks)
+- Call `submit_pending_pull_request_review`
 
 Do NOT add: summaries, praise, explanations of code, trivial suggestions.
 """

--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -16,6 +16,10 @@ permissions:
   contents: 'read'
   pull-requests: 'write'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review:
     runs-on: 'ubuntu-latest'
@@ -29,17 +33,23 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
-          PULL_REQUEST_BODY: ${{ github.event.pull_request.body || github.event.issue.body }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+          PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_model: 'gemini-3-flash-preview'
           prompt: '/github-actions-review'
-          workflow_name: 'gemini_review'
+          gemini_debug: false
+          workflow_name: 'gemini-review'
           settings: |-
             {
+              "model": {
+                "maxSessionTurns": 20,
+                "compressionThreshold": 0.4
+              },
               "mcpServers": {
                 "github": {
                   "command": "docker",
@@ -51,9 +61,7 @@ jobs:
                   "includeTools": [
                     "add_comment_to_pending_review",
                     "pull_request_read",
-                    "pull_request_review_write",
-                    "get_pull_request_comments",
-                    "get_pull_request_reviews"
+                    "pull_request_review_write"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
@@ -62,10 +70,7 @@ jobs:
               },
               "tools": {
                 "core": [
-                  "run_shell_command(cat)",
-                  "run_shell_command(ls)",
-                  "run_shell_command(grep)",
-                  "run_shell_command(find)"
+                  "run_shell_command(git)"
                 ]
               }
             }


### PR DESCRIPTION
## Summary
- Gemini review now submits `APPROVE` when no critical issues are found, instead of just commenting "LGTM"
- When issues exist, explicitly uses `REQUEST_CHANGES` with inline comments
- Aligns `gemini.yml` with other repos: adds concurrency group, `GITHUB_EVENT_ACTION` env, model settings, and normalizes tool config

## Test plan
- [ ] Open a PR with no issues and verify Gemini submits an APPROVE review
- [ ] Open a PR with a critical issue and verify Gemini submits REQUEST_CHANGES with inline comments