### PR TITLE
fix(zitadel): fix gRPC dial failure and add comprehensive tests

### DIFF
--- a/internal/infrastructure/zitadel/email_verifier.go
+++ b/internal/infrastructure/zitadel/email_verifier.go
@@ -5,11 +5,13 @@ package zitadel
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/zitadel/zitadel-go/v3/pkg/client/middleware"
 	userv2 "github.com/zitadel/zitadel-go/v3/pkg/client/user/v2"
 	zitadelconn "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel"
 	userpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user/v2"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 
 	"github.com/liverty-music/backend/internal/usecase"
@@ -20,26 +22,39 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 )
 
+// emailCodeClient is the subset of the Zitadel UserServiceClient that
+// EmailVerifier needs. Extracting this narrow interface allows unit testing
+// without a real gRPC connection.
+type emailCodeClient interface {
+	SendEmailCode(ctx context.Context, in *userpb.SendEmailCodeRequest, opts ...grpc.CallOption) (*userpb.SendEmailCodeResponse, error)
+	ResendEmailCode(ctx context.Context, in *userpb.ResendEmailCodeRequest, opts ...grpc.CallOption) (*userpb.ResendEmailCodeResponse, error)
+}
+
 // Compile-time interface compliance check.
 var _ usecase.EmailVerifier = (*EmailVerifier)(nil)
 
 // EmailVerifier calls the Zitadel User Service v2 API to send and resend
 // email verification codes.
 type EmailVerifier struct {
-	client *userv2.Client
+	client emailCodeClient
 	logger *logging.Logger
 }
 
 // NewEmailVerifier creates a new EmailVerifier that authenticates to the
 // Zitadel API using a machine user's private key JWT.
 //
-// domain is the Zitadel instance URL (e.g., "https://dev-svijfm.us1.zitadel.cloud").
+// issuerURL is the OIDC issuer URL (e.g., "https://dev-svijfm.us1.zitadel.cloud").
 // keyPath is the file path to the machine key JSON.
