### PR TITLE
fix(ci): add concert-discovery to deploy workflow build matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
             target: server
           - name: consumer
             target: consumer
+          - name: concert-discovery
+            target: concert-discovery
     env:
       REGION: ${{ vars.REGION }}
       PROJECT_ID: ${{ vars.PROJECT_ID }}


### PR DESCRIPTION
## Summary
- Add `concert-discovery` target to the deploy workflow's Docker build matrix
- The CronJob in the cluster references `concert-discovery:latest` but this image was never built, causing `ErrImagePull`

## Root Cause
The EDA migration added a `concert-discovery` Dockerfile target and K8s CronJob manifest, but the deploy workflow matrix only included `server` and `consumer`.

## Test plan
- [ ] Merge triggers deploy workflow → verify all 3 images (server, consumer, concert-discovery) are built and pushed
- [ ] Verify CronJob pod can pull the `concert-discovery` image successfully