### PR TITLE
fix(k8s): disable ConfigMap name suffix hash for Atlas migration

### DIFF
--- a/k8s/atlas/base/kustomization.yaml
+++ b/k8s/atlas/base/kustomization.yaml
@@ -6,6 +6,9 @@ namespace: atlas-operator
 resources:
 - atlas-migration.yaml
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - name: atlas-migration-dir
   files:


### PR DESCRIPTION
## Summary
- Add `generatorOptions.disableNameSuffixHash: true` to atlas kustomization

## Context
Kustomize generates ConfigMap as `atlas-migration-dir-d5h8865ftk` but `AtlasMigration` CRD references `atlas-migration-dir` literally (Kustomize doesn't auto-rewrite CRD field refs). This causes:
```
ConfigMap "atlas-migration-dir" not found
```

## Test plan
- [ ] ArgoCD syncs `backend-migrations` app
- [ ] AtlasMigration reaches `Ready: True`
- [ ] Migration runs successfully against Cloud SQL