### PR TITLE
fix(rdb): include fanart in ListByUser query

### DIFF
--- a/internal/infrastructure/database/rdb/follow_repo.go
+++ b/internal/infrastructure/database/rdb/follow_repo.go
@@ -2,6 +2,7 @@ package rdb
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 
 	"github.com/liverty-music/backend/internal/entity"
@@ -30,7 +31,7 @@ const (
 		WHERE user_id = $1 AND artist_id = $2
 	`
 	followListByUserQuery = `
-		SELECT a.id, a.name, COALESCE(a.mbid, ''), fa.hype
+		SELECT a.id, a.name, COALESCE(a.mbid, ''), a.fanart, fa.hype
 		FROM artists a
 		JOIN followed_artists fa ON a.id = fa.artist_id
 		WHERE fa.user_id = $1
@@ -114,9 +115,17 @@ func (r *FollowRepository) ListByUser(ctx context.Context, userID string) ([]*en
 	var followed []*entity.FollowedArtist
 	for rows.Next() {
 		var a entity.Artist
+		var fanartJSON []byte
 		var hype string
-		if err := rows.Scan(&a.ID, &a.Name, &a.MBID, &hype); err != nil {
+		if err := rows.Scan(&a.ID, &a.Name, &a.MBID, &fanartJSON, &hype); err != nil {
 			return nil, toAppErr(err, "failed to scan followed artist")
+		}
+		if len(fanartJSON) > 0 {
+			var f entity.Fanart
+			if err := json.Unmarshal(fanartJSON, &f); err != nil {
+				return nil, toAppErr(err, "failed to unmarshal fanart JSON")
+			}
+			a.Fanart = &f
 		}
 		followed = append(followed, &entity.FollowedArtist{
 			UserID: userID,

--- a/internal/infrastructure/database/rdb/follow_repo_test.go
+++ b/internal/infrastructure/database/rdb/follow_repo_test.go
@@ -1,0 +1,211 @@
+package rdb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/liverty-music/backend/internal/entity"
+	"github.com/liverty-music/backend/internal/infrastructure/database/rdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFollowRepository_ListByUser(t *testing.T) {
+	followRepo := rdb.NewFollowRepository(testDB)
+	artistRepo := rdb.NewArtistRepository(testDB)
+	ctx := context.Background()
+
+	type args struct {
+		userID string
+	}
+
+	tests := []struct {
+		name    string
+		setup   func() string // returns userID
+		args    args
+		want    []*entity.FollowedArtist
+		wantErr error
+	}{
+		{
+			name: "includes fanart when artist has fanart data",
+			setup: func() string {
+				cleanDatabase()
+				created, err := artistRepo.Create(ctx, entity.NewArtist("Logo Artist", "f1000000-0000-0000-0000-00000000fa01"))
+				require.NoError(t, err)
+				artistID := created[0].ID
+
+				userID := "019cf800-0000-7000-8000-0000000fa001"
+				_, err = testDB.Pool.Exec(ctx,
+					"INSERT INTO users (id, name, email, external_id) VALUES ($1, $2, $3, $4)",
+					userID, "Test User 1", "fanart-test-1@example.com", "ext-fanart-01")
+				require.NoError(t, err)
+
+				fanart := &entity.Fanart{
+					ArtistThumb: []entity.FanartImage{
+						{ID: "100", URL: "https://assets.fanart.tv/thumb.jpg", Likes: 5, Lang: "en"},
+					},
+					HDMusicLogo: []entity.FanartImage{
+						{ID: "200", URL: "https://assets.fanart.tv/logo.png", Likes: 10, Lang: "ja"},
+					},
+				}
+				err = artistRepo.UpdateFanart(ctx, artistID, fanart, time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC))
+				require.NoError(t, err)
+
+				err = followRepo.Follow(ctx, userID, artistID)
+				require.NoError(t, err)
+				err = followRepo.SetHype(ctx, userID, artistID, entity.HypeAway)
+				require.NoError(t, err)
+
+				return userID
+			},
+			want: []*entity.FollowedArtist{
+				{
+					UserID: "019cf800-0000-7000-8000-0000000fa001",
+					Artist: &entity.Artist{
+						Name: "Logo Artist",
+						MBID: "f1000000-0000-0000-0000-00000000fa01",
+						Fanart: &entity.Fanart{
+							ArtistThumb: []entity.FanartImage{
+								{ID: "100", URL: "https://assets.fanart.tv/thumb.jpg", Likes: 5, Lang: "en"},
+							},
+							HDMusicLogo: []entity.FanartImage{
+								{ID: "200", URL: "https://assets.fanart.tv/logo.png", Likes: 10, Lang: "ja"},
+							},
+						},
+					},
+					Hype: entity.HypeAway,
+				},
+			},
+		},
+		{
+			name: "no followed artists returns empty slice",
+			setup: func() string {
+				cleanDatabase()
+				userID := "019cf800-0000-7000-8000-0000000fa003"
+				_, err := testDB.Pool.Exec(ctx,
+					"INSERT INTO users (id, name, email, external_id) VALUES ($1, $2, $3, $4)",
+					userID, "Lonely User", "lonely@example.com", "ext-lonely-01")
+				require.NoError(t, err)
+				return userID
+			},
+			want: nil,
+		},
+		{
+			name: "multiple artists with mixed fanart presence",
+			setup: func() string {
+				cleanDatabase()
+
+				created, err := artistRepo.Create(ctx,
+					entity.NewArtist("With Fanart", "f3000000-0000-0000-0000-00000000fa03"),
+					entity.NewArtist("Without Fanart", "f4000000-0000-0000-0000-00000000fa04"),
+				)
+				require.NoError(t, err)
+
+				fanart := &entity.Fanart{
+					ArtistThumb: []entity.FanartImage{
+						{ID: "300", URL: "https://assets.fanart.tv/mixed-thumb.jpg", Likes: 3, Lang: "en"},
+					},
+				}
+				err = artistRepo.UpdateFanart(ctx, created[0].ID, fanart, time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC))
+				require.NoError(t, err)
+
+				userID := "019cf800-0000-7000-8000-0000000fa004"
+				_, err = testDB.Pool.Exec(ctx,
+					"INSERT INTO users (id, name, email, external_id) VALUES ($1, $2, $3, $4)",
+					userID, "Mixed User", "mixed@example.com", "ext-mixed-01")
+				require.NoError(t, err)
+
+				err = followRepo.Follow(ctx, userID, created[0].ID)
+				require.NoError(t, err)
+				err = followRepo.Follow(ctx, userID, created[1].ID)
+				require.NoError(t, err)
+
+				return userID
+			},
+			want: []*entity.FollowedArtist{
+				{
+					UserID: "019cf800-0000-7000-8000-0000000fa004",
+					Artist: &entity.Artist{
+						Name: "With Fanart",
+						MBID: "f3000000-0000-0000-0000-00000000fa03",
+						Fanart: &entity.Fanart{
+							ArtistThumb: []entity.FanartImage{
+								{ID: "300", URL: "https://assets.fanart.tv/mixed-thumb.jpg", Likes: 3, Lang: "en"},
+							},
+						},
+					},
+					Hype: entity.HypeWatch,
+				},
+				{
+					UserID: "019cf800-0000-7000-8000-0000000fa004",
+					Artist: &entity.Artist{
+						Name: "Without Fanart",
+						MBID: "f4000000-0000-0000-0000-00000000fa04",
+					},
+					Hype: entity.HypeWatch,
+				},
+			},
+		},
+		{
+			name: "returns nil fanart when artist has no fanart data",
+			setup: func() string {
+				cleanDatabase()
+				created, err := artistRepo.Create(ctx, entity.NewArtist("Plain Artist", "f2000000-0000-0000-0000-00000000fa02"))
+				require.NoError(t, err)
+				artistID := created[0].ID
+
+				userID := "019cf800-0000-7000-8000-0000000fa002"
+				_, err = testDB.Pool.Exec(ctx,
+					"INSERT INTO users (id, name, email, external_id) VALUES ($1, $2, $3, $4)",
+					userID, "Test User 2", "fanart-test-2@example.com", "ext-fanart-02")
+				require.NoError(t, err)
+
+				err = followRepo.Follow(ctx, userID, artistID)
+				require.NoError(t, err)
+
+				return userID
+			},
+			want: []*entity.FollowedArtist{
+				{
+					UserID: "019cf800-0000-7000-8000-0000000fa002",
+					Artist: &entity.Artist{
+						Name: "Plain Artist",
+						MBID: "f2000000-0000-0000-0000-00000000fa02",
+					},
+					Hype: entity.HypeWatch,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID := tt.setup()
+			tt.args = args{userID: userID}
+
+			got, err := followRepo.ListByUser(ctx, tt.args.userID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, got, len(tt.want))
+
+			// Build lookup by MBID for order-independent comparison.
+			gotByMBID := make(map[string]*entity.FollowedArtist, len(got))
+			for _, g := range got {
+				assert.NotEmpty(t, g.Artist.ID)
+				gotByMBID[g.Artist.MBID] = g
+			}
+			for _, w := range tt.want {
+				g, ok := gotByMBID[w.Artist.MBID]
+				require.True(t, ok, "expected artist MBID %s not found", w.Artist.MBID)
+				w.Artist.ID = g.Artist.ID
+				assert.Equal(t, w, g)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 🔗 Related Issue

Closes #211

## 📝 Summary of Changes

`ListFollowed` RPC returned artists with nil `Fanart` even though the `artist-image-sync` job had populated the `fanart` JSONB column on the `artists` table. The root cause was that `followListByUserQuery` did not include `a.fanart` in its SELECT clause.

- Add `a.fanart` to the `followListByUserQuery` SELECT
- Scan the JSONB column and unmarshal into `entity.Artist.Fanart` in `ListByUser()`
- Add integration tests covering: fanart present, fanart absent, empty result, multiple artists with mixed fanart

## 📋 Commit Log

08612c0 fix(rdb): include fanart in ListByUser query

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.

## 📸 Screenshots or Logs

N/A — data layer fix, no UI changes in this repo.
