### PR TITLE
fix(user): address review feedback on email verification

### DIFF
--- a/internal/adapter/event/user_consumer.go
+++ b/internal/adapter/event/user_consumer.go
@@ -50,7 +50,6 @@ func (h *UserConsumer) Handle(msg *message.Message) error {
 
 	h.logger.Info(ctx, "sending email verification",
 		slog.String("external_id", data.ExternalID),
-		slog.String("email", data.Email),
 	)
 
 	if err := h.emailVerifier.SendVerification(ctx, data.ExternalID); err != nil {

--- a/internal/adapter/rpc/user_handler.go
+++ b/internal/adapter/rpc/user_handler.go
@@ -169,6 +169,11 @@ func (h *UserHandler) allowResend(userID string) bool {
 		}
 	}
 
+	// Reclaim memory for users with no recent activity.
+	if len(recent) == 0 {
+		delete(h.resendLog, userID)
+	}
+
 	if len(recent) >= resendRateLimit {
 		h.resendLog[userID] = recent
 		return false


### PR DESCRIPTION
## Summary

Addresses review feedback from #241 (email verification flow).

- **Memory leak fix**: `resendLog` map entries are now deleted when all timestamps expire, preventing monotonic growth in long-running deployments
- **PII removal**: User email address removed from `user_consumer` log output — `external_id` provides sufficient correlation for debugging

## Review comments addressed

| Comment | Action |
|---------|--------|
| Memory leak in resendLog | Fixed: delete map key when empty |
| PII exposure in logs | Fixed: removed email from log |
| UseCase imports Infrastructure | Won't fix: pre-existing codebase pattern |
| Rate limiting in handler | Won't fix: adapter-layer concern |
| EmailVerifier interface placement | Won't fix: multiple consumers benefit from shared definition |

## Test plan

- [ ] Verify build passes
- [ ] Verify existing tests pass

Refs: #240
