### PR TITLE
fix(k8s): set AtlasMigration sync-wave after ConfigMap

### DIFF
--- a/k8s/atlas/base/atlas-migration.yaml
+++ b/k8s/atlas/base/atlas-migration.yaml
@@ -3,7 +3,7 @@ kind: AtlasMigration
 metadata:
   name: backend-migration
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   credentials:
     scheme: postgres


### PR DESCRIPTION
## Summary
- Change AtlasMigration sync-wave from `-1` to `1`

## Context
ArgoCD `backend-migrations` app creates AtlasMigration (wave -1) before ConfigMap (wave 0), causing:
```
ConfigMap "atlas-migration-dir" not found
```

By setting AtlasMigration to wave 1, the ConfigMap is created first (wave 0), then AtlasMigration can reference it.

## Test plan
- [ ] ArgoCD `backend-migrations` app syncs successfully
- [ ] AtlasMigration reaches `Ready: True`