### PR TITLE
fix(config): align blockchain envconfig tags with Secret Manager naming

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -237,7 +237,7 @@ type GCPConfig struct {
 // BlockchainConfig holds configuration for EVM interactions and the TicketSBT contract.
 type BlockchainConfig struct {
 	// RPCURL is the JSON-RPC endpoint URL for the target EVM chain.
-	RPCURL string `envconfig:"BASE_SEPOLIA_RPC_URL"`
+	RPCURL string `envconfig:"BLOCKCHAIN_RPC_URL"`
 
 	// ChainID is the EIP-155 chain ID used for transaction signing.
 	// Examples: 84532 (Base Sepolia), 8453 (Base Mainnet).
@@ -245,7 +245,7 @@ type BlockchainConfig struct {
 
 	// DeployerPrivateKey is the hex-encoded private key of the backend service EOA
 	// that holds MINTER_ROLE on the TicketSBT contract.
-	DeployerPrivateKey string `envconfig:"TICKET_SBT_DEPLOYER_KEY"`
+	DeployerPrivateKey string `envconfig:"BLOCKCHAIN_DEPLOYER_PRIVATE_KEY"`
 
 	// TicketSBTAddress is the deployed TicketSBT contract address.
 	TicketSBTAddress string `envconfig:"TICKET_SBT_ADDRESS"`


### PR DESCRIPTION
## Related Issue
Refs: liverty-music/cloud-provisioning#140

## Summary

Rename blockchain-related `envconfig` struct tags to match the unified `BLOCKCHAIN_*` naming convention used across all infrastructure layers (Secret Manager, ExternalSecret, Pulumi ESC).

### Changes
- `TICKET_SBT_DEPLOYER_KEY` → `BLOCKCHAIN_DEPLOYER_PRIVATE_KEY`
- `BASE_SEPOLIA_RPC_URL` → `BLOCKCHAIN_RPC_URL`

### Why
The ticket minting feature has never worked in dev due to naming inconsistencies across layers. This is safe to rename since the feature is non-functional.

### Related PRs
- liverty-music/cloud-provisioning#143 (Pulumi + ExternalSecret + docs)