### PR TITLE
fix(ci): pin claude-code-action to v1.0.42

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1.0.51
+      - uses: anthropics/claude-code-action@v1.0.42
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1.0.51
+      - uses: anthropics/claude-code-action@v1.0.42
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Pin `anthropics/claude-code-action` from v1.0.51 to v1.0.42 to avoid SDK AJV crash

## Test plan
- [ ] Claude auto-review triggers on PR events
- [ ] Interactive `@claude` mentions work in PR comments