### PR TITLE
fix(rpc): resolve Zitadel sub to internal UUID in Follow, TicketJourney, and TicketEmail handlers

### DIFF
--- a/internal/adapter/rpc/follow_handler.go
+++ b/internal/adapter/rpc/follow_handler.go
@@ -7,7 +7,7 @@ import (
 	rpc "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/follow/v1"
 	"connectrpc.com/connect"
 	"github.com/liverty-music/backend/internal/adapter/rpc/mapper"
-	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/usecase"
 	"github.com/pannpers/go-logging/logging"
 )
@@ -15,32 +15,46 @@ import (
 // FollowHandler implements the FollowService Connect interface.
 type FollowHandler struct {
 	followUseCase usecase.FollowUseCase
+	userRepo      entity.UserRepository
 	logger        *logging.Logger
 }
 
 // NewFollowHandler creates a new instance of the follow RPC service handler.
 func NewFollowHandler(
 	followUseCase usecase.FollowUseCase,
+	userRepo entity.UserRepository,
 	logger *logging.Logger,
 ) *FollowHandler {
 	return &FollowHandler{
 		followUseCase: followUseCase,
+		userRepo:      userRepo,
 		logger:        logger,
 	}
 }
 
 // Follow establishes a follow relationship between the current user and an artist.
 func (h *FollowHandler) Follow(ctx context.Context, req *connect.Request[rpc.FollowRequest]) (*connect.Response[rpc.FollowResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if req.Msg.ArtistId == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("artist_id is required"))
 	}
 
-	err := h.followUseCase.Follow(ctx, userID, req.Msg.ArtistId.Value)
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// follows.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	err = h.followUseCase.Follow(ctx, user.ID, req.Msg.ArtistId.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -50,16 +64,27 @@ func (h *FollowHandler) Follow(ctx context.Context, req *connect.Request[rpc.Fol
 
 // Unfollow removes an existing follow relationship.
 func (h *FollowHandler) Unfollow(ctx context.Context, req *connect.Request[rpc.UnfollowRequest]) (*connect.Response[rpc.UnfollowResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if req.Msg.ArtistId == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("artist_id is required"))
 	}
 
-	err := h.followUseCase.Unfollow(ctx, userID, req.Msg.ArtistId.Value)
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// follows.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	err = h.followUseCase.Unfollow(ctx, user.ID, req.Msg.ArtistId.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -69,12 +94,23 @@ func (h *FollowHandler) Unfollow(ctx context.Context, req *connect.Request[rpc.U
 
 // ListFollowed retrieves the list of artists currently followed by the authenticated user.
 func (h *FollowHandler) ListFollowed(ctx context.Context, _ *connect.Request[rpc.ListFollowedRequest]) (*connect.Response[rpc.ListFollowedResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	followed, err := h.followUseCase.ListFollowed(ctx, userID)
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// follows.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	followed, err := h.followUseCase.ListFollowed(ctx, user.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -86,9 +122,9 @@ func (h *FollowHandler) ListFollowed(ctx context.Context, _ *connect.Request[rpc
 
 // SetHype updates the user's enthusiasm tier for a followed artist.
 func (h *FollowHandler) SetHype(ctx context.Context, req *connect.Request[rpc.SetHypeRequest]) (*connect.Response[rpc.SetHypeResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if req.Msg.ArtistId == nil {
@@ -100,7 +136,18 @@ func (h *FollowHandler) SetHype(ctx context.Context, req *connect.Request[rpc.Se
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid hype level"))
 	}
 
-	err := h.followUseCase.SetHype(ctx, userID, req.Msg.ArtistId.Value, hype)
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// follows.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	err = h.followUseCase.SetHype(ctx, user.ID, req.Msg.ArtistId.Value, hype)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/rpc/follow_handler_test.go
+++ b/internal/adapter/rpc/follow_handler_test.go
@@ -1,0 +1,331 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+
+	entityv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/entity/v1"
+	followv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/follow/v1"
+	"connectrpc.com/connect"
+	handler "github.com/liverty-music/backend/internal/adapter/rpc"
+	"github.com/liverty-music/backend/internal/entity"
+	entitymocks "github.com/liverty-music/backend/internal/entity/mocks"
+	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
+	"github.com/pannpers/go-logging/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func followAuthedCtx(sub string) context.Context {
+	return auth.WithClaims(context.Background(), &auth.Claims{Sub: sub})
+}
+
+func TestFollowHandler_Follow(t *testing.T) {
+	t.Parallel()
+
+	artistID := "artist-uuid-1"
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		req      *followv1.FollowRequest
+		setup    func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository)
+		wantCode connect.Code
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			ctx:  followAuthedCtx("ext-user-1"),
+			req:  &followv1.FollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
+			setup: func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().Follow(mock.Anything, "user-uuid-1", artistID).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:     "error - unauthenticated",
+			ctx:      context.Background(),
+			req:      &followv1.FollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
+			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeUnauthenticated,
+			wantErr:  true,
+		},
+		{
+			name:     "error - missing artist_id",
+			ctx:      followAuthedCtx("ext-user-1"),
+			req:      &followv1.FollowRequest{ArtistId: nil},
+			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeInvalidArgument,
+			wantErr:  true,
+		},
+		{
+			name: "error - user not found",
+			ctx:  followAuthedCtx("ext-user-1"),
+			req:  &followv1.FollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
+			setup: func(_ *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, err := logging.New()
+			require.NoError(t, err)
+
+			uc := ucmocks.NewMockFollowUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewFollowHandler(uc, ur, logger)
+
+			resp, err := h.Follow(tt.ctx, connect.NewRequest(tt.req))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantCode != 0 {
+					assert.Equal(t, tt.wantCode, connect.CodeOf(err))
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+		})
+	}
+}
+
+func TestFollowHandler_Unfollow(t *testing.T) {
+	t.Parallel()
+
+	artistID := "artist-uuid-1"
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		req      *followv1.UnfollowRequest
+		setup    func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository)
+		wantCode connect.Code
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			ctx:  followAuthedCtx("ext-user-1"),
+			req:  &followv1.UnfollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
+			setup: func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().Unfollow(mock.Anything, "user-uuid-1", artistID).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:     "error - unauthenticated",
+			ctx:      context.Background(),
+			req:      &followv1.UnfollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
+			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeUnauthenticated,
+			wantErr:  true,
+		},
+		{
+			name: "error - user not found",
+			ctx:  followAuthedCtx("ext-user-1"),
+			req:  &followv1.UnfollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
+			setup: func(_ *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, err := logging.New()
+			require.NoError(t, err)
+
+			uc := ucmocks.NewMockFollowUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewFollowHandler(uc, ur, logger)
+
+			resp, err := h.Unfollow(tt.ctx, connect.NewRequest(tt.req))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantCode != 0 {
+					assert.Equal(t, tt.wantCode, connect.CodeOf(err))
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+		})
+	}
+}
+
+func TestFollowHandler_ListFollowed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		setup    func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository)
+		wantCode connect.Code
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			ctx:  followAuthedCtx("ext-user-1"),
+			setup: func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().ListFollowed(mock.Anything, "user-uuid-1").Return([]*entity.FollowedArtist{}, nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:     "error - unauthenticated",
+			ctx:      context.Background(),
+			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeUnauthenticated,
+			wantErr:  true,
+		},
+		{
+			name: "error - user not found",
+			ctx:  followAuthedCtx("ext-user-1"),
+			setup: func(_ *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, err := logging.New()
+			require.NoError(t, err)
+
+			uc := ucmocks.NewMockFollowUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewFollowHandler(uc, ur, logger)
+
+			resp, err := h.ListFollowed(tt.ctx, connect.NewRequest(&followv1.ListFollowedRequest{}))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantCode != 0 {
+					assert.Equal(t, tt.wantCode, connect.CodeOf(err))
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+		})
+	}
+}
+
+func TestFollowHandler_SetHype(t *testing.T) {
+	t.Parallel()
+
+	artistID := "artist-uuid-1"
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		req      *followv1.SetHypeRequest
+		setup    func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository)
+		wantCode connect.Code
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			ctx:  followAuthedCtx("ext-user-1"),
+			req: &followv1.SetHypeRequest{
+				ArtistId: &entityv1.ArtistId{Value: artistID},
+				Hype:     entityv1.HypeType_HYPE_TYPE_HOME,
+			},
+			setup: func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().SetHype(mock.Anything, "user-uuid-1", artistID, mock.Anything).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:     "error - unauthenticated",
+			ctx:      context.Background(),
+			req:      &followv1.SetHypeRequest{ArtistId: &entityv1.ArtistId{Value: artistID}, Hype: entityv1.HypeType_HYPE_TYPE_HOME},
+			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeUnauthenticated,
+			wantErr:  true,
+		},
+		{
+			name:     "error - missing artist_id",
+			ctx:      followAuthedCtx("ext-user-1"),
+			req:      &followv1.SetHypeRequest{ArtistId: nil, Hype: entityv1.HypeType_HYPE_TYPE_HOME},
+			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeInvalidArgument,
+			wantErr:  true,
+		},
+		{
+			name: "error - user not found",
+			ctx:  followAuthedCtx("ext-user-1"),
+			req: &followv1.SetHypeRequest{
+				ArtistId: &entityv1.ArtistId{Value: artistID},
+				Hype:     entityv1.HypeType_HYPE_TYPE_HOME,
+			},
+			setup: func(_ *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, err := logging.New()
+			require.NoError(t, err)
+
+			uc := ucmocks.NewMockFollowUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewFollowHandler(uc, ur, logger)
+
+			resp, err := h.SetHype(tt.ctx, connect.NewRequest(tt.req))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantCode != 0 {
+					assert.Equal(t, tt.wantCode, connect.CodeOf(err))
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+		})
+	}
+}

