### PR TITLE
fix(migration): grant app schema access to all IAM database users

### DIFF
--- a/k8s/atlas/base/kustomization.yaml
+++ b/k8s/atlas/base/kustomization.yaml
@@ -40,3 +40,4 @@ configMapGenerator:
   - migrations/20260221160000_fix_ticket_system_schema.sql
   - migrations/20260222120000_add_push_subscriptions_table.sql
   - migrations/20260222130000_add_passion_level_to_followed_artists.sql
+  - migrations/20260223120000_grant_iam_users_app_schema.sql

--- a/k8s/atlas/base/migrations/20260223120000_grant_iam_users_app_schema.sql
+++ b/k8s/atlas/base/migrations/20260223120000_grant_iam_users_app_schema.sql
@@ -1,0 +1,19 @@
+-- Grant app schema permissions to all Cloud SQL IAM-authenticated users.
+-- The original bootstrap migration only matched '%@%.iam' (Workload Identity SAs).
+-- This migration extends access to human IAM users (CLOUD_IAM_USER type)
+-- so they can browse the app schema via Cloud SQL Studio and other tools.
+
+DO $$
+DECLARE
+  iam_role TEXT;
+BEGIN
+  -- Match all IAM-authenticated roles: both service accounts (user@project.iam)
+  -- and human users (user@domain.tld) registered via CLOUD_IAM_USER.
+  FOR iam_role IN SELECT rolname FROM pg_roles WHERE rolname LIKE '%@%' LOOP
+    EXECUTE format('GRANT USAGE ON SCHEMA app TO %I', iam_role);
+    EXECUTE format('GRANT SELECT ON ALL TABLES IN SCHEMA app TO %I', iam_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT ON TABLES TO %I', iam_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT USAGE, SELECT ON SEQUENCES TO %I', iam_role);
+  END LOOP;
+END
+$$;

--- a/k8s/atlas/base/migrations/atlas.sum
+++ b/k8s/atlas/base/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:cL34lN8PFQ9QIKtLSQlHjHKSuGk43zcF6IENQSiU6AA=
+h1:Go6IsfnSqBZygu+j0ZSLTzRS0Ai7F33i0muU/HrU5sM=
 20250726000000_bootstrap_app_schema.sql h1:nKAFSMmbY+9pdhajenyx25jK6t5SAHc5x/JpNt9EgFM=
 20250726081442_initial_schema.sql h1:cWOx1AMHpgE784lJBtFmEj1oXRBkeqv56bKw1XV8ThI=
 20250726101741_add_foreign_key_to_posts.sql h1:Yq6yocwX7/UQHaMneA16MoHzImLamXDe7PvGYiGWudw=
@@ -26,3 +26,4 @@ h1:cL34lN8PFQ9QIKtLSQlHjHKSuGk43zcF6IENQSiU6AA=
 20260221160000_fix_ticket_system_schema.sql h1:8Vq8uJ1FBElErQJG2mroZsADNGk7LKP86kblIkYzouc=
 20260222120000_add_push_subscriptions_table.sql h1:HkmeJARmOBgit6Kh7fX3WLu/whg4UW+VW5zwd9GHbwo=
 20260222130000_add_passion_level_to_followed_artists.sql h1:L+XH0J+h7VDT5IrypdpLc5abAgO6Bmzz3CufHGF7IN0=
+20260223120000_grant_iam_users_app_schema.sql h1:MhR+jNFUF05mq4ubAkxaSp7AA6Mv4JEX0y7o+ffi2wk=


### PR DESCRIPTION
## Summary

- The bootstrap migration (`20250726000000`) only granted `USAGE ON SCHEMA app` to Workload Identity service accounts (pattern `'%@%.iam'`)
- Human IAM users registered via `CLOUD_IAM_USER` (e.g., `pannpers@pannpers.dev`) were excluded from the grant
- This made the `app` schema invisible in Cloud SQL Studio's Explorer tree

This migration broadens the `GRANT` pattern from `'%@%.iam'` to `'%@%'` so all IAM-authenticated roles (both service accounts and human users) receive read access to the `app` schema.

## Test plan

- [ ] Verify Atlas Operator applies the new migration successfully (ArgoCD sync)
- [ ] Confirm `app` schema is visible in Cloud SQL Studio without manual grants
- [ ] Verify backend SA still has full CRUD access (existing grants are additive)