### PR TITLE
ci: unify lint and test via Makefile and pre-commit hook

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# PreToolUse hook: runs `make check` before git commit.
+# Exit 2 = block the tool call (stderr shown to Claude as reason).
+
+COMMAND=$(jq -r '.tool_input.command' < /dev/stdin)
+
+# Only act on git commit calls
+if ! echo "$COMMAND" | grep -q 'git commit'; then
+  exit 0
+fi
+
+make check
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "Blocked: 'make check' failed (exit $EXIT_CODE). Fix errors before committing." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,8 +14,6 @@
     "additionalDirectories": [
       "/home/pannpers/dev/src/github.com/liverty-music/backend",
       "/home/pannpers/.claude/skills",
-      "/home/pannpers/.claude/skills/code-verifier",
-      "/home/pannpers/dev/src/github.com/pannpers/dotfiles/agent/skills/code-verifier",
       "/home/pannpers/.claude/skills/db-migration",
       "/home/pannpers/dev/src/github.com/pannpers/dotfiles/agent/skills/db-migration",
       "/home/pannpers/.claude",
@@ -30,6 +28,16 @@
           {
             "type": "prompt",
             "prompt": "Check if the file_path being written/edited is under 'k8s/atlas/base/migrations/'. If YES: this is a migration file being directly created or modified. Warn that Atlas best practice requires editing schema.sql first, then running 'atlas migrate diff'. Recommend using /db-migration skill. Return 'deny' with explanation UNLESS the tool input shows this is an atlas-generated file being amended with DML (data migration statements like INSERT/UPDATE). If the file is NOT under migrations/, return 'allow'."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-commit-check.sh",
+            "timeout": 300
           }
         ]
       }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,12 +28,13 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - '.golangci.yml'
+              - 'Makefile'
               - '.github/workflows/**'
 
-  golangci:
+  lint:
     needs: changes
     if: needs.changes.outputs.src == 'true'
-    name: golangci-lint
+    name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -42,46 +43,29 @@ jobs:
         with:
           go-version: "1.25.7"
           cache: false
-      - name: Run golangci-lint
+      - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
           version: latest
-          args: --timeout=3m --build-tags=integration
+          install-only: true
+      - name: Run make lint
+        run: make lint
 
-  golangci-skip:
+  lint-skip:
     needs: changes
     if: needs.changes.outputs.src == 'false'
-    name: golangci-lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - run: echo "No relevant changes, skipping lint"
 
-  gofmt:
-    name: gofmt
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.25.7"
-          cache: false
-      - name: Check gofmt
-        run: |
-          unformatted=$(gofmt -l .)
-          if [ -n "$unformatted" ]; then
-            echo "The following files are not formatted with gofmt:"
-            echo "$unformatted"
-            exit 1
-          fi
-
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [changes, golangci, golangci-skip, gofmt]
+    needs: [changes, lint, lint-skip]
     if: always()
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: golangci, golangci-skip
+          allowed-skips: lint, lint-skip
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Apply database migrations
         run: atlas migrate apply --url "postgres://test-user@localhost:5432/test-db?sslmode=disable" --dir "file://k8s/atlas/base/migrations"
 
-      - name: Run tests with race detection and coverage
-        run: go test -tags=integration -race -v -timeout=5m -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Run integration tests
+        run: make test-integration GOTEST_FLAGS="-v -coverprofile=coverage.out -covermode=atomic"
         env:
           LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,20 +78,20 @@ When adding a new migration:
 3. Both changes go in the same PR
 
 
+### Development Commands
+
+```bash
+make lint              # Format check + golangci-lint (matches CI)
+make fix               # Auto-fix formatting (gofmt -w)
+make test              # Unit tests with local DB (docker compose + atlas migrate)
+make test-integration  # Integration tests (DB must already be running, used by CI)
+make check             # Full pre-commit check (lint + test)
+```
+
+`make check` is automatically enforced before `git commit` by the Claude Code PreToolUse hook in `.claude/settings.json`.
+
 ### Integration Tests
 
-Integration tests under `internal/infrastructure/database/rdb/` require a local PostgreSQL instance.
-
-**Before running integration tests, you MUST ensure the database is running:**
-
-```bash
-docker compose up -d postgres
-```
-
-The schema is applied automatically via Atlas migrations on container startup. If the container was freshly created, also apply the schema manually:
-
-```bash
-docker compose exec postgres psql -U test-user -d test-db < internal/infrastructure/database/rdb/schema/schema.sql
-```
+Integration tests under `internal/infrastructure/database/rdb/` require a local PostgreSQL instance. `make test` handles DB startup automatically via `docker compose up -d postgres --wait`.
 
 </agent-rules>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: lint fix test test-integration check
+
+## lint: format check + golangci-lint (matches CI)
+lint:
+	@echo "==> Checking gofmt..."
+	@test -z "$$(gofmt -l .)" || (gofmt -l . && exit 1)
+	@echo "==> Running golangci-lint..."
+	golangci-lint run --timeout=3m --build-tags=integration ./...
+
+## fix: auto-fix formatting
+fix:
+	gofmt -w .
+
+## test: unit tests with local DB (docker compose)
+test:
+	docker compose up -d postgres --wait
+	atlas migrate apply --env local
+	go test ./...
+
+## test-integration: integration tests (DB must already be running)
+## Pass GOTEST_FLAGS for CI-specific options (e.g., coverage)
+test-integration:
+	go test -tags=integration -race -timeout=5m $(GOTEST_FLAGS) ./...
+
+## check: full local pre-commit check (lint + test)
+check: lint test


### PR DESCRIPTION
## Summary

Unify lint and test operations across the backend repo via Makefile targets, and enforce pre-commit checks structurally through a Claude Code PreToolUse hook.

### Changes

- **Makefile**: New file with unified targets (`lint`, `fix`, `test`, `test-integration`, `check`)
  - `make lint`: gofmt check + golangci-lint (matches CI)
  - `make fix`: auto-fix formatting with `gofmt -w`
  - `make test`: local unit tests with docker compose DB + atlas migrate
  - `make test-integration`: integration tests (CI, DB already running)
  - `make check`: full pre-commit (lint + test)
- **CI workflows**: Updated `lint.yml` and `test.yml` to use `make lint` and `make test-integration` respectively. Merged separate gofmt job into unified lint job.
- **PreToolUse hook**: Blocks `git commit` unless `make check` passes, replacing prompt-based code-verifier skill
- **AGENTS.md**: Updated development commands section to reference Makefile targets

close: #133, close: #134, close: #135, close: #136
