### PR TITLE
ci: add skip-job pattern to prevent Required Check merge blocks

### DIFF
--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -3,11 +3,6 @@ name: Atlas CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'internal/infrastructure/database/rdb/migrations/**'
-      - 'internal/infrastructure/database/rdb/model.go'
-      - 'atlas.hcl'
-      - '.github/workflows/atlas-ci.yml'
 
 permissions:
   contents: read
@@ -20,7 +15,25 @@ env:
   DATABASE_URL: "postgres://postgres:password@localhost:5432/postgres?sslmode=disable"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'internal/infrastructure/database/rdb/migrations/**'
+              - 'internal/infrastructure/database/rdb/model.go'
+              - 'atlas.hcl'
+              - '.github/workflows/atlas-ci.yml'
+
   atlas-ci:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -49,3 +62,10 @@ jobs:
           atlas migrate validate \
             --dev-url "${{ env.DATABASE_URL }}" \
             --dir "file://internal/infrastructure/database/rdb/migrations/versions"
+
+  atlas-ci-skip:
+    needs: changes
+    if: needs.changes.outputs.src == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No relevant changes, skipping Atlas CI"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,19 +3,7 @@ name: Lint
 on:
   push:
     branches: [main]
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.golangci.yml'
-      - '.github/workflows/lint.yml'
   pull_request:
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.golangci.yml'
-      - '.github/workflows/lint.yml'
 
 permissions:
   contents: read
@@ -25,7 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.golangci.yml'
+              - '.github/workflows/lint.yml'
+
   golangci:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: golangci-lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -40,6 +47,14 @@ jobs:
         with:
           version: latest
           args: --timeout=3m --build-tags=integration
+
+  golangci-skip:
+    needs: changes
+    if: needs.changes.outputs.src == 'false'
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No relevant changes, skipping lint"
 
   gofmt:
     name: gofmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,19 +3,7 @@ name: Test
 on:
   push:
     branches: [main]
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'internal/infrastructure/database/rdb/migrations/**'
-      - '.github/workflows/test.yml'
   pull_request:
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'internal/infrastructure/database/rdb/migrations/**'
-      - '.github/workflows/test.yml'
 
 permissions:
   contents: read
@@ -25,7 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'internal/infrastructure/database/rdb/migrations/**'
+              - '.github/workflows/test.yml'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -80,7 +87,17 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  test-skip:
+    needs: changes
+    if: needs.changes.outputs.src == 'false'
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No relevant changes, skipping tests"
+
   vulnerability-check:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Vulnerability Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -98,10 +115,18 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 
+  vulnerability-check-skip:
+    needs: changes
+    if: needs.changes.outputs.src == 'false'
+    name: Vulnerability Check
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No relevant changes, skipping vulnerability check"
+
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [test, vulnerability-check]
+    needs: [test, test-skip, vulnerability-check, vulnerability-check-skip]
     if: always()
     steps:
       - name: Check all jobs passed


### PR DESCRIPTION
## 🔗 Related Issue

Closes #65

## 📝 Summary of Changes

Workflows with `paths` filters are **skipped entirely** when non-matching files are changed. GitHub treats skipped jobs as "not reported" rather than "success", which blocks merges when those jobs are configured as Required Status Checks.

This PR replaces workflow-level `paths` filters with `dorny/paths-filter` at the job level, so a dedicated skip job always reports a success status to GitHub — even when there are no relevant changes.

**Pattern applied:**
- `changes` job: detects relevant file changes via `dorny/paths-filter`
- Main job: runs only when `changes.outputs.src == 'true'`
- Skip job: runs when `changes.outputs.src == 'false'`, reporting success immediately

**Affected workflows:**
- `atlas-ci.yml` — Required Check: `Atlas CI / atlas-ci`
- `lint.yml` — Required Check: `Lint / golangci`
- `test.yml` — Required Checks: `Test / test`, `Test / vulnerability-check`

Also incorporates upstream changes from `main` (Atlas Migrate Validate step, `gofmt` job, `ci-success` aggregate job, `timeout-minutes`).

## 📋 Commit Log

```
d5d260e ci: add skip-job pattern to prevent Required Check merge blocks
```

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [ ] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [ ] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.