### PR TITLE
fix(auth): add ListWithProximity to public procedures whitelist

### DIFF
--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -205,6 +205,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		"/" + concertconnect.ConcertServiceName + "/List":               true,
 		"/" + concertconnect.ConcertServiceName + "/SearchNewConcerts":  true,
 		"/" + concertconnect.ConcertServiceName + "/ListSearchStatuses": true,
+		"/" + concertconnect.ConcertServiceName + "/ListWithProximity":  true,
 	}
 
 	authFunc := auth.NewAuthFunc(jwtValidator, publicProcedures)


### PR DESCRIPTION
## Summary
- Add `ConcertService/ListWithProximity` to the auth interceptor's `publicProcedures` whitelist so guest users can call it during onboarding without a 401

## Context
The concert-service spec defines `ListWithProximity` as a public RPC (no auth required). During onboarding, the frontend calls this endpoint for unauthenticated guest users, but it was missing from the whitelist — returning 401 and triggering console warnings.

## Test plan
- [ ] Existing `authn_test.go` covers the public procedure bypass path (6 test cases)
- [ ] `make check` passes
- [ ] Manual verification on dev: onboarding flow no longer shows 401 for `ListWithProximity`

close: #229