### PR TITLE
fix(k8s): use single schema in search_path for Atlas

### DIFF
--- a/k8s/atlas/base/atlas-migration.yaml
+++ b/k8s/atlas/base/atlas-migration.yaml
@@ -16,7 +16,7 @@ spec:
         key: postgres-admin-password
     database: liverty-music
     parameters:
-      search_path: app,public
+      search_path: app
       sslmode: require
   dir:
     configMapRef:


### PR DESCRIPTION
## Summary
- Atlas Operator interprets `search_path=app,public` as a single literal schema name `"app,public"` rather than two separate schemas
- This caused: `relation "app,public.atlas_schema_revisions" does not exist`
- Changed to `search_path=app` since all tables are created in the `app` schema

## Context
Part of Cloud SQL migration (specification#67). Previous fixes:
- PR #86: Remove out-of-bounds symlink
- PR #87: Fix sync-wave ordering
- PR #88: Disable ConfigMap hash suffix
- PR #89: Use sslmode=require

## Test plan
- [ ] ArgoCD syncs updated manifest
- [ ] AtlasMigration successfully applies 26 pending migrations
- [ ] Backend pod connects and serves API