### PR TITLE
feat(ci): update Claude Code Actions to official examples

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,21 +1,9 @@
-name: 'Claude Auto Review'
+# https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml
+name: PR Review with Progress Tracking
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    paths:
-      - '**/*.go'
-      - '**/go.mod'
-      - '**/go.sum'
-      - 'internal/**'
-      - 'pkg/**'
-      - 'cmd/**'
-
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -25,41 +13,55 @@ jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - name: PR Review with Progress Tracking
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Enable progress tracking
           track_progress: true
+
+          # Your custom review instructions
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request. Focus on issues introduced by this PR only.
+            Perform a comprehensive code review with the following focus areas:
 
-            Review criteria:
-            - Go best practices and idiomatic code
-            - Clean Architecture layer boundary violations
-            - Potential bugs, race conditions, or nil pointer issues
-            - Security implications (SQL injection, input validation)
-            - Error handling patterns
+            1. **Go Code Quality**
+               - Idiomatic Go per https://go.dev/wiki/CodeReviewComments
+               - Clean Architecture layer boundaries (domain / usecase / adapter / infrastructure)
+               - Error handling: errors are wrapped with context and never silently discarded
 
-            For each issue found, rate your confidence 0-100.
-            Only report issues with confidence >= 80.
+            2. **Security**
+               - SQL injection and input validation at system boundaries
+               - Authentication and authorization logic is correct
+               - Secrets are never logged or leaked into error messages
 
-            Do NOT report:
-            - Pre-existing issues not introduced in this PR
-            - Issues that linters or staticcheck will catch
-            - Pedantic style nitpicks
-            - General suggestions unrelated to the diff
+            3. **Concurrency**
+               - Race conditions and improper shared state
+               - Goroutine leaks (missing cancel, unclosed channels)
 
-            Use `gh pr comment` for a summary.
-            Use `mcp__github_inline_comment__create_inline_comment` for specific code issues.
-            Only post GitHub comments - don't submit review text as messages.
+            Provide detailed feedback using inline comments for specific issues.
+            Use top-level comments for general observations or praise.
 
+          # Tools for comprehensive PR review
           claude_args: |
-            --max-turns 10
+            --max-turns 5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+# When track_progress is enabled:
+# - Creates a tracking comment with progress checkboxes
+# - Includes all PR context (comments, attachments, images)
+# - Updates progress as the review proceeds
+# - Marks as completed when done

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,32 +1,59 @@
-name: 'Claude'
+# https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml
+name: Claude Code
 
 on:
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  issues:
+    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
 
 jobs:
-  respond:
+  claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+
+          # Optional: Configure Claude's behavior with CLI arguments
+          # claude_args: |
+          #   --model claude-opus-4-1-20250805
+          #   --max-turns 10
+          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
+
+          # Optional: Advanced settings configuration
+          # settings: |
+          #   {
+          #     "env": {
+          #       "NODE_ENV": "test"
+          #     }
+          #   }


### PR DESCRIPTION
## Summary
- Replace `claude.yml` with the official example from [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml)
- Replace `claude-review.yml` with the official [pr-review-comprehensive](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) example
- Add Go-specific review criteria (Code Quality per CodeReviewComments, Security, Concurrency)

## Key changes
- `claude.yml`: Issues trigger (`@claude` in issue body/title), `contents: write`, `actions: read`, `checkout@v6`
- `claude-review.yml`: Progress tracking, custom prompt with Go/Clean Architecture focus

## Test plan
- [ ] Create a test issue with `@claude` mention to verify interactive workflow
- [ ] Open a draft PR, mark as ready, verify auto-review triggers