--- a/internal/adapter/rpc/ticket_email_handler.go
+++ b/internal/adapter/rpc/ticket_email_handler.go
@@ -8,7 +8,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/liverty-music/backend/internal/adapter/rpc/mapper"
 	"github.com/liverty-music/backend/internal/entity"
-	"github.com/liverty-music/backend/internal/infrastructure/auth"
 	"github.com/liverty-music/backend/internal/usecase"
 	"github.com/pannpers/go-logging/logging"
 )
@@ -16,25 +15,28 @@ import (
 // TicketEmailHandler implements the TicketEmailService Connect interface.
 type TicketEmailHandler struct {
 	ticketEmailUC usecase.TicketEmailUseCase
+	userRepo      entity.UserRepository
 	logger        *logging.Logger
 }
 
 // NewTicketEmailHandler creates a new instance of the ticket email RPC service handler.
 func NewTicketEmailHandler(
 	ticketEmailUC usecase.TicketEmailUseCase,
+	userRepo entity.UserRepository,
 	logger *logging.Logger,
 ) *TicketEmailHandler {
 	return &TicketEmailHandler{
 		ticketEmailUC: ticketEmailUC,
+		userRepo:      userRepo,
 		logger:        logger,
 	}
 }
 
 // CreateTicketEmail parses a shared email and persists the results.
 func (h *TicketEmailHandler) CreateTicketEmail(ctx context.Context, req *connect.Request[rpc.CreateTicketEmailRequest]) (*connect.Response[rpc.CreateTicketEmailResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	emailType, ok := mapper.TicketEmailTypeFromProto[req.Msg.EmailType]
@@ -50,7 +52,18 @@ func (h *TicketEmailHandler) CreateTicketEmail(ctx context.Context, req *connect
 		eventIDs = append(eventIDs, eid.Value)
 	}
 
-	emails, err := h.ticketEmailUC.Create(ctx, userID, eventIDs, emailType, req.Msg.RawBody)
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// ticket_emails.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	emails, err := h.ticketEmailUC.Create(ctx, user.ID, eventIDs, emailType, req.Msg.RawBody)
 	if err != nil {
 		return nil, err
 	}
@@ -62,13 +75,24 @@ func (h *TicketEmailHandler) CreateTicketEmail(ctx context.Context, req *connect
 
 // UpdateTicketEmail applies user corrections and triggers TicketJourney status updates.
 func (h *TicketEmailHandler) UpdateTicketEmail(ctx context.Context, req *connect.Request[rpc.UpdateTicketEmailRequest]) (*connect.Response[rpc.UpdateTicketEmailResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if req.Msg.TicketEmailId == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ticket_email_id is required"))
+	}
+
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// ticket_emails.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
 	}
 
 	params := &entity.UpdateTicketEmail{}
@@ -94,7 +118,7 @@ func (h *TicketEmailHandler) UpdateTicketEmail(ctx context.Context, req *connect
 		}
 	}
 
-	updated, err := h.ticketEmailUC.Update(ctx, userID, req.Msg.TicketEmailId.Value, params)
+	updated, err := h.ticketEmailUC.Update(ctx, user.ID, req.Msg.TicketEmailId.Value, params)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/rpc/ticket_email_handler_test.go
+++ b/internal/adapter/rpc/ticket_email_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 	handler "github.com/liverty-music/backend/internal/adapter/rpc"
 	"github.com/liverty-music/backend/internal/entity"
+	entitymocks "github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/infrastructure/auth"
 	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-logging/logging"
@@ -28,7 +29,7 @@ func TestTicketEmailHandler_CreateTicketEmail(t *testing.T) {
 		name     string
 		ctx      context.Context
 		req      *ticketemailv1.CreateTicketEmailRequest
-		setup    func(uc *ucmocks.MockTicketEmailUseCase)
+		setup    func(uc *ucmocks.MockTicketEmailUseCase, ur *entitymocks.MockUserRepository)
 		wantCode connect.Code
 		wantLen  int
 		wantErr  error
@@ -44,16 +45,20 @@ func TestTicketEmailHandler_CreateTicketEmail(t *testing.T) {
 					{Value: "event-2"},
 				},
 			},
-			setup: func(uc *ucmocks.MockTicketEmailUseCase) {
+			setup: func(uc *ucmocks.MockTicketEmailUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "user-sub-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "user-sub-1",
+				}, nil)
 				uc.EXPECT().Create(
 					mock.Anything,
-					"user-sub-1",
+					"user-uuid-1",
 					[]string{"event-1", "event-2"},
 					entity.TicketEmailTypeLotteryInfo,
 					"lottery info body",
 				).Return([]*entity.TicketEmail{
-					{ID: "te-1", UserID: "user-sub-1", EventID: "event-1", EmailType: entity.TicketEmailTypeLotteryInfo},
-					{ID: "te-2", UserID: "user-sub-1", EventID: "event-2", EmailType: entity.TicketEmailTypeLotteryInfo},
+					{ID: "te-1", UserID: "user-uuid-1", EventID: "event-1", EmailType: entity.TicketEmailTypeLotteryInfo},
+					{ID: "te-2", UserID: "user-uuid-1", EventID: "event-2", EmailType: entity.TicketEmailTypeLotteryInfo},
 				}, nil)
 			},
 			wantLen: 2,
@@ -67,7 +72,7 @@ func TestTicketEmailHandler_CreateTicketEmail(t *testing.T) {
 				EmailType: entityv1.TicketEmailType_TICKET_EMAIL_TYPE_LOTTERY_INFO,
 				EventIds:  []*entityv1.EventId{{Value: "event-1"}},
 			},
-			setup:    func(_ *ucmocks.MockTicketEmailUseCase) {},
+			setup:    func(_ *ucmocks.MockTicketEmailUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeUnauthenticated,
 			wantErr:  assert.AnError,
 		},
@@ -79,7 +84,7 @@ func TestTicketEmailHandler_CreateTicketEmail(t *testing.T) {
 				EmailType: entityv1.TicketEmailType_TICKET_EMAIL_TYPE_UNSPECIFIED,
 				EventIds:  []*entityv1.EventId{{Value: "event-1"}},
 			},
-			setup:    func(_ *ucmocks.MockTicketEmailUseCase) {},
+			setup:    func(_ *ucmocks.MockTicketEmailUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeInvalidArgument,
 			wantErr:  assert.AnError,
 		},
@@ -91,8 +96,22 @@ func TestTicketEmailHandler_CreateTicketEmail(t *testing.T) {
 				EmailType: entityv1.TicketEmailType_TICKET_EMAIL_TYPE_LOTTERY_INFO,
 				EventIds:  []*entityv1.EventId{{Value: "event-1"}, nil},
 			},
-			setup:    func(_ *ucmocks.MockTicketEmailUseCase) {},
+			setup:    func(_ *ucmocks.MockTicketEmailUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeInvalidArgument,
+			wantErr:  assert.AnError,
+		},
+		{
+			name: "return not found error when user does not exist",
+			ctx:  ticketEmailAuthedCtx("user-sub-1"),
+			req: &ticketemailv1.CreateTicketEmailRequest{
+				RawBody:   "body",
+				EmailType: entityv1.TicketEmailType_TICKET_EMAIL_TYPE_LOTTERY_INFO,
+				EventIds:  []*entityv1.EventId{{Value: "event-1"}},
+			},
+			setup: func(_ *ucmocks.MockTicketEmailUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "user-sub-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
 			wantErr:  assert.AnError,
 		},
 		{
@@ -103,10 +122,14 @@ func TestTicketEmailHandler_CreateTicketEmail(t *testing.T) {
 				EmailType: entityv1.TicketEmailType_TICKET_EMAIL_TYPE_LOTTERY_INFO,
 				EventIds:  []*entityv1.EventId{{Value: "event-1"}},
 			},
-			setup: func(uc *ucmocks.MockTicketEmailUseCase) {
+			setup: func(uc *ucmocks.MockTicketEmailUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "user-sub-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "user-sub-1",
+				}, nil)
 				uc.EXPECT().Create(
 					mock.Anything,
-					"user-sub-1",
+					"user-uuid-1",
 					[]string{"event-1"},
 					entity.TicketEmailTypeLotteryInfo,
 					"body",
@@ -124,9 +147,10 @@ func TestTicketEmailHandler_CreateTicketEmail(t *testing.T) {
 			require.NoError(t, err)
 
 			ticketEmailUC := ucmocks.NewMockTicketEmailUseCase(t)
-			tc.setup(ticketEmailUC)
+			ur := entitymocks.NewMockUserRepository(t)
+			tc.setup(ticketEmailUC, ur)
 
-			h := handler.NewTicketEmailHandler(ticketEmailUC, logger)
+			h := handler.NewTicketEmailHandler(ticketEmailUC, ur, logger)
 			req := connect.NewRequest(tc.req)
 
 			resp, err := h.CreateTicketEmail(tc.ctx, req)
@@ -156,7 +180,7 @@ func TestTicketEmailHandler_UpdateTicketEmail(t *testing.T) {
 		name     string
 		ctx      context.Context
 		req      *ticketemailv1.UpdateTicketEmailRequest
-		setup    func(uc *ucmocks.MockTicketEmailUseCase)
+		setup    func(uc *ucmocks.MockTicketEmailUseCase, ur *entitymocks.MockUserRepository)
 		wantCode connect.Code
 		wantErr  error
 	}{
@@ -168,15 +192,19 @@ func TestTicketEmailHandler_UpdateTicketEmail(t *testing.T) {
 				ApplicationUrl: &appURL,
 				JourneyStatus:  &journeyStatus,
 			},
-			setup: func(uc *ucmocks.MockTicketEmailUseCase) {
+			setup: func(uc *ucmocks.MockTicketEmailUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "user-sub-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "user-sub-1",
+				}, nil)
 				uc.EXPECT().Update(
 					mock.Anything,
-					"user-sub-1",
+					"user-uuid-1",
 					"te-123",
 					mock.AnythingOfType("*entity.UpdateTicketEmail"),
 				).Return(&entity.TicketEmail{
 					ID:             "te-123",
-					UserID:         "user-sub-1",
+					UserID:         "user-uuid-1",
 					EventID:        "event-1",
 					ApplicationURL: appURL,
 				}, nil)
@@ -189,7 +217,7 @@ func TestTicketEmailHandler_UpdateTicketEmail(t *testing.T) {
 			req: &ticketemailv1.UpdateTicketEmailRequest{
 				TicketEmailId: &entityv1.TicketEmailId{Value: "te-123"},
 			},
-			setup:    func(_ *ucmocks.MockTicketEmailUseCase) {},
+			setup:    func(_ *ucmocks.MockTicketEmailUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeUnauthenticated,
 			wantErr:  assert.AnError,
 		},
@@ -199,8 +227,20 @@ func TestTicketEmailHandler_UpdateTicketEmail(t *testing.T) {
 			req: &ticketemailv1.UpdateTicketEmailRequest{
 				TicketEmailId: nil,
 			},
-			setup:    func(_ *ucmocks.MockTicketEmailUseCase) {},
+			setup:    func(_ *ucmocks.MockTicketEmailUseCase, _ *entitymocks.MockUserRepository) {},
 			wantCode: connect.CodeInvalidArgument,
+			wantErr:  assert.AnError,
+		},
+		{
+			name: "return not found error when user does not exist",
+			ctx:  ticketEmailAuthedCtx("user-sub-1"),
+			req: &ticketemailv1.UpdateTicketEmailRequest{
+				TicketEmailId: &entityv1.TicketEmailId{Value: "te-123"},
+			},
+			setup: func(_ *ucmocks.MockTicketEmailUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "user-sub-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
 			wantErr:  assert.AnError,
 		},
 		{
@@ -209,10 +249,14 @@ func TestTicketEmailHandler_UpdateTicketEmail(t *testing.T) {
 			req: &ticketemailv1.UpdateTicketEmailRequest{
 				TicketEmailId: &entityv1.TicketEmailId{Value: "te-123"},
 			},
-			setup: func(uc *ucmocks.MockTicketEmailUseCase) {
+			setup: func(uc *ucmocks.MockTicketEmailUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "user-sub-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "user-sub-1",
+				}, nil)
 				uc.EXPECT().Update(
 					mock.Anything,
-					"user-sub-1",
+					"user-uuid-1",
 					"te-123",
 					mock.AnythingOfType("*entity.UpdateTicketEmail"),
 				).Return(nil, assert.AnError)
@@ -229,9 +273,10 @@ func TestTicketEmailHandler_UpdateTicketEmail(t *testing.T) {
 			require.NoError(t, err)
 
 			ticketEmailUC := ucmocks.NewMockTicketEmailUseCase(t)
-			tc.setup(ticketEmailUC)
+			ur := entitymocks.NewMockUserRepository(t)
+			tc.setup(ticketEmailUC, ur)
 
-			h := handler.NewTicketEmailHandler(ticketEmailUC, logger)
+			h := handler.NewTicketEmailHandler(ticketEmailUC, ur, logger)
 			req := connect.NewRequest(tc.req)
 
 			resp, err := h.UpdateTicketEmail(tc.ctx, req)

--- a/internal/adapter/rpc/ticket_journey_handler.go
+++ b/internal/adapter/rpc/ticket_journey_handler.go
@@ -7,7 +7,7 @@ import (
 	rpc "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/ticket_journey/v1"
 	"connectrpc.com/connect"
 	"github.com/liverty-music/backend/internal/adapter/rpc/mapper"
-	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/usecase"
 	"github.com/pannpers/go-logging/logging"
 )
@@ -15,25 +15,28 @@ import (
 // TicketJourneyHandler implements the TicketJourneyService Connect interface.
 type TicketJourneyHandler struct {
 	ticketJourneyUC usecase.TicketJourneyUseCase
+	userRepo        entity.UserRepository
 	logger          *logging.Logger
 }
 
 // NewTicketJourneyHandler creates a new instance of the ticket journey RPC service handler.
 func NewTicketJourneyHandler(
 	ticketJourneyUC usecase.TicketJourneyUseCase,
+	userRepo entity.UserRepository,
 	logger *logging.Logger,
 ) *TicketJourneyHandler {
 	return &TicketJourneyHandler{
 		ticketJourneyUC: ticketJourneyUC,
+		userRepo:        userRepo,
 		logger:          logger,
 	}
 }
 
 // SetStatus creates or updates the fan's ticket journey status for a specific event.
 func (h *TicketJourneyHandler) SetStatus(ctx context.Context, req *connect.Request[rpc.SetStatusRequest]) (*connect.Response[rpc.SetStatusResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if req.Msg.EventId == nil {
@@ -45,7 +48,18 @@ func (h *TicketJourneyHandler) SetStatus(ctx context.Context, req *connect.Reque
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid ticket journey status"))
 	}
 
-	if err := h.ticketJourneyUC.SetStatus(ctx, userID, req.Msg.EventId.Value, status); err != nil {
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// ticket_journeys.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	if err := h.ticketJourneyUC.SetStatus(ctx, user.ID, req.Msg.EventId.Value, status); err != nil {
 		return nil, err
 	}
 
@@ -54,16 +68,27 @@ func (h *TicketJourneyHandler) SetStatus(ctx context.Context, req *connect.Reque
 
 // Delete removes the fan's ticket journey for a specific event.
 func (h *TicketJourneyHandler) Delete(ctx context.Context, req *connect.Request[rpc.DeleteRequest]) (*connect.Response[rpc.DeleteResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if req.Msg.EventId == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("event_id is required"))
 	}
 
-	if err := h.ticketJourneyUC.Delete(ctx, userID, req.Msg.EventId.Value); err != nil {
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// ticket_journeys.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	if err := h.ticketJourneyUC.Delete(ctx, user.ID, req.Msg.EventId.Value); err != nil {
 		return nil, err
 	}
 
@@ -72,12 +97,23 @@ func (h *TicketJourneyHandler) Delete(ctx context.Context, req *connect.Request[
 
 // ListByUser retrieves all ticket journeys for the authenticated fan.
 func (h *TicketJourneyHandler) ListByUser(ctx context.Context, _ *connect.Request[rpc.ListByUserRequest]) (*connect.Response[rpc.ListByUserResponse], error) {
-	userID, ok := auth.GetUserID(ctx)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not authenticated"))
+	claims, err := mapper.GetClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	journeys, err := h.ticketJourneyUC.ListByUser(ctx, userID)
+	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
+	// ticket_journeys.user_id references users.id (internal UUID),
+	// not the identity-provider-specific external_id.
+	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	}
+
+	journeys, err := h.ticketJourneyUC.ListByUser(ctx, user.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/rpc/ticket_journey_handler_test.go
+++ b/internal/adapter/rpc/ticket_journey_handler_test.go
@@ -1,0 +1,264 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+
+	entityv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/entity/v1"
+	ticketjourneyv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/ticket_journey/v1"
+	"connectrpc.com/connect"
+	handler "github.com/liverty-music/backend/internal/adapter/rpc"
+	"github.com/liverty-music/backend/internal/entity"
+	entitymocks "github.com/liverty-music/backend/internal/entity/mocks"
+	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
+	"github.com/pannpers/go-logging/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func ticketJourneyAuthedCtx(sub string) context.Context {
+	return auth.WithClaims(context.Background(), &auth.Claims{Sub: sub})
+}
+
+func TestTicketJourneyHandler_SetStatus(t *testing.T) {
+	t.Parallel()
+
+	eventID := "event-uuid-1"
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		req      *ticketjourneyv1.SetStatusRequest
+		setup    func(uc *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository)
+		wantCode connect.Code
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			ctx:  ticketJourneyAuthedCtx("ext-user-1"),
+			req: &ticketjourneyv1.SetStatusRequest{
+				EventId: &entityv1.EventId{Value: eventID},
+				Status:  entityv1.TicketJourneyStatus_TICKET_JOURNEY_STATUS_TRACKING,
+			},
+			setup: func(uc *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().SetStatus(mock.Anything, "user-uuid-1", eventID, mock.Anything).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name: "error - unauthenticated",
+			ctx:  context.Background(),
+			req: &ticketjourneyv1.SetStatusRequest{
+				EventId: &entityv1.EventId{Value: eventID},
+				Status:  entityv1.TicketJourneyStatus_TICKET_JOURNEY_STATUS_TRACKING,
+			},
+			setup:    func(_ *ucmocks.MockTicketJourneyUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeUnauthenticated,
+			wantErr:  true,
+		},
+		{
+			name: "error - missing event_id",
+			ctx:  ticketJourneyAuthedCtx("ext-user-1"),
+			req: &ticketjourneyv1.SetStatusRequest{
+				EventId: nil,
+				Status:  entityv1.TicketJourneyStatus_TICKET_JOURNEY_STATUS_TRACKING,
+			},
+			setup:    func(_ *ucmocks.MockTicketJourneyUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeInvalidArgument,
+			wantErr:  true,
+		},
+		{
+			name: "error - user not found",
+			ctx:  ticketJourneyAuthedCtx("ext-user-1"),
+			req: &ticketjourneyv1.SetStatusRequest{
+				EventId: &entityv1.EventId{Value: eventID},
+				Status:  entityv1.TicketJourneyStatus_TICKET_JOURNEY_STATUS_TRACKING,
+			},
+			setup: func(_ *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, err := logging.New()
+			require.NoError(t, err)
+
+			uc := ucmocks.NewMockTicketJourneyUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewTicketJourneyHandler(uc, ur, logger)
+
+			resp, err := h.SetStatus(tt.ctx, connect.NewRequest(tt.req))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantCode != 0 {
+					assert.Equal(t, tt.wantCode, connect.CodeOf(err))
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+		})
+	}
+}
+
+func TestTicketJourneyHandler_Delete(t *testing.T) {
+	t.Parallel()
+
+	eventID := "event-uuid-1"
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		req      *ticketjourneyv1.DeleteRequest
+		setup    func(uc *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository)
+		wantCode connect.Code
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			ctx:  ticketJourneyAuthedCtx("ext-user-1"),
+			req:  &ticketjourneyv1.DeleteRequest{EventId: &entityv1.EventId{Value: eventID}},
+			setup: func(uc *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().Delete(mock.Anything, "user-uuid-1", eventID).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:     "error - unauthenticated",
+			ctx:      context.Background(),
+			req:      &ticketjourneyv1.DeleteRequest{EventId: &entityv1.EventId{Value: eventID}},
+			setup:    func(_ *ucmocks.MockTicketJourneyUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeUnauthenticated,
+			wantErr:  true,
+		},
+		{
+			name:     "error - missing event_id",
+			ctx:      ticketJourneyAuthedCtx("ext-user-1"),
+			req:      &ticketjourneyv1.DeleteRequest{EventId: nil},
+			setup:    func(_ *ucmocks.MockTicketJourneyUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeInvalidArgument,
+			wantErr:  true,
+		},
+		{
+			name: "error - user not found",
+			ctx:  ticketJourneyAuthedCtx("ext-user-1"),
+			req:  &ticketjourneyv1.DeleteRequest{EventId: &entityv1.EventId{Value: eventID}},
+			setup: func(_ *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, err := logging.New()
+			require.NoError(t, err)
+
+			uc := ucmocks.NewMockTicketJourneyUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewTicketJourneyHandler(uc, ur, logger)
+
+			resp, err := h.Delete(tt.ctx, connect.NewRequest(tt.req))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantCode != 0 {
+					assert.Equal(t, tt.wantCode, connect.CodeOf(err))
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+		})
+	}
+}
+
+func TestTicketJourneyHandler_ListByUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		setup    func(uc *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository)
+		wantCode connect.Code
+		wantErr  bool
+	}{
+		{
+			name: "success - returns empty list when no journeys exist",
+			ctx:  ticketJourneyAuthedCtx("ext-user-1"),
+			setup: func(uc *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+				uc.EXPECT().ListByUser(mock.Anything, "user-uuid-1").Return([]*entity.TicketJourney{}, nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:     "error - unauthenticated",
+			ctx:      context.Background(),
+			setup:    func(_ *ucmocks.MockTicketJourneyUseCase, _ *entitymocks.MockUserRepository) {},
+			wantCode: connect.CodeUnauthenticated,
+			wantErr:  true,
+		},
+		{
+			name: "error - user not found",
+			ctx:  ticketJourneyAuthedCtx("ext-user-1"),
+			setup: func(_ *ucmocks.MockTicketJourneyUseCase, ur *entitymocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
+			},
+			wantCode: connect.CodeNotFound,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, err := logging.New()
+			require.NoError(t, err)
+
+			uc := ucmocks.NewMockTicketJourneyUseCase(t)
+			ur := entitymocks.NewMockUserRepository(t)
+			tt.setup(uc, ur)
+			h := handler.NewTicketJourneyHandler(uc, ur, logger)
+
+			resp, err := h.ListByUser(tt.ctx, connect.NewRequest(&ticketjourneyv1.ListByUserRequest{}))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantCode != 0 {
+					assert.Equal(t, tt.wantCode, connect.CodeOf(err))
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+		})
+	}
+}

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -244,7 +244,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		},
 		func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return followconnect.NewFollowServiceHandler(
-				rpc.NewFollowHandler(followUC, logger),
+				rpc.NewFollowHandler(followUC, userRepo, logger),
 				opts...,
 			)
 		},
@@ -262,7 +262,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		},
 		func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return ticketjourneyconnect.NewTicketJourneyServiceHandler(
-				rpc.NewTicketJourneyHandler(ticketJourneyUC, logger),
+				rpc.NewTicketJourneyHandler(ticketJourneyUC, userRepo, logger),
 				opts...,
 			)
 		},
@@ -281,7 +281,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	if ticketEmailUC != nil {
 		handlers = append(handlers, func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return ticketemailconnect.NewTicketEmailServiceHandler(
-				rpc.NewTicketEmailHandler(ticketEmailUC, logger),
+				rpc.NewTicketEmailHandler(ticketEmailUC, userRepo, logger),
 				opts...,
 			)
 		})


### PR DESCRIPTION
## Summary

- `FollowHandler`, `TicketJourneyHandler`, and `TicketEmailHandler` were passing the Zitadel JWT `sub` claim (a numeric string) directly as `user_id` to PostgreSQL UUID columns, causing `SQLSTATE 22P02: invalid input syntax for type uuid` on every authenticated request
- Fixed by resolving the external identity to the internal UUID via `userRepo.GetByExternalID` before calling the use case — same pattern already used in `TicketHandler` and `PushNotificationHandler`
- Added unit tests for all affected handlers covering success, unauthenticated, invalid argument, and user-not-found scenarios

## Root cause

`auth.GetUserID(ctx)` returns `claims.Sub` (the Zitadel-assigned numeric string like `"365016846690184714"`). All per-user DB tables (`followed_artists`, `ticket_journeys`, `ticket_emails`) have `user_id UUID REFERENCES users(id)`, which stores the internal UUID, not the Zitadel external ID.

## Test plan

- [ ] Unit tests pass: `go test ./internal/adapter/rpc/...`
- [ ] Manual: sign up → `TicketJourneyService/ListByUser` returns 200 (not 400)
- [ ] Manual: `FollowService/Follow`, `FollowService/ListFollowed` work after signup
- [ ] Manual: `TicketEmailService/CreateTicketEmail` works after signup
