### PR TITLE
fix(entity): rename ProximityGroup.Distant to Away

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ tool (
 )
 
 require (
-	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260311045553-1f8021df2ae2.2
-	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260311045553-1f8021df2ae2.1
+	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260312074833-163690671e3f.2
+	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260312074833-163690671e3f.1
 	cloud.google.com/go/cloudsqlconn v1.20.0
 	connectrpc.com/authn v0.2.0
 	connectrpc.com/connect v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,12 @@ buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4b
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1/go.mod h1:Y3m+VD8IH6JTgnFYggPHvFul/ry6dL3QDliy8xH7610=
 buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260311045553-1f8021df2ae2.2 h1:w7kzkpxDqzDoJGY5TiDvOEQ8rb7hfIo764mYEnxe06k=
 buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260311045553-1f8021df2ae2.2/go.mod h1:1gp5elGtxg4nzOoDEMCc192DrtgD21O8Omk9RhTwFqo=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260312074833-163690671e3f.2 h1:SuIAqL/YF4UMPNiG6jt5/HWre1RkGLZoaO15OM6JyZw=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260312074833-163690671e3f.2/go.mod h1:ciVGW2LKVs+9R3w1mM1XkWVqRdQ+qVV7+A6lNei2HZc=
 buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260311045553-1f8021df2ae2.1 h1:LXp9clsdHXQdDdO+JeZjLJ9gz+RTqa3s1Q3M1gXA9AM=
 buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260311045553-1f8021df2ae2.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260312074833-163690671e3f.1 h1:r6Heexf/0FJxPD/xC/ylqOPcDmO0TKbNp1eMwuEqwbI=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260312074833-163690671e3f.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1 h1:KuP+b+in6LGh2ukof5KgDCD8hPXotEq6EVOo13Wg1pE=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1/go.mod h1:dV1Kz6zdmyXt7QWm5OXby44OFpyLemllUDBUG5HMLio=
 buf.build/go/app v0.1.0 h1:nlqD/h0rhIN73ZoiDElprrPiO2N6JV+RmNK34K29Ihg=

--- a/internal/adapter/rpc/mapper/concert.go
+++ b/internal/adapter/rpc/mapper/concert.go
@@ -70,18 +70,16 @@ func ConcertsToProto(concerts []*entity.Concert) []*entityv1.Concert {
 }
 
 // ProximityGroupsToProto converts a slice of domain ProximityGroup entities to protobuf.
-// NOTE: The proto type is still DateLaneGroup until the specification release publishes
-// ProximityGroup to BSR. The Distant domain field maps to the Away proto field.
-func ProximityGroupsToProto(groups []*entity.ProximityGroup) []*concertv1.DateLaneGroup {
-	result := make([]*concertv1.DateLaneGroup, 0, len(groups))
+func ProximityGroupsToProto(groups []*entity.ProximityGroup) []*concertv1.ProximityGroup {
+	result := make([]*concertv1.ProximityGroup, 0, len(groups))
 	for _, g := range groups {
-		result = append(result, &concertv1.DateLaneGroup{
+		result = append(result, &concertv1.ProximityGroup{
 			Date: &entityv1.LocalDate{
 				Value: TimeToDate(g.Date),
 			},
 			Home:   ConcertsToProto(g.Home),
 			Nearby: ConcertsToProto(g.Nearby),
-			Away:   ConcertsToProto(g.Distant),
+			Away:   ConcertsToProto(g.Away),
 		})
 	}
 	return result

--- a/internal/entity/concert.go
+++ b/internal/entity/concert.go
@@ -80,11 +80,11 @@ type ProximityGroup struct {
 	Home []*Concert
 	// Nearby contains concerts at venues within 200km of the user's home centroid.
 	Nearby []*Concert
-	// Distant contains concerts beyond 200km, with unknown location, or when the user has no home set.
-	Distant []*Concert
+	// Away contains concerts beyond 200km, with unknown location, or when the user has no home set.
+	Away []*Concert
 }
 
-// GroupByDateAndProximity classifies concerts into home/nearby/distant buckets
+// GroupByDateAndProximity classifies concerts into home/nearby/away buckets
 // and groups them by calendar date. Concerts are expected to be ordered by
 // local_event_date ascending, which is preserved in the returned slice.
 func GroupByDateAndProximity(concerts []*Concert, home *Home) []*ProximityGroup {
@@ -110,7 +110,7 @@ func GroupByDateAndProximity(concerts []*Concert, home *Home) []*ProximityGroup 
 		case ProximityNearby:
 			g.Nearby = append(g.Nearby, c)
 		default:
-			g.Distant = append(g.Distant, c)
+			g.Away = append(g.Away, c)
 		}
 	}
 

--- a/internal/entity/concert_test.go
+++ b/internal/entity/concert_test.go
@@ -213,7 +213,7 @@ func TestGroupByDateAndProximity(t *testing.T) {
 		name         string
 		args         args
 		wantLen      int
-		wantDate1Len [3]int // [home, nearby, distant]
+		wantDate1Len [3]int // [home, nearby, away]
 	}{
 		{
 			name: "return nil for empty concert list",
@@ -248,7 +248,7 @@ func TestGroupByDateAndProximity(t *testing.T) {
 			wantLen: 2,
 		},
 		{
-			name: "classify all concerts as distant when home is nil",
+			name: "classify all concerts as away when home is nil",
 			args: args{
 				concerts: []*entity.Concert{
 					{Event: entity.Event{LocalDate: date1, Venue: &entity.Venue{AdminArea: &tokyoLevel1, Coordinates: tokyoCoords}}},
@@ -278,7 +278,7 @@ func TestGroupByDateAndProximity(t *testing.T) {
 				g := got[0]
 				assert.Len(t, g.Home, tt.wantDate1Len[0])
 				assert.Len(t, g.Nearby, tt.wantDate1Len[1])
-				assert.Len(t, g.Distant, tt.wantDate1Len[2])
+				assert.Len(t, g.Away, tt.wantDate1Len[2])
 			}
 		})
 	}

--- a/internal/entity/follow_test.go
+++ b/internal/entity/follow_test.go
@@ -193,7 +193,7 @@ func TestHype_ShouldNotify(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "return false for HypeNearby when all concerts are distant",
+			name: "return false for HypeNearby when all concerts are away",
 			args: args{
 				hype:       entity.HypeNearby,
 				home:       tokyoHome,

--- a/internal/usecase/concert_uc_test.go
+++ b/internal/usecase/concert_uc_test.go
@@ -163,15 +163,15 @@ func TestConcertUseCase_ListByFollowerGrouped(t *testing.T) {
 		assert.Equal(t, "c1", groups[0].Home[0].ID)
 		assert.Len(t, groups[0].Nearby, 1)
 		assert.Equal(t, "c2", groups[0].Nearby[0].ID)
-		assert.Len(t, groups[0].Distant, 1)
-		assert.Equal(t, "c3", groups[0].Distant[0].ID)
+		assert.Len(t, groups[0].Away, 1)
+		assert.Equal(t, "c3", groups[0].Away[0].ID)
 
 		// Date 2
 		assert.Equal(t, date2, groups[1].Date)
 		assert.Len(t, groups[1].Home, 0)
 		assert.Len(t, groups[1].Nearby, 0)
-		assert.Len(t, groups[1].Distant, 1)
-		assert.Equal(t, "c4", groups[1].Distant[0].ID)
+		assert.Len(t, groups[1].Away, 1)
+		assert.Equal(t, "c4", groups[1].Away[0].ID)
 	})
 
 	t.Run("no home set puts everything in away", func(t *testing.T) {
@@ -193,7 +193,7 @@ func TestConcertUseCase_ListByFollowerGrouped(t *testing.T) {
 		assert.Len(t, groups, 1)
 		assert.Len(t, groups[0].Home, 0)
 		assert.Len(t, groups[0].Nearby, 0)
-		assert.Len(t, groups[0].Distant, 1)
+		assert.Len(t, groups[0].Away, 1)
 	})
 
 	t.Run("empty concerts returns nil groups", func(t *testing.T) {


### PR DESCRIPTION
## Related Issue

Refs: #191

## Summary of Changes

Rename `ProximityGroup.Distant` to `ProximityGroup.Away` in entity, mapper, and tests to match the `PROXIMITY_AWAY` enum naming convention.

The original refactor introduced `Distant` as the field name, but the corresponding enum value is `PROXIMITY_AWAY`. Field names should be consistent with their enum values. Also updates BSR dependencies to v0.24.0 which contains the proto-level field rename.

## Commit Log

- fix(entity): rename ProximityGroup.Distant to Away

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [x] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.
