### PR TITLE
fix(rpc): resolve Zitadel ID to internal UUID in PushNotificationHandler

### DIFF
--- a/internal/adapter/rpc/push_notification_handler.go
+++ b/internal/adapter/rpc/push_notification_handler.go
@@ -6,7 +6,8 @@ import (
 
 	rpc "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/push_notification/v1"
 	"connectrpc.com/connect"
-	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	"github.com/liverty-music/backend/internal/adapter/rpc/mapper"
+	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/usecase"
 	"github.com/pannpers/go-logging/logging"
 )
@@ -14,25 +15,28 @@ import (
 // PushNotificationHandler implements the PushNotificationService Connect interface.
 type PushNotificationHandler struct {
 	pushUseCase usecase.PushNotificationUseCase
+	userRepo    entity.UserRepository
 	logger      *logging.Logger
 }
 
 // NewPushNotificationHandler creates a new instance of the push notification RPC service handler.
 func NewPushNotificationHandler(
 	pushUseCase usecase.PushNotificationUseCase,
+	userRepo entity.UserRepository,
 	logger *logging.Logger,
 ) *PushNotificationHandler {
 	return &PushNotificationHandler{
 		pushUseCase: pushUseCase,
+		userRepo:    userRepo,
 		logger:      logger,
 	}
 }
 
 // Subscribe registers or updates the browser push subscription for the authenticated user.
 func (h *PushNotificationHandler) Subscribe(ctx context.Context, req *connect.Request[rpc.SubscribeRequest]) (*connect.Response[rpc.SubscribeResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if req.Msg.Endpoint == "" {
@@ -45,7 +49,18 @@ func (h *PushNotificationHandler) Subscribe(ctx context.Context, req *connect.Re
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("auth is required"))
 	}
 
-	if err := h.pushUseCase.Subscribe(ctx, userID, req.Msg.Endpoint, req.Msg.P256Dh, req.Msg.Auth); err != nil {
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// push_subscriptions.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	if err := h.pushUseCase.Subscribe(ctx, user.ID, req.Msg.Endpoint, req.Msg.P256Dh, req.Msg.Auth); err != nil {
 		return nil, err
 	}
 
@@ -54,12 +69,20 @@ func (h *PushNotificationHandler) Subscribe(ctx context.Context, req *connect.Re
 
 // Unsubscribe removes all push subscriptions associated with the authenticated user.
 func (h *PushNotificationHandler) Unsubscribe(ctx context.Context, _ *connect.Request[rpc.UnsubscribeRequest]) (*connect.Response[rpc.UnsubscribeResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := h.pushUseCase.Unsubscribe(ctx, userID); err != nil {
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	if err := h.pushUseCase.Unsubscribe(ctx, user.ID); err != nil {
 		return nil, err
 	}
 

--- a/internal/adapter/rpc/push_notification_handler_test.go
+++ b/internal/adapter/rpc/push_notification_handler_test.go
@@ -7,10 +7,13 @@ import (
 	rpcv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/push_notification/v1"
 	"connectrpc.com/connect"
 	handler "github.com/liverty-music/backend/internal/adapter/rpc"
+	"github.com/liverty-music/backend/internal/entity"
+	entitymocks "github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/infrastructure/auth"
-	"github.com/liverty-music/backend/internal/usecase/mocks"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-logging/logging"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,20 +28,24 @@ func TestPushNotificationHandler_Subscribe(t *testing.T) {
 		name     string
 		ctx      context.Context
 		req      *rpcv1.SubscribeRequest
-		setup    func(uc *mocks.MockPushNotificationUseCase)
+		setup    func(uc *ucmocks.MockPushNotificationUseCase, ur *entitymocks.MockUserRepository)
 		wantCode connect.Code
 		wantErr  bool
 	}{
 		{
 			name: "success",
-			ctx:  authedCtx("user-1"),
+			ctx:  authedCtx("ext-user-1"),
 			req: &rpcv1.SubscribeRequest{
 				Endpoint: "https://push.example.com/sub",
 				P256Dh:   "key",
 				Auth:     "authSecret",
 			},
-			setup: func(uc *mocks.MockPushNotificationUseCase) {
-				uc.EXPECT().Subscribe(authedCtx("user-1"), "user-1", "https://push.example.com/sub", "key", "authSecret").
+			setup: func(uc *ucmocks.MockPushNotificationUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().Subscribe(mock.Anything, "user-uuid-1", "https://push.example.com/sub", "key", "authSecret").
 					Return(nil).Once()
 			},
 			wantErr: false,
@@ -47,31 +54,31 @@ func TestPushNotificationHandler_Subscribe(t *testing.T) {
 			name:     "error - unauthenticated",
 			ctx:      context.Background(),
 			req:      &rpcv1.SubscribeRequest{Endpoint: "https://push.example.com/sub", P256Dh: "k", Auth: "a"},
-			setup:    func(_ *mocks.MockPushNotificationUseCase) {},
+			setup:    func(_ *ucmocks.MockPushNotificationUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeUnauthenticated,
 			wantErr:  true,
 		},
 		{
 			name:     "error - missing endpoint",
-			ctx:      authedCtx("user-1"),
+			ctx:      authedCtx("ext-user-1"),
 			req:      &rpcv1.SubscribeRequest{P256Dh: "k", Auth: "a"},
-			setup:    func(_ *mocks.MockPushNotificationUseCase) {},
+			setup:    func(_ *ucmocks.MockPushNotificationUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeInvalidArgument,
 			wantErr:  true,
 		},
 		{
 			name:     "error - missing p256dh",
-			ctx:      authedCtx("user-1"),
+			ctx:      authedCtx("ext-user-1"),
 			req:      &rpcv1.SubscribeRequest{Endpoint: "https://push.example.com/sub", Auth: "a"},
-			setup:    func(_ *mocks.MockPushNotificationUseCase) {},
+			setup:    func(_ *ucmocks.MockPushNotificationUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeInvalidArgument,
 			wantErr:  true,
 		},
 		{
 			name:     "error - missing auth",
-			ctx:      authedCtx("user-1"),
+			ctx:      authedCtx("ext-user-1"),
 			req:      &rpcv1.SubscribeRequest{Endpoint: "https://push.example.com/sub", P256Dh: "k"},
-			setup:    func(_ *mocks.MockPushNotificationUseCase) {},
+			setup:    func(_ *ucmocks.MockPushNotificationUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeInvalidArgument,
 			wantErr:  true,
 		},
@@ -84,9 +91,10 @@ func TestPushNotificationHandler_Subscribe(t *testing.T) {
 			logger, err := logging.New()
 			require.NoError(t, err)
 
-			uc := mocks.NewMockPushNotificationUseCase(t)
-			tt.setup(uc)
-			h := handler.NewPushNotificationHandler(uc, logger)
+			uc := ucmocks.NewMockPushNotificationUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewPushNotificationHandler(uc, ur, logger)
 
 			resp, err := h.Subscribe(tt.ctx, connect.NewRequest(tt.req))
 
@@ -109,22 +117,26 @@ func TestPushNotificationHandler_Unsubscribe(t *testing.T) {
 	tests := []struct {
 		name     string
 		ctx      context.Context
-		setup    func(uc *mocks.MockPushNotificationUseCase)
+		setup    func(uc *ucmocks.MockPushNotificationUseCase, ur *entitymocks.MockUserRepository)
 		wantCode connect.Code
 		wantErr  bool
 	}{
 		{
 			name: "success",
-			ctx:  authedCtx("user-1"),
-			setup: func(uc *mocks.MockPushNotificationUseCase) {
-				uc.EXPECT().Unsubscribe(authedCtx("user-1"), "user-1").Return(nil).Once()
+			ctx:  authedCtx("ext-user-1"),
+			setup: func(uc *ucmocks.MockPushNotificationUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().Unsubscribe(mock.Anything, "user-uuid-1").Return(nil).Once()
 			},
 			wantErr: false,
 		},
 		{
 			name:     "error - unauthenticated",
 			ctx:      context.Background(),
-			setup:    func(_ *mocks.MockPushNotificationUseCase) {},
+			setup:    func(_ *ucmocks.MockPushNotificationUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeUnauthenticated,
 			wantErr:  true,
 		},
@@ -137,9 +149,10 @@ func TestPushNotificationHandler_Unsubscribe(t *testing.T) {
 			logger, err := logging.New()
 			require.NoError(t, err)
 
-			uc := mocks.NewMockPushNotificationUseCase(t)
-			tt.setup(uc)
-			h := handler.NewPushNotificationHandler(uc, logger)
+			uc := ucmocks.NewMockPushNotificationUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewPushNotificationHandler(uc, ur, logger)
 
 			resp, err := h.Unsubscribe(tt.ctx, connect.NewRequest(&rpcv1.UnsubscribeRequest{}))
 

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -256,7 +256,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		},
 		func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return pushconnect.NewPushNotificationServiceHandler(
-				rpc.NewPushNotificationHandler(pushNotificationUC, logger),
+				rpc.NewPushNotificationHandler(pushNotificationUC, userRepo, logger),
 				opts...,
 			)
 		},


### PR DESCRIPTION
## Summary

- Fix `PushNotificationHandler.Subscribe` UUID type mismatch: resolve Zitadel external ID to internal UUID via `UserRepository.GetByExternalID` before database insert
- Also fix `Unsubscribe` with the same ID resolution pattern
- Update DI wiring and tests to match new handler signature

## Test plan

- [ ] `make check` passes (lint + unit tests)
- [ ] Push notification subscribe no longer returns SQLSTATE 22P02 on dev
