### PR TITLE
fix(telemetry): use plain HTTP for in-cluster OTLP exporter

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -38,6 +38,7 @@ func SetupTelemetry(ctx context.Context, telCfg config.TelemetryConfig, shutdown
 	if telCfg.OTLPEndpoint != "" {
 		exporter, err := otlptracehttp.New(ctx,
 			otlptracehttp.WithEndpoint(telCfg.OTLPEndpoint),
+			otlptracehttp.WithInsecure(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create OTLP exporter: %w", err)


### PR DESCRIPTION
## Summary

- Add `otlptracehttp.WithInsecure()` to the OTLP HTTP exporter to use plain HTTP for in-cluster communication with the OTel Collector

The `otlptracehttp` Go SDK defaults to HTTPS when configured with a bare `host:port` via `WithEndpoint()`. The in-cluster OTel Collector listens on plain HTTP (port 4318), causing a TLS handshake failure and silently dropping all traces.

## Test plan

- [ ] Verify backend pods restart and connect to the OTel Collector without TLS errors
- [ ] Confirm traces appear in Cloud Trace after sending requests to the backend

Closes #156
