### PR TITLE
refactor(config): split monolithic Config into per-workload types

### DIFF
--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -31,7 +31,7 @@ type ConsumerApp struct {
 
 // InitializeConsumerApp creates a ConsumerApp with all event handler dependencies wired.
 func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
-	cfg, err := config.Load()
+	cfg, err := config.Load[config.ConsumerConfig]()
 	if err != nil {
 		return nil, err
 	}
@@ -40,17 +40,17 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		return nil, err
 	}
 
-	logger, err := provideLogger(cfg)
+	logger, err := provideLogger(cfg.Logging)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := rdb.New(ctx, cfg, logger)
+	db, err := rdb.New(ctx, cfg.Database, cfg.IsLocal(), logger)
 	if err != nil {
 		return nil, err
 	}
 
-	telemetryCloser, err := telemetry.SetupTelemetry(ctx, cfg)
+	telemetryCloser, err := telemetry.SetupTelemetry(ctx, cfg.Telemetry, cfg.ShutdownTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/di/job.go
+++ b/internal/di/job.go
@@ -30,7 +30,7 @@ type JobApp struct {
 
 // InitializeJobApp creates a JobApp with only the dependencies needed for batch processing.
 func InitializeJobApp(ctx context.Context) (*JobApp, error) {
-	cfg, err := config.Load()
+	cfg, err := config.Load[config.JobConfig]()
 	if err != nil {
 		return nil, err
 	}
@@ -39,17 +39,17 @@ func InitializeJobApp(ctx context.Context) (*JobApp, error) {
 		return nil, err
 	}
 
-	logger, err := provideLogger(cfg)
+	logger, err := provideLogger(cfg.Logging)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := rdb.New(ctx, cfg, logger)
+	db, err := rdb.New(ctx, cfg.Database, cfg.IsLocal(), logger)
 	if err != nil {
 		return nil, err
 	}
 
-	telemetryCloser, err := telemetry.SetupTelemetry(ctx, cfg)
+	telemetryCloser, err := telemetry.SetupTelemetry(ctx, cfg.Telemetry, cfg.ShutdownTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -40,7 +40,7 @@ import (
 
 // InitializeApp creates a new App with all dependencies wired up manually.
 func InitializeApp(ctx context.Context) (*App, error) {
-	cfg, err := config.Load()
+	cfg, err := config.Load[config.ServerConfig]()
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		return nil, err
 	}
 
-	logger, err := provideLogger(cfg)
+	logger, err := provideLogger(cfg.Logging)
 	if err != nil {
 		return nil, err
 	}
@@ -58,12 +58,12 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		logger.Warn(ctx, "⚠️  CORS not configured, browser requests will fail")
 	}
 
-	db, err := rdb.New(ctx, cfg, logger)
+	db, err := rdb.New(ctx, cfg.Database, cfg.IsLocal(), logger)
 	if err != nil {
 		return nil, err
 	}
 
-	telemetryCloser, err := telemetry.SetupTelemetry(ctx, cfg)
+	telemetryCloser, err := telemetry.SetupTelemetry(ctx, cfg.Telemetry, cfg.ShutdownTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		logger.Warn(ctx, "⚠️  ZKP verification key not configured, entry verification is disabled")
 	}
 
-	srv := server.NewConnectServer(cfg, logger, db, authFunc, healthHandler, handlers...)
+	srv := server.NewConnectServer(cfg.Server, logger, authFunc, healthHandler, handlers...)
 
 	// Register shutdown phases.
 	// Drain: health → NOT_SERVING, then server drains in-flight requests,
@@ -268,9 +268,9 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	}, nil
 }
 
-func provideLogger(cfg *config.Config) (*logging.Logger, error) {
+func provideLogger(logCfg config.LoggingConfig) (*logging.Logger, error) {
 	var opts []logging.Option
-	switch cfg.Logging.Level {
+	switch logCfg.Level {
 	case "debug":
 		opts = append(opts, logging.WithLevel(slog.LevelDebug))
 	case "info":
@@ -280,7 +280,7 @@ func provideLogger(cfg *config.Config) (*logging.Logger, error) {
 	case "error":
 		opts = append(opts, logging.WithLevel(slog.LevelError))
 	}
-	switch cfg.Logging.Format {
+	switch logCfg.Format {
 	case "text":
 		opts = append(opts, logging.WithFormat(logging.FormatText))
 	case "json":

--- a/internal/infrastructure/database/rdb/postgres.go
+++ b/internal/infrastructure/database/rdb/postgres.go
@@ -21,19 +21,19 @@ type Database struct {
 }
 
 // New creates a new database instance with connection and ping verification.
-func New(ctx context.Context, cfg *config.Config, logger *logging.Logger) (*Database, error) {
-	dsn := cfg.Database.GetDSN()
+func New(ctx context.Context, dbCfg config.DatabaseConfig, isLocal bool, logger *logging.Logger) (*Database, error) {
+	dsn := dbCfg.GetDSN()
 
 	// Create pgxpool for direct pgx usage
 	poolConfig, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse pgxpool config: %w", err)
 	}
-	poolConfig.MaxConns = int32(cfg.Database.MaxOpenConns)
-	poolConfig.MinConns = int32(cfg.Database.MaxIdleConns)
+	poolConfig.MaxConns = int32(dbCfg.MaxOpenConns)
+	poolConfig.MinConns = int32(dbCfg.MaxIdleConns)
 
 	var dialer *cloudsqlconn.Dialer
-	if !cfg.IsLocal() {
+	if !isLocal {
 		opts := []cloudsqlconn.Option{
 			cloudsqlconn.WithIAMAuthN(),
 			// Use Private Service Connect (PSC) for non-local environments (dev, stg, prod)
@@ -48,7 +48,7 @@ func New(ctx context.Context, cfg *config.Config, logger *logging.Logger) (*Data
 
 		// Configure pgx to use the dialer
 		poolConfig.ConnConfig.DialFunc = func(dialCtx context.Context, _ string, _ string) (net.Conn, error) {
-			return d.Dial(dialCtx, cfg.Database.InstanceConnectionName)
+			return d.Dial(dialCtx, dbCfg.InstanceConnectionName)
 		}
 	}
 
@@ -72,11 +72,11 @@ func New(ctx context.Context, cfg *config.Config, logger *logging.Logger) (*Data
 	}
 
 	logger.Info(ctx, "Database connection established successfully",
-		slog.String("host", cfg.Database.Host),
-		slog.Int("port", cfg.Database.Port),
-		slog.String("database", cfg.Database.Name),
-		slog.Int("max_open_conns", cfg.Database.MaxOpenConns),
-		slog.Int("max_idle_conns", cfg.Database.MaxIdleConns),
+		slog.String("host", dbCfg.Host),
+		slog.Int("port", dbCfg.Port),
+		slog.String("database", dbCfg.Name),
+		slog.Int("max_open_conns", dbCfg.MaxOpenConns),
+		slog.Int("max_idle_conns", dbCfg.MaxIdleConns),
 	)
 
 	return database, nil

--- a/internal/infrastructure/database/rdb/setup_test.go
+++ b/internal/infrastructure/database/rdb/setup_test.go
@@ -34,25 +34,22 @@ func TestMain(m *testing.M) {
 }
 
 func setupTestDatabase() *rdb.Database {
-	cfg := &config.Config{
-		Environment: "local",
-		Database: config.DatabaseConfig{
-			Host:            "localhost",
-			Port:            5432,
-			Name:            "test-db",
-			User:            "test-user",
-			SSLMode:         "disable",
-			MaxOpenConns:    10,
-			MaxIdleConns:    5,
-			ConnMaxLifetime: 300,
-		},
+	dbCfg := config.DatabaseConfig{
+		Host:            "localhost",
+		Port:            5432,
+		Name:            "test-db",
+		User:            "test-user",
+		SSLMode:         "disable",
+		MaxOpenConns:    10,
+		MaxIdleConns:    5,
+		ConnMaxLifetime: 300,
 	}
 
 	logger, _ := logging.New()
 	ctx := context.Background()
 
 	// Create database connection using rdb.New()
-	db, err := rdb.New(ctx, cfg, logger)
+	db, err := rdb.New(ctx, dbCfg, true, logger)
 	if err != nil {
 		panic("Failed to connect to test database: " + err.Error())
 	}

--- a/internal/infrastructure/music/lastfm/client_integration_test.go
+++ b/internal/infrastructure/music/lastfm/client_integration_test.go
@@ -22,7 +22,7 @@ func TestClient_Integration(t *testing.T) {
 	t.Setenv("DATABASE_USER", "test-user")
 	t.Setenv("OIDC_ISSUER_URL", "https://test-issuer.example.com")
 
-	cfg, err := config.Load()
+	cfg, err := config.Load[config.ServerConfig]()
 	require.NoError(t, err)
 
 	if cfg.LastFMAPIKey == "" {

--- a/internal/infrastructure/server/connect.go
+++ b/internal/infrastructure/server/connect.go
@@ -16,7 +16,6 @@ import (
 	"connectrpc.com/otelconnect"
 	"connectrpc.com/validate"
 	"github.com/liverty-music/backend/internal/infrastructure/auth"
-	"github.com/liverty-music/backend/internal/infrastructure/database/rdb"
 	"github.com/liverty-music/backend/pkg/config"
 	apperr_connect "github.com/pannpers/go-apperr/apperr/connect"
 	"github.com/pannpers/go-logging/logging"
@@ -26,7 +25,6 @@ import (
 type ConnectServer struct {
 	server  *http.Server
 	logger  *logging.Logger
-	Cfg     *config.Config
 	address string
 }
 
@@ -38,9 +36,8 @@ type HealthHandlerFunc func(opts ...connect.HandlerOption) (string, http.Handler
 
 // NewConnectServer creates a new Connect server instance.
 func NewConnectServer(
-	cfg *config.Config,
+	serverCfg config.ServerSettings,
 	logger *logging.Logger,
-	_ *rdb.Database,
 	authFunc authn.AuthFunc,
 	healthHandler HealthHandlerFunc,
 	handlerFuncs ...RPCHandlerFunc,
@@ -117,9 +114,9 @@ func NewConnectServer(
 	rootMux.Handle(healthPath, healthH)
 	rootMux.Handle("/", authMiddleware.Wrap(protectedMux))
 
-	address := net.JoinHostPort(cfg.Server.Host, strconv.Itoa(cfg.Server.Port))
+	address := net.JoinHostPort(serverCfg.Host, strconv.Itoa(serverCfg.Port))
 
-	handler := NewCORSHandler(rootMux, cfg.Server.AllowedOrigins)
+	handler := NewCORSHandler(rootMux, serverCfg.AllowedOrigins)
 
 	// Enable h2c (HTTP/2 without TLS) for Kubernetes gRPC health probes
 	p := new(http.Protocols)
@@ -128,17 +125,16 @@ func NewConnectServer(
 
 	server := &http.Server{
 		Addr:              address,
-		Handler:           http.TimeoutHandler(handler, cfg.Server.HandlerTimeout, ""),
+		Handler:           http.TimeoutHandler(handler, serverCfg.HandlerTimeout, ""),
 		Protocols:         p,
-		ReadHeaderTimeout: cfg.Server.ReadHeaderTimeout,
-		ReadTimeout:       cfg.Server.ReadTimeout,
-		IdleTimeout:       cfg.Server.IdleTimeout,
+		ReadHeaderTimeout: serverCfg.ReadHeaderTimeout,
+		ReadTimeout:       serverCfg.ReadTimeout,
+		IdleTimeout:       serverCfg.IdleTimeout,
 	}
 
 	return &ConnectServer{
 		server:  server,
 		logger:  logger,
-		Cfg:     cfg,
 		address: address,
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,85 +2,35 @@
 // It uses github.com/kelseyhightower/envconfig for loading configuration from environment variables
 // with support for validation, default values, and environment-specific helpers.
 //
-// # Basic Usage
+// # Workload-Specific Configuration
 //
-// Load configuration from environment variables:
+// Each backend workload loads only the environment variables it needs:
 //
-//	cfg, err := config.Load()
-//	if err != nil {
-//		log.Fatalf("Failed to load configuration: %v", err)
-//	}
+//	// API server — loads all fields including JWT, Blockchain, ZKP
+//	cfg, err := config.Load[config.ServerConfig]()
 //
-//	// Validate configuration
+//	// CronJob — loads base fields plus GCP and NATS
+//	cfg, err := config.Load[config.JobConfig]()
+//
+//	// Event consumer — loads base fields plus NATS, VAPID, Google Maps
+//	cfg, err := config.Load[config.ConsumerConfig]()
+//
+// # BaseConfig
+//
+// All workload configs embed BaseConfig which provides:
+//   - ENVIRONMENT: Environment (local, development, staging, production)
+//   - SHUTDOWN_TIMEOUT: Graceful shutdown timeout (default: 30s)
+//   - DATABASE_*: Database connection settings
+//   - LOGGING_*: Log level and format
+//   - TELEMETRY_*: OpenTelemetry tracing
+//
+// # Validation
+//
+// Each config type implements Validate() with workload-appropriate checks:
+//
 //	if err := cfg.Validate(); err != nil {
 //		log.Fatalf("Invalid configuration: %v", err)
 //	}
-//
-// # Environment Variables
-//
-// The following environment variables are supported:
-//
-// Basic configuration:
-//   - ENVIRONMENT: Environment (development, staging, production)
-//
-// Server configuration:
-//   - SERVER_PORT: Server port (default: 8080)
-//   - SERVER_HOST: Server host (default: localhost)
-//   - SERVER_READ_TIMEOUT: Read timeout in milliseconds (default: 1000ms)
-//   - SERVER_HANDLER_TIMEOUT: Handler timeout in seconds (default: 5s)
-//   - SERVER_IDLE_TIMEOUT: Idle timeout in seconds (default: 3s)
-//   - CORS_ALLOWED_ORIGINS: Allowed CORS origins (default: http://localhost:9000)
-//
-// Database configuration:
-//   - DATABASE_HOST: Database host (default: localhost)
-//   - DATABASE_PORT: Database port (default: 5432)
-//   - DATABASE_NAME: Database name (required)
-//   - DATABASE_USER: Database user (required)
-//   - DATABASE_SSL_MODE: SSL mode (default: disable)
-//   - DATABASE_MAX_OPEN_CONNS: Maximum open connections (default: 25)
-//   - DATABASE_MAX_IDLE_CONNS: Maximum idle connections (default: 5)
-//   - DATABASE_CONN_MAX_LIFETIME: Connection max lifetime in seconds (default: 300)
-//   - DATABASE_INSTANCE_CONNECTION_NAME: Cloud SQL instance connection name
-//
-// Logging configuration:
-//   - LOGGING_LEVEL: Log level (debug, info, warn, error, default: info)
-//   - LOGGING_FORMAT: Log format (json, text, default: json)
-//   - LOGGING_STRUCTURED: Enable structured logging (default: true)
-//   - LOGGING_INCLUDE_CALLER: Include caller information (default: false)
-//
-// Telemetry configuration:
-//   - TELEMETRY_OTLP_ENDPOINT: OTLP exporter endpoint for sending traces
-//   - TELEMETRY_SERVICE_NAME: Service name for tracing (default: go-backend-scaffold)
-//   - TELEMETRY_SERVICE_VERSION: Service version for tracing (default: 1.0.0)
-//
-// GCP configuration:
-//   - GCP_PROJECT_ID: GCP Project ID
-//   - GCP_LOCATION: GCP Location (default: us-central1)
-//   - GCP_GEMINI_MODEL: Gemini Model Name (default: gemini-3-flash-preview)
-//   - GCP_VERTEX_AI_SEARCH_DATA_STORE: Vertex AI Search Data Store ID
-//
-// JWT configuration:
-//   - JWT_ISSUER: JWT issuer URL (required)
-//   - JWT_JWKS_REFRESH_INTERVAL: JWKS refresh interval (default: 15m)
-//
-// # Environment Helpers
-//
-// Use environment detection helpers:
-//
-//	if cfg.IsDevelopment() {
-//		// Development-specific logic
-//	}
-//
-//	if cfg.IsProduction() {
-//		// Production-specific logic
-//	}
-//
-// # Database Connection
-//
-// Get database connection string:
-//
-//	dsn := cfg.Database.GetDSN()
-//	// Returns: "postgres://user:pass@host:port/dbname?sslmode=disable"
 package config
 
 import (
@@ -90,53 +40,80 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// Config represents the application configuration loaded from environment variables.
-type Config struct {
-	// Server configuration
-	Server ServerConfig `envconfig:""`
+// BaseConfig contains fields shared by all backend workloads.
+type BaseConfig struct {
+	// Environment
+	Environment string `envconfig:"ENVIRONMENT" default:"local"`
 
-	// Database configuration
-	Database DatabaseConfig `envconfig:""`
+	// Shutdown timeout
+	ShutdownTimeout time.Duration `envconfig:"SHUTDOWN_TIMEOUT" default:"30s"`
 
 	// Logging configuration
 	Logging LoggingConfig `envconfig:""`
 
+	// Database configuration
+	Database DatabaseConfig `envconfig:""`
+
 	// Telemetry configuration
 	Telemetry TelemetryConfig `envconfig:""`
+}
 
-	// GCP configuration
-	GCP GCPConfig `envconfig:""`
+// ServerConfig is the configuration for the API server workload.
+type ServerConfig struct {
+	BaseConfig
+
+	// Server settings (port, host, timeouts, CORS)
+	Server ServerSettings `envconfig:""`
 
 	// JWT configuration
 	JWT JWTConfig `envconfig:""`
 
-	// Blockchain configuration
-	Blockchain BlockchainConfig `envconfig:""`
-
-	// VAPID configuration for Web Push notifications
-	VAPID VAPIDConfig `envconfig:""`
-
-	// ZKP configuration
-	ZKP ZKPConfig `envconfig:""`
+	// GCP configuration
+	GCP GCPConfig `envconfig:""`
 
 	// NATS configuration for event messaging
 	NATS NATSConfig `envconfig:""`
 
-	// Environment
-	Environment string `envconfig:"ENVIRONMENT" default:"local"`
+	// VAPID configuration for Web Push notifications
+	VAPID VAPIDConfig `envconfig:""`
+
+	// Blockchain configuration
+	Blockchain BlockchainConfig `envconfig:""`
+
+	// ZKP configuration
+	ZKP ZKPConfig `envconfig:""`
 
 	// LastFM API Key
 	LastFMAPIKey string `envconfig:"LASTFM_API_KEY"`
+}
+
+// JobConfig is the configuration for batch job workloads (e.g., concert-discovery CronJob).
+type JobConfig struct {
+	BaseConfig
+
+	// GCP configuration
+	GCP GCPConfig `envconfig:""`
+
+	// NATS configuration for event messaging
+	NATS NATSConfig `envconfig:""`
+}
+
+// ConsumerConfig is the configuration for the event consumer workload.
+type ConsumerConfig struct {
+	BaseConfig
+
+	// NATS configuration for event messaging
+	NATS NATSConfig `envconfig:""`
+
+	// VAPID configuration for Web Push notifications
+	VAPID VAPIDConfig `envconfig:""`
 
 	// Google Maps API Key
 	GoogleMapsAPIKey string `envconfig:"GOOGLE_MAPS_API_KEY"`
-
-	// Shutdown timeout in seconds
-	ShutdownTimeout time.Duration `envconfig:"SHUTDOWN_TIMEOUT" default:"30s"`
 }
 
-// ServerConfig represents server-specific configuration.
-type ServerConfig struct {
+// ServerSettings represents HTTP server settings (port, host, timeouts, CORS).
+type ServerSettings struct {
 	// Port to listen on
 	Port int `envconfig:"SERVER_PORT" default:"8080"`
 
@@ -302,38 +279,29 @@ type JWTConfig struct {
 	JWKSRefreshInterval time.Duration `envconfig:"JWKS_REFRESH_INTERVAL" default:"15m"`
 }
 
-// Load loads configuration from environment variables.
-//
-// Example:
-//
-//	cfg, err := config.Load()
-//	if err != nil {
-//		return fmt.Errorf("failed to load config: %w", err)
-//	}
-func Load() (*Config, error) {
-	var cfg Config
+// Loadable constrains the config types that can be loaded from environment variables.
+type Loadable interface {
+	ServerConfig | JobConfig | ConsumerConfig
+}
 
-	// Process environment variables
-	err := envconfig.Process("", &cfg)
-	if err != nil {
+// Load loads configuration from environment variables into the specified workload config type.
+func Load[T Loadable]() (*T, error) {
+	var cfg T
+
+	if err := envconfig.Process("", &cfg); err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
 	return &cfg, nil
 }
 
-// Validate validates the configuration according to the following rules:
-//   - Server port: 1-65535 range
+// Validate validates BaseConfig fields shared by all workloads:
 //   - Database port: 1-65535 range
-//   - Environment: development, staging, or production
+//   - Environment: local, development, staging, or production
 //   - Log level: debug, info, warn, or error
 //   - Log format: json or text
-//   - Required fields: Database name, user, and password
-func (c *Config) Validate() error {
-	if c.Server.Port <= 0 || c.Server.Port > 65535 {
-		return fmt.Errorf("invalid server port: %d", c.Server.Port)
-	}
-
+//   - Database instance connection name: required for non-local environments
+func (c *BaseConfig) Validate() error {
 	if c.Database.Port <= 0 || c.Database.Port > 65535 {
 		return fmt.Errorf("invalid database port: %d", c.Database.Port)
 	}
@@ -383,12 +351,30 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid log format: %s", c.Logging.Format)
 	}
 
-	if !c.IsLocal() && len(c.Server.AllowedOrigins) == 0 {
-		return fmt.Errorf("CORS allowed origins are required for non-local environments")
-	}
-
 	if !c.IsLocal() && c.Database.InstanceConnectionName == "" {
 		return fmt.Errorf("database instance connection name is required for non-local environments")
+	}
+
+	return nil
+}
+
+// Validate validates ServerConfig including base checks plus server-specific rules:
+//   - Server port: 1-65535 range
+//   - CORS allowed origins: required for non-local environments
+//   - NATS URL: required for non-local environments
+//   - JWT issuer: required
+//   - JWKS refresh interval: must be positive
+func (c *ServerConfig) Validate() error {
+	if err := c.BaseConfig.Validate(); err != nil {
+		return err
+	}
+
+	if c.Server.Port <= 0 || c.Server.Port > 65535 {
+		return fmt.Errorf("invalid server port: %d", c.Server.Port)
+	}
+
+	if !c.IsLocal() && len(c.Server.AllowedOrigins) == 0 {
+		return fmt.Errorf("CORS allowed origins are required for non-local environments")
 	}
 
 	if !c.IsLocal() && c.NATS.URL == "" {
@@ -406,6 +392,32 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// Validate validates JobConfig including base checks plus NATS URL for non-local environments.
+func (c *JobConfig) Validate() error {
+	if err := c.BaseConfig.Validate(); err != nil {
+		return err
+	}
+
+	if !c.IsLocal() && c.NATS.URL == "" {
+		return fmt.Errorf("NATS URL is required for non-local environments")
+	}
+
+	return nil
+}
+
+// Validate validates ConsumerConfig including base checks plus NATS URL for non-local environments.
+func (c *ConsumerConfig) Validate() error {
+	if err := c.BaseConfig.Validate(); err != nil {
+		return err
+	}
+
+	if !c.IsLocal() && c.NATS.URL == "" {
+		return fmt.Errorf("NATS URL is required for non-local environments")
+	}
+
+	return nil
+}
+
 // GetDSN returns the database connection string.
 func (c DatabaseConfig) GetDSN() string {
 	dsn := fmt.Sprintf("host=%s port=%d user=%s dbname=%s sslmode=%s",
@@ -417,21 +429,21 @@ func (c DatabaseConfig) GetDSN() string {
 }
 
 // IsDevelopment returns true if the environment is "development".
-func (c *Config) IsDevelopment() bool {
+func (c *BaseConfig) IsDevelopment() bool {
 	return c.Environment == "development"
 }
 
 // IsProduction returns true if the environment is "production".
-func (c *Config) IsProduction() bool {
+func (c *BaseConfig) IsProduction() bool {
 	return c.Environment == "production"
 }
 
 // IsStaging returns true if the environment is "staging".
-func (c *Config) IsStaging() bool {
+func (c *BaseConfig) IsStaging() bool {
 	return c.Environment == "staging"
 }
 
 // IsLocal returns true if the environment is "local".
-func (c *Config) IsLocal() bool {
+func (c *BaseConfig) IsLocal() bool {
 	return c.Environment == "local"
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoad(t *testing.T) {
+func TestLoad_ServerConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		envVars map[string]string
-		want    *Config
-		wantErr error
+		want    *ServerConfig
+		wantErr bool
 	}{
 		{
 			name: "load with default values",
@@ -24,10 +24,34 @@ func TestLoad(t *testing.T) {
 				"GCP_VERTEX_AI_SEARCH_DATA_STORE": "test-datastore",
 				"OIDC_ISSUER_URL":                 "https://test-issuer.com",
 			},
-			want: &Config{
-				Environment:     "local",
-				ShutdownTimeout: 30 * time.Second,
-				Server: ServerConfig{
+			want: &ServerConfig{
+				BaseConfig: BaseConfig{
+					Environment:     "local",
+					ShutdownTimeout: 30 * time.Second,
+					Database: DatabaseConfig{
+						Host:            "localhost",
+						Port:            5432,
+						Name:            "defaultdb",
+						User:            "defaultuser",
+						SSLMode:         "disable",
+						Schema:          "app",
+						MaxOpenConns:    25,
+						MaxIdleConns:    5,
+						ConnMaxLifetime: 300,
+					},
+					Logging: LoggingConfig{
+						Level:         "info",
+						Format:        "json",
+						Structured:    true,
+						IncludeCaller: false,
+					},
+					Telemetry: TelemetryConfig{
+						OTLPEndpoint:   "",
+						ServiceName:    "go-backend-scaffold",
+						ServiceVersion: "1.0.0",
+					},
+				},
+				Server: ServerSettings{
 					Port:              8080,
 					Host:              "localhost",
 					ReadHeaderTimeout: 500 * time.Millisecond,
@@ -35,28 +59,6 @@ func TestLoad(t *testing.T) {
 					HandlerTimeout:    30 * time.Second,
 					IdleTimeout:       3 * time.Second,
 					AllowedOrigins:    nil,
-				},
-				Database: DatabaseConfig{
-					Host:            "localhost",
-					Port:            5432,
-					Name:            "defaultdb",
-					User:            "defaultuser",
-					SSLMode:         "disable",
-					Schema:          "app",
-					MaxOpenConns:    25,
-					MaxIdleConns:    5,
-					ConnMaxLifetime: 300,
-				},
-				Logging: LoggingConfig{
-					Level:         "info",
-					Format:        "json",
-					Structured:    true,
-					IncludeCaller: false,
-				},
-				Telemetry: TelemetryConfig{
-					OTLPEndpoint:   "",
-					ServiceName:    "go-backend-scaffold",
-					ServiceVersion: "1.0.0",
 				},
 				GCP: GCPConfig{
 					ProjectID:               "test-project",
@@ -80,7 +82,6 @@ func TestLoad(t *testing.T) {
 					StreamName: "LIVERTY_MUSIC",
 				},
 			},
-			wantErr: nil,
 		},
 		{
 			name: "load with custom values",
@@ -102,10 +103,34 @@ func TestLoad(t *testing.T) {
 				"OIDC_ISSUER_URL":                 "https://custom-issuer.com",
 				"JWKS_REFRESH_INTERVAL":           "30m",
 			},
-			want: &Config{
-				Environment:     "production",
-				ShutdownTimeout: 15 * time.Second,
-				Server: ServerConfig{
+			want: &ServerConfig{
+				BaseConfig: BaseConfig{
+					Environment:     "production",
+					ShutdownTimeout: 15 * time.Second,
+					Database: DatabaseConfig{
+						Host:            "localhost",
+						Port:            5432,
+						Name:            "testdb",
+						User:            "testuser",
+						SSLMode:         "disable",
+						Schema:          "app",
+						MaxOpenConns:    25,
+						MaxIdleConns:    5,
+						ConnMaxLifetime: 300,
+					},
+					Logging: LoggingConfig{
+						Level:         "debug",
+						Format:        "text",
+						Structured:    true,
+						IncludeCaller: false,
+					},
+					Telemetry: TelemetryConfig{
+						OTLPEndpoint:   "",
+						ServiceName:    "go-backend-scaffold",
+						ServiceVersion: "1.0.0",
+					},
+				},
+				Server: ServerSettings{
 					Port:              9090,
 					Host:              "0.0.0.0",
 					ReadHeaderTimeout: 200 * time.Millisecond,
@@ -113,28 +138,6 @@ func TestLoad(t *testing.T) {
 					HandlerTimeout:    10 * time.Second,
 					IdleTimeout:       45 * time.Second,
 					AllowedOrigins:    nil,
-				},
-				Database: DatabaseConfig{
-					Host:            "localhost",
-					Port:            5432,
-					Name:            "testdb",
-					User:            "testuser",
-					SSLMode:         "disable",
-					Schema:          "app",
-					MaxOpenConns:    25,
-					MaxIdleConns:    5,
-					ConnMaxLifetime: 300,
-				},
-				Logging: LoggingConfig{
-					Level:         "debug",
-					Format:        "text",
-					Structured:    true,
-					IncludeCaller: false,
-				},
-				Telemetry: TelemetryConfig{
-					OTLPEndpoint:   "",
-					ServiceName:    "go-backend-scaffold",
-					ServiceVersion: "1.0.0",
 				},
 				GCP: GCPConfig{
 					ProjectID:               "custom-project",
@@ -158,7 +161,6 @@ func TestLoad(t *testing.T) {
 					StreamName: "LIVERTY_MUSIC",
 				},
 			},
-			wantErr: nil,
 		},
 	}
 
@@ -168,8 +170,8 @@ func TestLoad(t *testing.T) {
 				t.Setenv(key, value)
 			}
 
-			got, err := Load()
-			if tt.wantErr != nil {
+			got, err := Load[ServerConfig]()
+			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
@@ -180,23 +182,49 @@ func TestLoad(t *testing.T) {
 	}
 }
 
-func TestConfig_Validate(t *testing.T) {
+func TestLoad_JobConfig(t *testing.T) {
+	t.Run("loads without OIDC_ISSUER_URL", func(t *testing.T) {
+		t.Setenv("DATABASE_NAME", "testdb")
+		t.Setenv("DATABASE_USER", "testuser")
+
+		got, err := Load[JobConfig]()
+		require.NoError(t, err)
+		assert.Equal(t, "testdb", got.Database.Name)
+		assert.Equal(t, "local", got.Environment)
+	})
+}
+
+func TestLoad_ConsumerConfig(t *testing.T) {
+	t.Run("loads without OIDC_ISSUER_URL", func(t *testing.T) {
+		t.Setenv("DATABASE_NAME", "testdb")
+		t.Setenv("DATABASE_USER", "testuser")
+		t.Setenv("NATS_URL", "nats://localhost:4222")
+
+		got, err := Load[ConsumerConfig]()
+		require.NoError(t, err)
+		assert.Equal(t, "nats://localhost:4222", got.NATS.URL)
+	})
+}
+
+func TestServerConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		config  *Config
+		config  *ServerConfig
 		wantErr bool
 	}{
 		{
 			name: "valid development config",
-			config: &Config{
-				Environment: "development",
-				Server:      ServerConfig{Port: 8080, AllowedOrigins: []string{"http://localhost:9000"}},
-				Database: DatabaseConfig{
-					Port:                   5432,
-					InstanceConnectionName: "project:region:instance",
+			config: &ServerConfig{
+				BaseConfig: BaseConfig{
+					Environment: "development",
+					Database: DatabaseConfig{
+						Port:                   5432,
+						InstanceConnectionName: "project:region:instance",
+					},
+					Logging: LoggingConfig{Level: "info", Format: "json"},
 				},
-				Logging: LoggingConfig{Level: "info", Format: "json"},
-				NATS:    NATSConfig{URL: "nats://nats.nats.svc.cluster.local:4222"},
+				Server: ServerSettings{Port: 8080, AllowedOrigins: []string{"http://localhost:9000"}},
+				NATS:   NATSConfig{URL: "nats://nats.nats.svc.cluster.local:4222"},
 				JWT: JWTConfig{
 					Issuer:              "https://test-issuer.com",
 					JWKSRefreshInterval: 15 * time.Minute,
@@ -206,14 +234,13 @@ func TestConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "missing connection name in development",
-			config: &Config{
-				Environment: "development",
-				Server:      ServerConfig{Port: 8080},
-				Database: DatabaseConfig{
-					Port: 5432,
-					// Missing InstanceConnectionName
+			config: &ServerConfig{
+				BaseConfig: BaseConfig{
+					Environment: "development",
+					Database:    DatabaseConfig{Port: 5432},
+					Logging:     LoggingConfig{Level: "info", Format: "json"},
 				},
-				Logging: LoggingConfig{Level: "info", Format: "json"},
+				Server: ServerSettings{Port: 8080},
 				JWT: JWTConfig{
 					Issuer:              "https://test-issuer.com",
 					JWKSRefreshInterval: 15 * time.Minute,
@@ -223,27 +250,31 @@ func TestConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "missing allowed origins in development",
-			config: &Config{
-				Environment: "development",
-				Server:      ServerConfig{Port: 8080},
-				Database: DatabaseConfig{
-					Port:                   5432,
-					InstanceConnectionName: "project:region:instance",
+			config: &ServerConfig{
+				BaseConfig: BaseConfig{
+					Environment: "development",
+					Database: DatabaseConfig{
+						Port:                   5432,
+						InstanceConnectionName: "project:region:instance",
+					},
+					Logging: LoggingConfig{Level: "info", Format: "json"},
 				},
-				Logging: LoggingConfig{Level: "info", Format: "json"},
+				Server: ServerSettings{Port: 8080},
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing NATS URL in development",
-			config: &Config{
-				Environment: "development",
-				Server:      ServerConfig{Port: 8080, AllowedOrigins: []string{"http://localhost:9000"}},
-				Database: DatabaseConfig{
-					Port:                   5432,
-					InstanceConnectionName: "project:region:instance",
+			config: &ServerConfig{
+				BaseConfig: BaseConfig{
+					Environment: "development",
+					Database: DatabaseConfig{
+						Port:                   5432,
+						InstanceConnectionName: "project:region:instance",
+					},
+					Logging: LoggingConfig{Level: "info", Format: "json"},
 				},
-				Logging: LoggingConfig{Level: "info", Format: "json"},
+				Server: ServerSettings{Port: 8080, AllowedOrigins: []string{"http://localhost:9000"}},
 				JWT: JWTConfig{
 					Issuer:              "https://test-issuer.com",
 					JWKSRefreshInterval: 15 * time.Minute,
@@ -253,14 +284,13 @@ func TestConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "valid local config without connection name",
-			config: &Config{
-				Environment: "local",
-				Server:      ServerConfig{Port: 8080},
-				Database: DatabaseConfig{
-					Port: 5432,
-					// Missing InstanceConnectionName is OK for local
+			config: &ServerConfig{
+				BaseConfig: BaseConfig{
+					Environment: "local",
+					Database:    DatabaseConfig{Port: 5432},
+					Logging:     LoggingConfig{Level: "info", Format: "json"},
 				},
-				Logging: LoggingConfig{Level: "info", Format: "json"},
+				Server: ServerSettings{Port: 8080},
 				JWT: JWTConfig{
 					Issuer:              "https://test-issuer.com",
 					JWKSRefreshInterval: 15 * time.Minute,
@@ -280,4 +310,73 @@ func TestConfig_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJobConfig_Validate(t *testing.T) {
+	t.Run("valid local without NATS", func(t *testing.T) {
+		cfg := &JobConfig{
+			BaseConfig: BaseConfig{
+				Environment: "local",
+				Database:    DatabaseConfig{Port: 5432},
+				Logging:     LoggingConfig{Level: "info", Format: "json"},
+			},
+		}
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("missing NATS URL in development", func(t *testing.T) {
+		cfg := &JobConfig{
+			BaseConfig: BaseConfig{
+				Environment: "development",
+				Database: DatabaseConfig{
+					Port:                   5432,
+					InstanceConnectionName: "project:region:instance",
+				},
+				Logging: LoggingConfig{Level: "info", Format: "json"},
+			},
+		}
+		assert.Error(t, cfg.Validate())
+	})
+
+	t.Run("valid development with NATS", func(t *testing.T) {
+		cfg := &JobConfig{
+			BaseConfig: BaseConfig{
+				Environment: "development",
+				Database: DatabaseConfig{
+					Port:                   5432,
+					InstanceConnectionName: "project:region:instance",
+				},
+				Logging: LoggingConfig{Level: "info", Format: "json"},
+			},
+			NATS: NATSConfig{URL: "nats://nats:4222"},
+		}
+		assert.NoError(t, cfg.Validate())
+	})
+}
+
+func TestConsumerConfig_Validate(t *testing.T) {
+	t.Run("valid local without NATS", func(t *testing.T) {
+		cfg := &ConsumerConfig{
+			BaseConfig: BaseConfig{
+				Environment: "local",
+				Database:    DatabaseConfig{Port: 5432},
+				Logging:     LoggingConfig{Level: "info", Format: "json"},
+			},
+		}
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("missing NATS URL in development", func(t *testing.T) {
+		cfg := &ConsumerConfig{
+			BaseConfig: BaseConfig{
+				Environment: "development",
+				Database: DatabaseConfig{
+					Port:                   5432,
+					InstanceConnectionName: "project:region:instance",
+				},
+				Logging: LoggingConfig{Level: "info", Format: "json"},
+			},
+		}
+		assert.Error(t, cfg.Validate())
+	})
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -18,11 +18,11 @@ import (
 // SetupTelemetry initializes OpenTelemetry tracing and returns a closer for shutdown.
 // If telemetry OTLP endpoint is not configured, tracer is initialized without exporter
 // to disable sending trace info to OTEL collector.
-func SetupTelemetry(ctx context.Context, cfg *config.Config) (io.Closer, error) {
+func SetupTelemetry(ctx context.Context, telCfg config.TelemetryConfig, shutdownTimeout time.Duration) (io.Closer, error) {
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
-			semconv.ServiceNameKey.String(cfg.Telemetry.ServiceName),
-			semconv.ServiceVersionKey.String(cfg.Telemetry.ServiceVersion),
+			semconv.ServiceNameKey.String(telCfg.ServiceName),
+			semconv.ServiceVersionKey.String(telCfg.ServiceVersion),
 		),
 	)
 	if err != nil {
@@ -35,9 +35,9 @@ func SetupTelemetry(ctx context.Context, cfg *config.Config) (io.Closer, error) 
 	}
 
 	// disable to export traces to OTEL collector for local development
-	if cfg.Telemetry.OTLPEndpoint != "" {
+	if telCfg.OTLPEndpoint != "" {
 		exporter, err := otlptracehttp.New(ctx,
-			otlptracehttp.WithEndpoint(cfg.Telemetry.OTLPEndpoint),
+			otlptracehttp.WithEndpoint(telCfg.OTLPEndpoint),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create OTLP exporter: %w", err)
@@ -51,7 +51,7 @@ func SetupTelemetry(ctx context.Context, cfg *config.Config) (io.Closer, error) 
 	// Set the global tracer provider
 	otel.SetTracerProvider(tracerProvider)
 
-	return &tracerCloser{provider: tracerProvider, shutdownTimeout: cfg.ShutdownTimeout}, nil
+	return &tracerCloser{provider: tracerProvider, shutdownTimeout: shutdownTimeout}, nil
 }
 
 // tracerCloser implements io.Closer for shutting down the tracer provider

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -3,6 +3,7 @@ package telemetry_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/liverty-music/backend/pkg/config"
 	"github.com/liverty-music/backend/pkg/telemetry"
@@ -14,30 +15,29 @@ func TestSetupTelemetry(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		cfg          *config.Config
-		expectCloser bool
+		name            string
+		telCfg          config.TelemetryConfig
+		shutdownTimeout time.Duration
+		expectCloser    bool
 	}{
 		{
 			name: "setup without OTLP endpoint",
-			cfg: &config.Config{
-				Telemetry: config.TelemetryConfig{
-					OTLPEndpoint:   "",
-					ServiceName:    "test-service",
-					ServiceVersion: "1.0.0",
-				},
+			telCfg: config.TelemetryConfig{
+				OTLPEndpoint:   "",
+				ServiceName:    "test-service",
+				ServiceVersion: "1.0.0",
 			},
-			expectCloser: true,
+			shutdownTimeout: 30 * time.Second,
+			expectCloser:    true,
 		},
 		{
 			name: "setup with default config values",
-			cfg: &config.Config{
-				Telemetry: config.TelemetryConfig{
-					ServiceName:    "go-backend-scaffold",
-					ServiceVersion: "1.0.0",
-				},
+			telCfg: config.TelemetryConfig{
+				ServiceName:    "go-backend-scaffold",
+				ServiceVersion: "1.0.0",
 			},
-			expectCloser: true,
+			shutdownTimeout: 30 * time.Second,
+			expectCloser:    true,
 		},
 	}
 
@@ -45,7 +45,7 @@ func TestSetupTelemetry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			closer, err := telemetry.SetupTelemetry(context.Background(), tt.cfg)
+			closer, err := telemetry.SetupTelemetry(context.Background(), tt.telCfg, tt.shutdownTimeout)
 
 			require.NoError(t, err)
 			if tt.expectCloser {


### PR DESCRIPTION
## 🔗 Related Issue

Closes #149

## 📝 Summary of Changes

The monolithic `config.Load()` required all environment variables regardless of workload type, causing CronJobs to fail because `OIDC_ISSUER_URL` (JWT config) was marked `required:"true"` but not needed by batch jobs.

- **Split config types**: Replace single `Config` with `BaseConfig`, `ServerConfig`, `JobConfig`, `ConsumerConfig`. Each workload embeds `BaseConfig` plus only its needed fields.
- **Generic loader**: Replace `Load()` with `Load[T ServerConfig | JobConfig | ConsumerConfig]()` using Go generics.
- **Per-type validation**: Each workload type has its own `Validate()` method with workload-specific checks.
- **Narrowed signatures**: `rdb.New`, `telemetry.SetupTelemetry`, `server.NewConnectServer`, and `provideLogger` now accept only the config fields they need instead of the full config struct.

## 📋 Commit Log

- dc40d8f refactor(config): split monolithic Config into per-workload types

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.