### PR TITLE
fix(deps): upgrade go-apperr to v1.1.0 to fix client error logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/nats-io/nats.go v1.49.0
-	github.com/pannpers/go-apperr v1.0.2
+	github.com/pannpers/go-apperr v1.1.0
 	github.com/pannpers/go-logging v1.2.0
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/pannpers/go-apperr v1.0.2 h1:AUAOvysjFsrJmdlRdZGD5T/ltAPOHL1njRKMeNjWFbw=
-github.com/pannpers/go-apperr v1.0.2/go.mod h1:UoPq74pC57RDDvkCw2YwskY9A/7i7wmOfiGqHKpg4/Q=
+github.com/pannpers/go-apperr v1.1.0 h1:u8y0t0RQPJD8waJ8Rt3Qh34/a0wR7qbEYZSc9acXSrg=
+github.com/pannpers/go-apperr v1.1.0/go.mod h1:UoPq74pC57RDDvkCw2YwskY9A/7i7wmOfiGqHKpg4/Q=
 github.com/pannpers/go-logging v1.2.0 h1:qs3keEnz7L2da0QyZtDi/1sHEVXpmdxwYHC2bGsowbU=
 github.com/pannpers/go-logging v1.2.0/go.mod h1:C3AO5d+CfzsNdmuhX0gjS56hWEq2WZhj2fXGO+Ksj5Y=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 h1:oYW+YCJ1pachXTQmzR3rNLYGGz4g/UgFcjb28p/viDM=


### PR DESCRIPTION
## Related Issue

Closes pannpers/go-apperr#3

## Summary of Changes

Upgrades `go-apperr` from v1.0.2 to v1.1.0.

`HandleError` now recognizes `*connect.Error` (e.g., from `connectrpc.com/validate` or `connectrpc.com/authn`) and:
- **Preserves the original error code** instead of overwriting it to `Unknown`
- **Skips ERROR logging for client errors** (4xx) — only server errors (5xx) are logged at ERROR severity

Previously, protovalidate's `invalid_argument` errors were logged as `severity: ERROR` with `"msg": "unhandled error occurred"` and returned to clients as `unknown`. Now they pass through silently with the correct code.

## Commit Log

- `fix(deps): upgrade go-apperr to v1.1.0`

## Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes. (Tests are in go-apperr repo)
- [x] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`). (N/A — dependency bump only)
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.

## Screenshots or Logs

**Before** (ERROR for client validation error):
```json
{
  "level": "ERROR",
  "msg": "unhandled error occurred",
  "error": "invalid_argument: validation error: - artist_id.value: value must be a valid UUID [string.uuid]"
}
```

**After**: No log output for client validation errors. Error returned to client with correct `invalid_argument` code.
