### PR TITLE
fix(cors): add W3C Trace Context headers to allowed CORS headers

### DIFF
--- a/internal/infrastructure/server/cors.go
+++ b/internal/infrastructure/server/cors.go
@@ -14,7 +14,7 @@ func NewCORSHandler(mu http.Handler, allowedOrigins []string) http.Handler {
 
 // GetCorsOptions returns the rs/cors Options used by the handler.
 func GetCorsOptions(allowedOrigins []string) cors.Options {
-	allowedHeaders := append(connectcors.AllowedHeaders(), "Authorization")
+	allowedHeaders := append(connectcors.AllowedHeaders(), "Authorization", "Traceparent", "Tracestate")
 	return cors.Options{
 		AllowedOrigins: allowedOrigins,
 		AllowedMethods: connectcors.AllowedMethods(),

--- a/internal/infrastructure/server/cors_test.go
+++ b/internal/infrastructure/server/cors_test.go
@@ -15,6 +15,8 @@ func TestGetCorsOptions(t *testing.T) {
 	assert.Contains(t, options.AllowedMethods, http.MethodPost)
 	assert.Contains(t, options.AllowedHeaders, "Connect-Protocol-Version")
 	assert.Contains(t, options.AllowedHeaders, "Authorization")
+	assert.Contains(t, options.AllowedHeaders, "Traceparent")
+	assert.Contains(t, options.AllowedHeaders, "Tracestate")
 	assert.Contains(t, options.ExposedHeaders, "Grpc-Status")
 }
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #102

## 📝 Summary of Changes

Add `Traceparent` and `Tracestate` (W3C Trace Context) headers to the CORS `AllowedHeaders` list.

The frontend's OpenTelemetry instrumentation includes these headers in RPC requests. The browser's CORS preflight sends them in `Access-Control-Request-Headers`, but `rs/cors` rejects the preflight because they are not in the allowed set — resulting in no `Access-Control-Allow-Origin` response header and blocking `UserService/Create` and `ArtistService/ListFollowed` during the auth callback flow.

## 📋 Commit Log

$(git log --oneline main..HEAD)

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.