### PR TITLE
ci(deploy): add artist-image-sync to Docker build matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,8 @@ jobs:
             target: consumer
           - name: concert-discovery
             target: concert-discovery
+          - name: artist-image-sync
+            target: artist-image-sync
     env:
       REGION: ${{ vars.REGION }}
       PROJECT_ID: ${{ vars.PROJECT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,17 @@ FROM gcr.io/distroless/static:nonroot AS concert-discovery
 COPY --from=build-concert-discovery /out /concert-discovery
 ENTRYPOINT ["/concert-discovery"]
 
+# --- Artist Image Sync Job target ---
+FROM builder AS build-artist-image-sync
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags='-w -s' \
+    -pgo=auto \
+    -o /out ./cmd/job/artist-image-sync
+
+FROM gcr.io/distroless/static:nonroot AS artist-image-sync
+COPY --from=build-artist-image-sync /out /artist-image-sync
+ENTRYPOINT ["/artist-image-sync"]
+
 # --- Consumer target ---
 FROM builder AS build-consumer
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \


### PR DESCRIPTION
## Summary
- Add `artist-image-sync` Dockerfile multi-stage build target
- Add `artist-image-sync` to deploy workflow build matrix

Missing from the initial artist-image PR (#210) — the CronJob image was not being built or pushed to Artifact Registry.

## Test plan
- [ ] Deploy workflow builds and pushes `artist-image-sync` image to AR
- [ ] K8s CronJob references the correct image