### PR TITLE
ci(gemini): increase maxSessionTurns from 20 to 40

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -47,7 +47,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 20,
+                "maxSessionTurns": 40,
                 "compressionThreshold": 0.4
               },
               "mcpServers": {


### PR DESCRIPTION
## Summary

- `maxSessionTurns` を 20 → 40 に増加

## Background

差分が大きい PR で Gemini review が `FatalTurnLimitedError` に達し、
インラインコメントを投稿できないまま `CHANGES_REQUESTED` を submit する問題が発生。
ターン数を倍にして、レビューを完了できるよう対処。