### PR TITLE
fix(k8s): add missing migration files to kustomization configmap

### DIFF
--- a/k8s/atlas/base/kustomization.yaml
+++ b/k8s/atlas/base/kustomization.yaml
@@ -40,4 +40,6 @@ configMapGenerator:
   - migrations/20260221160000_fix_ticket_system_schema.sql
   - migrations/20260222120000_add_push_subscriptions_table.sql
   - migrations/20260222130000_add_passion_level_to_followed_artists.sql
+  - migrations/20260223000000_change_external_id_to_text.sql
+  - migrations/20260223100000_add_ticket_system_checks.sql
   - migrations/20260223120000_grant_iam_users_app_schema.sql


### PR DESCRIPTION
## Summary
- Add `20260223000000_change_external_id_to_text.sql` and `20260223100000_add_ticket_system_checks.sql` to the kustomization configMapGenerator files list
- These files exist on disk and in `atlas.sum` but were missing from `kustomization.yaml`, causing Atlas Operator checksum mismatch (stalled for 11+ hours, 24 failed retries)

## Root Cause
PR #109 (implement-ticket-system-mvp) added the migration files and updated `atlas.sum` but did not register them in `kustomization.yaml`. The Atlas Operator mounts the ConfigMap and validates checksums — missing files cause a mismatch that blocks all pending migrations, including the `external_id` UUID→TEXT change needed for Zitadel auth.

## Test plan
- [ ] Verify ArgoCD syncs the updated ConfigMap
- [ ] Confirm Atlas Operator resolves checksum mismatch and applies pending migrations
- [ ] Verify `users.external_id` column type is `TEXT` after migration
- [ ] Test dashboard API calls (`ListByFollower`, `ListFollowed`) return 200

Closes #115