### PR TITLE
fix(ticketsbt): strip 0x prefix from deployer private key

### DIFF
--- a/internal/infrastructure/blockchain/ticketsbt/client.go
+++ b/internal/infrastructure/blockchain/ticketsbt/client.go
@@ -71,7 +71,7 @@ func NewClient(ctx context.Context, rpcURL, privateKeyHex, contractAddr string, 
 		return nil, fmt.Errorf("ticketsbt: failed to connect to RPC: %w", err)
 	}
 
-	privateKey, err := crypto.HexToECDSA(privateKeyHex)
+	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(privateKeyHex, "0x"))
 	if err != nil {
 		return nil, fmt.Errorf("ticketsbt: invalid deployer private key: %w", err)
 	}


### PR DESCRIPTION
## Related Issue
Refs: liverty-music/cloud-provisioning#140

## Summary

Fix `CrashLoopBackOff` on the `server-app` pod caused by `0x`-prefixed deployer private key in Secret Manager.

`crypto.HexToECDSA` expects a raw hex string without `0x` prefix. The value stored in Secret Manager includes the prefix, causing the error:
```
ticketsbt: invalid deployer private key: invalid hex character 'x' in private key
```

Uses `strings.TrimPrefix` to accept both `0x`-prefixed and raw hex formats.