-func NewEmailVerifier(ctx context.Context, domain, keyPath string, logger *logging.Logger) (*EmailVerifier, error) {
+func NewEmailVerifier(ctx context.Context, issuerURL, keyPath string, logger *logging.Logger) (*EmailVerifier, error) {
+	apiEndpoint, err := grpcEndpoint(issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse zitadel domain: %w", err)
+	}
+
 	userClient, err := userv2.NewClient(
 		ctx,
-		domain,
-		domain,
+		issuerURL,
+		apiEndpoint,
 		nil,
 		zitadelconn.WithJWTProfileTokenSource(
 			middleware.JWTProfileFromPath(ctx, keyPath),
@@ -79,4 +94,25 @@ func (v *EmailVerifier) ResendVerification(ctx context.Context, externalID strin
 		return apperr.Wrap(err, codes.Internal, "resend email verification code")
 	}
 	return nil
+}
+
+// grpcEndpoint extracts the host:port gRPC endpoint from an OIDC issuer URL.
+// The issuer URL uses https:// scheme, but gRPC Dial expects host:port.
+func grpcEndpoint(issuerURL string) (string, error) {
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid issuer URL %q: %w", issuerURL, err)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("issuer URL %q has no host", issuerURL)
+	}
+
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+
+	return host + ":" + port, nil
 }

--- a/internal/infrastructure/zitadel/email_verifier_test.go
+++ b/internal/infrastructure/zitadel/email_verifier_test.go
@@ -1,0 +1,233 @@
+package zitadel_test
+
+import (
+	"context"
+	"testing"
+
+	userpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user/v2"
+	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	infrazitadel "github.com/liverty-music/backend/internal/infrastructure/zitadel"
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/pannpers/go-logging/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubClient implements the emailCodeClient interface for unit testing.
+type stubClient struct {
+	sendErr   error
+	resendErr error
+
+	lastSendUserID   string
+	lastResendUserID string
+}
+
+func (s *stubClient) SendEmailCode(_ context.Context, in *userpb.SendEmailCodeRequest, _ ...grpc.CallOption) (*userpb.SendEmailCodeResponse, error) {
+	s.lastSendUserID = in.UserId
+	if s.sendErr != nil {
+		return nil, s.sendErr
+	}
+	return &userpb.SendEmailCodeResponse{}, nil
+}
+
+func (s *stubClient) ResendEmailCode(_ context.Context, in *userpb.ResendEmailCodeRequest, _ ...grpc.CallOption) (*userpb.ResendEmailCodeResponse, error) {
+	s.lastResendUserID = in.UserId
+	if s.resendErr != nil {
+		return nil, s.resendErr
+	}
+	return &userpb.ResendEmailCodeResponse{}, nil
+}
+
+func newTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	logger, err := logging.New()
+	require.NoError(t, err)
+	return logger
+}
+
+func TestEmailVerifier_SendVerification(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		externalID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		sendErr error
+		wantErr error
+		check   func(t *testing.T, stub *stubClient)
+	}{
+		{
+			name:    "success",
+			args:    args{externalID: "user-123"},
+			sendErr: nil,
+			wantErr: nil,
+			check: func(t *testing.T, stub *stubClient) {
+				t.Helper()
+				assert.Equal(t, "user-123", stub.lastSendUserID)
+			},
+		},
+		{
+			name:    "gRPC unavailable wraps as internal",
+			args:    args{externalID: "user-456"},
+			sendErr: grpcstatus.Error(grpccodes.Unavailable, "connection refused"),
+			wantErr: apperr.ErrInternal,
+		},
+		{
+			name:    "gRPC not found wraps as internal",
+			args:    args{externalID: "nonexistent"},
+			sendErr: grpcstatus.Error(grpccodes.NotFound, "user not found"),
+			wantErr: apperr.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			stub := &stubClient{sendErr: tt.sendErr}
+			v := infrazitadel.NewTestEmailVerifier(stub, newTestLogger(t))
+
+			err := v.SendVerification(context.Background(), tt.args.externalID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, stub)
+			}
+		})
+	}
+}
+
+func TestEmailVerifier_ResendVerification(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		externalID string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		resendErr error
+		wantErr   error
+		check     func(t *testing.T, stub *stubClient)
+	}{
+		{
+			name:      "success",
+			args:      args{externalID: "user-123"},
+			resendErr: nil,
+			wantErr:   nil,
+			check: func(t *testing.T, stub *stubClient) {
+				t.Helper()
+				assert.Equal(t, "user-123", stub.lastResendUserID)
+			},
+		},
+		{
+			name:      "already verified maps to FailedPrecondition",
+			args:      args{externalID: "verified-user"},
+			resendErr: grpcstatus.Error(grpccodes.FailedPrecondition, "email already verified"),
+			wantErr:   apperr.ErrFailedPrecondition,
+		},
+		{
+			name:      "gRPC unavailable wraps as internal",
+			args:      args{externalID: "user-456"},
+			resendErr: grpcstatus.Error(grpccodes.Unavailable, "connection refused"),
+			wantErr:   apperr.ErrInternal,
+		},
+		{
+			name:      "gRPC internal wraps as internal",
+			args:      args{externalID: "user-789"},
+			resendErr: grpcstatus.Error(grpccodes.Internal, "something went wrong"),
+			wantErr:   apperr.ErrInternal,
+		},
+		{
+			name:      "gRPC permission denied wraps as internal",
+			args:      args{externalID: "no-perms"},
+			resendErr: grpcstatus.Error(grpccodes.PermissionDenied, "insufficient permissions"),
+			wantErr:   apperr.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			stub := &stubClient{resendErr: tt.resendErr}
+			v := infrazitadel.NewTestEmailVerifier(stub, newTestLogger(t))
+
+			err := v.ResendVerification(context.Background(), tt.args.externalID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, stub)
+			}
+		})
+	}
+}
+
+func TestGrpcEndpoint(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		issuerURL string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr error
+	}{
+		{
+			name: "https URL extracts host with port 443",
+			args: args{issuerURL: "https://dev-svijfm.us1.zitadel.cloud"},
+			want: "dev-svijfm.us1.zitadel.cloud:443",
+		},
+		{
+			name: "https URL with explicit port",
+			args: args{issuerURL: "https://zitadel.example.com:8443"},
+			want: "zitadel.example.com:8443",
+		},
+		{
+			name: "http URL defaults to port 443",
+			args: args{issuerURL: "http://zitadel.local"},
+			want: "zitadel.local:443",
+		},
+		{
+			name:    "empty URL returns error",
+			args:    args{issuerURL: ""},
+			wantErr: assert.AnError,
+		},
+		{
+			name:    "scheme-only URL returns error",
+			args:    args{issuerURL: "https://"},
+			wantErr: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := infrazitadel.GrpcEndpoint(tt.args.issuerURL)
+
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/infrastructure/zitadel/export_test.go
+++ b/internal/infrastructure/zitadel/export_test.go
@@ -1,0 +1,17 @@
+package zitadel
+
+import (
+	"github.com/pannpers/go-logging/logging"
+)
+
+// NewTestEmailVerifier creates an EmailVerifier with a mock gRPC client
+// for unit testing. Bypasses the real gRPC connection setup.
+func NewTestEmailVerifier(client emailCodeClient, logger *logging.Logger) *EmailVerifier {
+	return &EmailVerifier{
+		client: client,
+		logger: logger,
+	}
+}
+
+// GrpcEndpoint exposes grpcEndpoint for testing.
+var GrpcEndpoint = grpcEndpoint


### PR DESCRIPTION
## Summary

Fix gRPC dial failure that caused all Zitadel API calls to fail with `unknown port` error in production. Add comprehensive unit tests for the `EmailVerifier` infrastructure component.

## Root cause

`NewEmailVerifier` passed the OIDC issuer URL (`https://dev-svijfm.us1.zitadel.cloud`) as both the `issuer` and `api` arguments to the Zitadel user client. gRPC `Dial` expects `host:port` format, not a URL with scheme — causing every call to fail with:

```
transport: Error while dialing: dial tcp: lookup tcp///dev-svijfm.us1.zitadel.cloud: unknown port
```

## Changes

- **Bug fix**: Extract `grpcEndpoint()` that parses the OIDC issuer URL and produces `host:443` for gRPC dial
- **Testability**: Extract `emailCodeClient` interface from concrete `userv2.Client` for unit testing without a real gRPC connection
- **Tests**: Table-driven tests covering:
  - `SendVerification`: success, gRPC Unavailable, gRPC NotFound
  - `ResendVerification`: success, FailedPrecondition (already verified), Unavailable, Internal, PermissionDenied
  - `grpcEndpoint`: https URL, explicit port, empty URL, scheme-only URL

## Test plan

- [x] All tests pass locally

Refs: #240
