### PR TITLE
chore(deps): update BSR proto deps to v0.25.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ tool (
 )
 
 require (
-	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260313085600-e2a0b0c53e22.2
-	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260313085600-e2a0b0c53e22.1
+	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260314160141-6f04c3c4c974.2
+	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260314160141-6f04c3c4c974.1
 	cloud.google.com/go/cloudsqlconn v1.20.0
 	connectrpc.com/authn v0.2.0
 	connectrpc.com/connect v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,10 @@ buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57
 buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57e197.1/go.mod h1:eGjb9P6sl1irS46NKyXnxkyozT2aWs3BF4tbYWQuCsw=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1 h1:q+tABqEH2Cpcp8fO9TBZlvKok7zorHGy+/UyywXaAKo=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1/go.mod h1:Y3m+VD8IH6JTgnFYggPHvFul/ry6dL3QDliy8xH7610=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260313085600-e2a0b0c53e22.2 h1:819x3pbvV+JiYbAFzNZjKlcyPwSdt5Fw+pyG5CcHV8k=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260313085600-e2a0b0c53e22.2/go.mod h1:V+I1VC4CX6u7frCNwJOVGY6dWLWm38ebZOrL9KpE76o=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260313085600-e2a0b0c53e22.1 h1:SmFYNFihcT+jkqR7T++lGeH68hh9Mw5ka8bnCppMJrE=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260313085600-e2a0b0c53e22.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260314160141-6f04c3c4c974.2 h1:KKnGbu9BjkNIWy/g6F0SFlm05Lngw5jTmip46Sq8wko=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260314160141-6f04c3c4c974.2/go.mod h1:88LcbUWw+OeJwdvBxMEoT+PaKgmH36+dY1vx1Wp7qSA=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260314160141-6f04c3c4c974.1 h1:gg0SMPY6FDcO8IYKwLJt1PlPn+txmCtNuqcwA3Wewm8=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260314160141-6f04c3c4c974.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1 h1:KuP+b+in6LGh2ukof5KgDCD8hPXotEq6EVOo13Wg1pE=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1/go.mod h1:dV1Kz6zdmyXt7QWm5OXby44OFpyLemllUDBUG5HMLio=
 buf.build/go/app v0.1.0 h1:nlqD/h0rhIN73ZoiDElprrPiO2N6JV+RmNK34K29Ihg=


### PR DESCRIPTION
## Related Issue

close: liverty-music/specification#231

## Summary of Changes

Update BSR-generated proto dependencies to specification v0.25.1, which removes the `not_in: [3]` protovalidate rule from `SetHypeRequest.hype`. This fixes 500 Internal Server Errors when users select the NEARBY hype tier on the My Artists page.

## Self-Checklist

- [x] I have linked the related issue.
- [ ] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation.
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.
