### PR TITLE
refactor(zitadel): use grpc.NewServer pattern for EmailVerifier tests

### DIFF
--- a/internal/infrastructure/zitadel/email_verifier.go
+++ b/internal/infrastructure/zitadel/email_verifier.go
@@ -45,20 +45,26 @@ type EmailVerifier struct {
 //
 // issuerURL is the OIDC issuer URL (e.g., "https://dev-svijfm.us1.zitadel.cloud").
 // keyPath is the file path to the machine key JSON.
-func NewEmailVerifier(ctx context.Context, issuerURL, keyPath string, logger *logging.Logger) (*EmailVerifier, error) {
+// opts are additional zitadel connection options (e.g., WithInsecure for testing).
+func NewEmailVerifier(ctx context.Context, issuerURL, keyPath string, logger *logging.Logger, opts ...zitadelconn.Option) (*EmailVerifier, error) {
 	apiEndpoint, err := grpcEndpoint(issuerURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse zitadel domain: %w", err)
 	}
+
+	connOpts := []zitadelconn.Option{
+		zitadelconn.WithJWTProfileTokenSource(
+			middleware.JWTProfileFromPath(ctx, keyPath),
+		),
+	}
+	connOpts = append(connOpts, opts...)
 
 	userClient, err := userv2.NewClient(
 		ctx,
 		issuerURL,
 		apiEndpoint,
 		nil,
-		zitadelconn.WithJWTProfileTokenSource(
-			middleware.JWTProfileFromPath(ctx, keyPath),
-		),
+		connOpts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create zitadel user client: %w", err)

--- a/internal/infrastructure/zitadel/email_verifier_test.go
+++ b/internal/infrastructure/zitadel/email_verifier_test.go
@@ -2,9 +2,12 @@ package zitadel_test
 
 import (
 	"context"
+	"net"
 	"testing"
 
+	zitadelconn "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel"
 	userpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user/v2"
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -16,8 +19,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// stubClient implements the emailCodeClient interface for unit testing.
-type stubClient struct {
+// stubUserServiceServer implements only the two email code methods under test.
+// All other UserServiceServer methods return Unimplemented via the embedded type.
+type stubUserServiceServer struct {
+	userpb.UnimplementedUserServiceServer
 	sendErr   error
 	resendErr error
 
@@ -25,7 +30,7 @@ type stubClient struct {
 	lastResendUserID string
 }
 
-func (s *stubClient) SendEmailCode(_ context.Context, in *userpb.SendEmailCodeRequest, _ ...grpc.CallOption) (*userpb.SendEmailCodeResponse, error) {
+func (s *stubUserServiceServer) SendEmailCode(_ context.Context, in *userpb.SendEmailCodeRequest) (*userpb.SendEmailCodeResponse, error) {
 	s.lastSendUserID = in.UserId
 	if s.sendErr != nil {
 		return nil, s.sendErr
@@ -33,7 +38,7 @@ func (s *stubClient) SendEmailCode(_ context.Context, in *userpb.SendEmailCodeRe
 	return &userpb.SendEmailCodeResponse{}, nil
 }
 
-func (s *stubClient) ResendEmailCode(_ context.Context, in *userpb.ResendEmailCodeRequest, _ ...grpc.CallOption) (*userpb.ResendEmailCodeResponse, error) {
+func (s *stubUserServiceServer) ResendEmailCode(_ context.Context, in *userpb.ResendEmailCodeRequest) (*userpb.ResendEmailCodeResponse, error) {
 	s.lastResendUserID = in.UserId
 	if s.resendErr != nil {
 		return nil, s.resendErr
@@ -41,11 +46,38 @@ func (s *stubClient) ResendEmailCode(_ context.Context, in *userpb.ResendEmailCo
 	return &userpb.ResendEmailCodeResponse{}, nil
 }
 
-func newTestLogger(t *testing.T) *logging.Logger {
+// startUserServiceServer starts a real gRPC server on a random local port and
+// returns the "host:port" address, mirroring the pattern used in the Zitadel SDK
+// own tests (pkg/client/zitadel/client_test.go).
+func startUserServiceServer(t *testing.T, srv *stubUserServiceServer) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s := grpc.NewServer()
+	userpb.RegisterUserServiceServer(s, srv)
+	go func() { _ = s.Serve(lis) }()
+	t.Cleanup(s.GracefulStop)
+	return lis.Addr().String()
+}
+
+// newTestVerifier creates an EmailVerifier pointing at the given gRPC server
+// address using insecure transport and a static token, bypassing JWT auth.
+func newTestVerifier(t *testing.T, addr string) *infrazitadel.EmailVerifier {
 	t.Helper()
 	logger, err := logging.New()
 	require.NoError(t, err)
-	return logger
+
+	v, err := infrazitadel.NewEmailVerifier(
+		context.Background(),
+		"http://test-issuer",
+		"",
+		logger,
+		zitadelconn.WithInsecure(),
+		zitadelconn.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test"})),
+		zitadelconn.WithCustomURL("http://test-issuer", addr),
+	)
+	require.NoError(t, err)
+	return v
 }
 
 func TestEmailVerifier_SendVerification(t *testing.T) {
@@ -59,14 +91,14 @@ func TestEmailVerifier_SendVerification(t *testing.T) {
 		args    args
 		sendErr error
 		wantErr error
-		check   func(t *testing.T, stub *stubClient)
+		check   func(t *testing.T, stub *stubUserServiceServer)
 	}{
 		{
 			name:    "success",
 			args:    args{externalID: "user-123"},
 			sendErr: nil,
 			wantErr: nil,
-			check: func(t *testing.T, stub *stubClient) {
+			check: func(t *testing.T, stub *stubUserServiceServer) {
 				t.Helper()
 				assert.Equal(t, "user-123", stub.lastSendUserID)
 			},
@@ -88,8 +120,9 @@ func TestEmailVerifier_SendVerification(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			stub := &stubClient{sendErr: tt.sendErr}
-			v := infrazitadel.NewTestEmailVerifier(stub, newTestLogger(t))
+			stub := &stubUserServiceServer{sendErr: tt.sendErr}
+			addr := startUserServiceServer(t, stub)
+			v := newTestVerifier(t, addr)
 
 			err := v.SendVerification(context.Background(), tt.args.externalID)
 
@@ -117,14 +150,14 @@ func TestEmailVerifier_ResendVerification(t *testing.T) {
 		args      args
 		resendErr error
 		wantErr   error
-		check     func(t *testing.T, stub *stubClient)
+		check     func(t *testing.T, stub *stubUserServiceServer)
 	}{
 		{
 			name:      "success",
 			args:      args{externalID: "user-123"},
 			resendErr: nil,
 			wantErr:   nil,
-			check: func(t *testing.T, stub *stubClient) {
+			check: func(t *testing.T, stub *stubUserServiceServer) {
 				t.Helper()
 				assert.Equal(t, "user-123", stub.lastResendUserID)
 			},
@@ -158,8 +191,9 @@ func TestEmailVerifier_ResendVerification(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			stub := &stubClient{resendErr: tt.resendErr}
-			v := infrazitadel.NewTestEmailVerifier(stub, newTestLogger(t))
+			stub := &stubUserServiceServer{resendErr: tt.resendErr}
+			addr := startUserServiceServer(t, stub)
+			v := newTestVerifier(t, addr)
 
 			err := v.ResendVerification(context.Background(), tt.args.externalID)
 

--- a/internal/infrastructure/zitadel/export_test.go
+++ b/internal/infrastructure/zitadel/export_test.go
@@ -1,17 +1,4 @@
 package zitadel
 
-import (
-	"github.com/pannpers/go-logging/logging"
-)
-
-// NewTestEmailVerifier creates an EmailVerifier with a mock gRPC client
-// for unit testing. Bypasses the real gRPC connection setup.
-func NewTestEmailVerifier(client emailCodeClient, logger *logging.Logger) *EmailVerifier {
-	return &EmailVerifier{
-		client: client,
-		logger: logger,
-	}
-}
-
 // GrpcEndpoint exposes grpcEndpoint for testing.
 var GrpcEndpoint = grpcEndpoint


### PR DESCRIPTION
## Summary

Refactor `EmailVerifier` tests to use a real gRPC server (`net.Listen(":0") + grpc.NewServer()`), matching the pattern used in the Zitadel SDK's own test suite.

## Problem with the previous approach

The prior tests used a hand-rolled `stubClient` interface injected via `export_test.go:NewTestEmailVerifier`, which bypassed:
- `NewEmailVerifier` constructor (including `grpcEndpoint` URL parsing)
- `grpc.Dial` and the gRPC transport layer
- Protobuf serialization/deserialization

This is analogous to testing an HTTP client by injecting a fake response object instead of starting an `httptest.Server`.

## What changed

- **`email_verifier_test.go`**: Replace `stubClient` + `NewTestEmailVerifier` with `stubUserServiceServer` (embeds `UnimplementedUserServiceServer`, overrides only `SendEmailCode` and `ResendEmailCode`) and a `startUserServiceServer` helper that binds to a random TCP port — the same pattern as `pkg/client/zitadel/client_test.go` in the Zitadel SDK.
- **`email_verifier.go`**: Add `opts ...zitadelconn.Option` variadic parameter to `NewEmailVerifier`, allowing tests to pass `WithInsecure()`, `WithTokenSource(StaticTokenSource(...))`, and `WithCustomURL(...)` to redirect the client to the test server.
- **`export_test.go`**: Remove `NewTestEmailVerifier` (no longer needed). Keep `GrpcEndpoint` export for `TestGrpcEndpoint`.

## Test coverage

All 13 test cases are preserved with identical scenarios — only the transport mechanism is now real end-to-end gRPC instead of a mocked interface.

Refs: #240
