### PR TITLE
fix(k8s): use sslmode=require for Cloud SQL connection

### DIFF
--- a/k8s/atlas/base/atlas-migration.yaml
+++ b/k8s/atlas/base/atlas-migration.yaml
@@ -17,7 +17,7 @@ spec:
     database: liverty-music
     parameters:
       search_path: app,public
-      sslmode: disable
+      sslmode: require
   dir:
     configMapRef:
       name: atlas-migration-dir


### PR DESCRIPTION
## Summary
- Change AtlasMigration `sslmode` from `disable` to `require`

## Context
Cloud SQL rejects the connection:
```
pg_hba.conf rejects connection for host "10.100.181.2", user "postgres", database "liverty-music", no encryption
```

## Test plan
- [ ] AtlasMigration connects and runs migrations successfully