### PR TITLE
fix(config): remove NATS URL requirement from JobConfig validation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -419,17 +419,11 @@ func (c *ServerConfig) Validate() error {
 	return nil
 }
 
-// Validate validates JobConfig including base checks plus NATS URL for non-local environments.
+// Validate validates JobConfig including base checks.
+// NATS URL is optional because not all jobs require event messaging
+// (e.g., artist-image-sync only needs database access).
 func (c *JobConfig) Validate() error {
-	if err := c.BaseConfig.Validate(); err != nil {
-		return err
-	}
-
-	if !c.IsLocal() && c.NATS.URL == "" {
-		return fmt.Errorf("NATS URL is required for non-local environments")
-	}
-
-	return nil
+	return c.BaseConfig.Validate()
 }
 
 // Validate validates ConsumerConfig including base checks plus NATS URL for non-local environments.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -324,7 +324,7 @@ func TestJobConfig_Validate(t *testing.T) {
 		assert.NoError(t, cfg.Validate())
 	})
 
-	t.Run("missing NATS URL in development", func(t *testing.T) {
+	t.Run("valid development without NATS", func(t *testing.T) {
 		cfg := &JobConfig{
 			BaseConfig: BaseConfig{
 				Environment: "development",
@@ -334,21 +334,6 @@ func TestJobConfig_Validate(t *testing.T) {
 				},
 				Logging: LoggingConfig{Level: "info", Format: "json"},
 			},
-		}
-		assert.Error(t, cfg.Validate())
-	})
-
-	t.Run("valid development with NATS", func(t *testing.T) {
-		cfg := &JobConfig{
-			BaseConfig: BaseConfig{
-				Environment: "development",
-				Database: DatabaseConfig{
-					Port:                   5432,
-					InstanceConnectionName: "project:region:instance",
-				},
-				Logging: LoggingConfig{Level: "info", Format: "json"},
-			},
-			NATS: NATSConfig{URL: "nats://nats:4222"},
 		}
 		assert.NoError(t, cfg.Validate())
 	})


### PR DESCRIPTION
## Related Issue

Refs: #209

## Summary of Changes

Remove NATS URL validation from JobConfig.Validate(). The artist-image-sync CronJob only needs database access and does not use NATS event messaging. The previous validation caused the job to fail in non-local environments with "NATS URL is required for non-local environments".

## Commit Log

608c283 fix(config): remove NATS URL requirement from JobConfig validation

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation.
- [x] I have run go test and lint locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.
