### PR TITLE
fix(ci): pin claude-code-action to v1.0.51

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.51
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.51
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Pin `anthropics/claude-code-action` from `@v1` to `@v1.0.51` in both `claude-review.yml` and `claude.yml`
- Works around the AJV schema validation crash in claude-agent-sdk 0.2.15+ that causes exit code 1 failures

## References
- https://github.com/anthropics/claude-code-action/issues/947
- https://github.com/anthropics/claude-code-action/issues/852

## Test plan
- [ ] Verify review job no longer crashes with exit code 1 on new PRs