### PR TITLE
fix(infra): demote Gemini error log to WARN and retry 401

### DIFF
--- a/internal/infrastructure/gcp/gemini/errors.go
+++ b/internal/infrastructure/gcp/gemini/errors.go
@@ -65,7 +65,8 @@ func toAppErr(err error, msg string, attrs ...slog.Attr) error {
 
 // isRetryable reports whether err is a transient Gemini API error that
 // may succeed on a subsequent attempt.
-// It returns true for HTTP 504 (Gateway Timeout), 503 (Service Unavailable),
+// It returns true for HTTP 401 (Unauthorized — transient WI token refresh),
+// 504 (Gateway Timeout), 503 (Service Unavailable),
 // 429 (Too Many Requests), and 499 (Client Cancelled on Gemini side).
 // Context errors (DeadlineExceeded, Canceled) are NOT retryable because
 // they indicate the caller's own deadline expired.
@@ -75,7 +76,8 @@ func isRetryable(err error) bool {
 		return false
 	}
 	switch apiErr.Code {
-	case http.StatusGatewayTimeout,
+	case http.StatusUnauthorized, // Transient: GKE Workload Identity token refresh
+		http.StatusGatewayTimeout,
 		http.StatusServiceUnavailable,
 		http.StatusTooManyRequests,
 		499: // Gemini-specific: operation cancelled on the server side

--- a/internal/infrastructure/gcp/gemini/errors_test.go
+++ b/internal/infrastructure/gcp/gemini/errors_test.go
@@ -43,9 +43,9 @@ func TestIsRetryable(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "401 Unauthorized is not retryable",
+			name: "401 Unauthorized is retryable (transient WI token refresh)",
 			err:  genai.APIError{Code: http.StatusUnauthorized, Message: "unauthorized"},
-			want: false,
+			want: true,
 		},
 		{
 			name: "500 Internal Server Error is not retryable",

--- a/internal/infrastructure/gcp/gemini/searcher.go
+++ b/internal/infrastructure/gcp/gemini/searcher.go
@@ -224,7 +224,8 @@ func (s *ConcertSearcher) Search(
 	results, err := backoff.Retry(ctx, func() ([]*entity.ScrapedConcert, error) {
 		resp, err := s.client.Models.GenerateContent(ctx, s.config.ModelName, genai.Text(prompt), generateCfg)
 		if err != nil {
-			s.logger.Error(ctx, "gemini model call failed", err, attrs...)
+			s.logger.Warn(ctx, "gemini model call failed",
+				append(attrs, slog.String("error", err.Error()))...)
 			if !isRetryable(err) {
 				return nil, backoff.Permanent(err)
 			}


### PR DESCRIPTION
## Summary

- Demote Gemini infrastructure-layer error log (`"gemini model call failed"`) from ERROR to WARN so only the usecase-layer log triggers Cloud Monitoring alerts
- Add HTTP 401 (Unauthorized) to `isRetryable` so transient GKE Workload Identity token refresh failures are retried with exponential backoff

## Context

Two alert incidents fired simultaneously from the same Gemini API failure because:
1. Two layers (infrastructure + usecase) both logged at ERROR level
2. Cloud Monitoring `labelExtractors` extracted different `error_code` values from each log line (empty vs `"unauthenticated"`), creating separate incidents

The 401 error was a transient WI token refresh failure that self-resolved within seconds, but `isRetryable` did not cover 401.

## Test plan

- [x] Updated `isRetryable` test case for 401 from `want: false` to `want: true`
- [x] `make check` passes (lint + all tests)
