### PR TITLE
fix(usecase): use detached context for search log cleanup

### DIFF
--- a/internal/usecase/concert_uc.go
+++ b/internal/usecase/concert_uc.go
@@ -174,8 +174,11 @@ func (uc *concertUseCase) SearchNewConcerts(ctx context.Context, artistID string
 	// 6. Search new concerts via external API
 	scraped, err := uc.concertSearcher.Search(ctx, artist, site, time.Now())
 	if err != nil {
-		// Clean up search log on failure to allow retry
-		if delErr := uc.searchLogRepo.Delete(ctx, artistID); delErr != nil {
+		// Clean up search log on failure to allow retry.
+		// Use context.WithoutCancel so cleanup succeeds even if the RPC deadline expired.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cleanupCancel()
+		if delErr := uc.searchLogRepo.Delete(cleanupCtx, artistID); delErr != nil {
 			uc.logger.Error(ctx, "failed to delete search log after Gemini failure", delErr, slog.String("artist_id", artistID))
 		}
 		return fmt.Errorf("failed to search concerts via external API: %w", err)

--- a/internal/usecase/concert_uc_test.go
+++ b/internal/usecase/concert_uc_test.go
@@ -185,7 +185,7 @@ func TestConcertUseCase_SearchNewConcerts(t *testing.T) {
 				d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(nil, nil).Once()
 				d.searchLogRepo.EXPECT().Upsert(ctx, artistID).Return(nil).Once()
 				d.searcher.EXPECT().Search(ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
-				d.searchLogRepo.EXPECT().Delete(ctx, artistID).Return(nil).Once()
+				d.searchLogRepo.EXPECT().Delete(mock.Anything, artistID).Return(nil).Once()
 			},
 			wantErr: assert.AnError,
 		},


### PR DESCRIPTION
## Summary

- Use `context.WithoutCancel` with a 5s timeout for search log deletion after Gemini failure, so cleanup succeeds even when the RPC context deadline has expired
- Prevents stale search log entries that cause subsequent searches to be incorrectly skipped as "recently searched"

## Test plan

- [x] `go test ./internal/usecase/...` passes
- [x] `golangci-lint run ./internal/usecase/...` passes

close: #138