### PR TITLE
fix: remove out-of-bounds symlink breaking ArgoCD sync

### DIFF
--- a/.claude/skills/backend-workflow
+++ b/.claude/skills/backend-workflow
@@ -1,1 +1,0 @@
-/home/pannpers/dev/src/worktrees/interactive-artist-onboarding/github.com/liverty-music/backend/.agent/skills/backend-workflow

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ vendor/
 
 # Claude settings
 .claude/settings.local.json
+.claude/skills/backend-workflow
 
 # OS-generated files
 .DS_Store


### PR DESCRIPTION
## Summary
- Remove `.claude/skills/backend-workflow` symlink that pointed to an absolute local path
- Add it to `.gitignore` to prevent re-committing

## Context
ArgoCD `backend-migrations` app fails to sync with:
```
repository contains out-of-bounds symlinks. file: .claude/skills/backend-workflow
```

## Test plan
- [ ] ArgoCD `backend-migrations` app syncs successfully after merge