### PR TITLE
feat(usecase): trigger Gemini concert search on first artist follow

### DIFF
--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -132,8 +132,8 @@ func InitializeApp(ctx context.Context) (*App, error) {
 
 	// Use Cases
 	userUC := usecase.NewUserUseCase(userRepo, logger)
-	artistUC := usecase.NewArtistUseCase(artistRepo, userRepo, lastfmClient, musicbrainzClient, musicbrainzClient, artistCache, logger)
 	concertUC := usecase.NewConcertUseCase(artistRepo, concertRepo, venueRepo, userRepo, searchLogRepo, geminiSearcher, logger)
+	artistUC := usecase.NewArtistUseCase(artistRepo, userRepo, lastfmClient, musicbrainzClient, musicbrainzClient, concertUC, searchLogRepo, artistCache, logger)
 	pushNotificationUC := usecase.NewPushNotificationUseCase(
 		artistRepo,
 		pushSubRepo,


### PR DESCRIPTION
## 🔗 Related Issue

N/A — discovered during investigation of post-signup callback flow.

## 📝 Summary of Changes

When a user follows an artist, the system now checks whether that artist has ever been searched (via `searchLogRepo`). If no search log exists, a background goroutine triggers `SearchNewConcerts` to immediately discover upcoming concerts via the Gemini API.

Previously, concert search only ran during the onboarding `LoadingSequence` or via the periodic CronJob. This meant artists followed outside of onboarding had no concerts until the next CronJob cycle.

**Technical approach:**
- Added `ConcertUseCase` and `SearchLogRepository` as dependencies of `artistUseCase`
- New `triggerFirstFollowSearch()` method: checks search log → if `ErrNotFound`, calls `SearchNewConcerts` in a fire-and-forget goroutine
- DI wiring updated in `provider.go` (moved `concertUC` creation before `artistUC`)

## 📋 Commit Log

```
50d14a4 feat(usecase): trigger Gemini concert search on first artist follow
```

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.