### PR TITLE
fix(rpc): remove double ID resolution in FollowHandler

### DIFF
--- a/internal/adapter/rpc/follow_handler.go
+++ b/internal/adapter/rpc/follow_handler.go
@@ -7,7 +7,6 @@ import (
 	rpc "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/follow/v1"
 	"connectrpc.com/connect"
 	"github.com/liverty-music/backend/internal/adapter/rpc/mapper"
-	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/usecase"
 	"github.com/pannpers/go-logging/logging"
 )
@@ -15,19 +14,16 @@ import (
 // FollowHandler implements the FollowService Connect interface.
 type FollowHandler struct {
 	followUseCase usecase.FollowUseCase
-	userRepo      entity.UserRepository
 	logger        *logging.Logger
 }
 
 // NewFollowHandler creates a new instance of the follow RPC service handler.
 func NewFollowHandler(
 	followUseCase usecase.FollowUseCase,
-	userRepo entity.UserRepository,
 	logger *logging.Logger,
 ) *FollowHandler {
 	return &FollowHandler{
 		followUseCase: followUseCase,
-		userRepo:      userRepo,
 		logger:        logger,
 	}
 }
@@ -43,18 +39,7 @@ func (h *FollowHandler) Follow(ctx context.Context, req *connect.Request[rpc.Fol
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("artist_id is required"))
 	}
 
-	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
-	// follows.user_id references users.id (internal UUID),
-	// not the identity-provider-specific external_id.
-	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
-	if err != nil {
-		return nil, err
-	}
-	if user == nil {
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
-	}
-
-	err = h.followUseCase.Follow(ctx, user.ID, req.Msg.ArtistId.Value)
+	err = h.followUseCase.Follow(ctx, claims.Sub, req.Msg.ArtistId.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -73,18 +58,7 @@ func (h *FollowHandler) Unfollow(ctx context.Context, req *connect.Request[rpc.U
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("artist_id is required"))
 	}
 
-	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
-	// follows.user_id references users.id (internal UUID),
-	// not the identity-provider-specific external_id.
-	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
-	if err != nil {
-		return nil, err
-	}
-	if user == nil {
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
-	}
-
-	err = h.followUseCase.Unfollow(ctx, user.ID, req.Msg.ArtistId.Value)
+	err = h.followUseCase.Unfollow(ctx, claims.Sub, req.Msg.ArtistId.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -99,18 +73,7 @@ func (h *FollowHandler) ListFollowed(ctx context.Context, _ *connect.Request[rpc
 		return nil, err
 	}
 
-	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
-	// follows.user_id references users.id (internal UUID),
-	// not the identity-provider-specific external_id.
-	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
-	if err != nil {
-		return nil, err
-	}
-	if user == nil {
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
-	}
-
-	followed, err := h.followUseCase.ListFollowed(ctx, user.ID)
+	followed, err := h.followUseCase.ListFollowed(ctx, claims.Sub)
 	if err != nil {
 		return nil, err
 	}
@@ -136,18 +99,7 @@ func (h *FollowHandler) SetHype(ctx context.Context, req *connect.Request[rpc.Se
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid hype level"))
 	}
 
-	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
-	// follows.user_id references users.id (internal UUID),
-	// not the identity-provider-specific external_id.
-	user, err := h.userRepo.GetByExternalID(ctx, claims.Sub)
-	if err != nil {
-		return nil, err
-	}
-	if user == nil {
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("user not found"))
-	}
-
-	err = h.followUseCase.SetHype(ctx, user.ID, req.Msg.ArtistId.Value, hype)
+	err = h.followUseCase.SetHype(ctx, claims.Sub, req.Msg.ArtistId.Value, hype)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/rpc/follow_handler_test.go
+++ b/internal/adapter/rpc/follow_handler_test.go
@@ -9,7 +9,6 @@ import (
 	"connectrpc.com/connect"
 	handler "github.com/liverty-music/backend/internal/adapter/rpc"
 	"github.com/liverty-music/backend/internal/entity"
-	entitymocks "github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/infrastructure/auth"
 	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-logging/logging"
@@ -31,7 +30,7 @@ func TestFollowHandler_Follow(t *testing.T) {
 		name     string
 		ctx      context.Context
 		req      *followv1.FollowRequest
-		setup    func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository)
+		setup    func(uc *ucmocks.MockFollowUseCase)
 		wantCode connect.Code
 		wantErr  bool
 	}{
@@ -39,12 +38,8 @@ func TestFollowHandler_Follow(t *testing.T) {
 			name: "success",
 			ctx:  followAuthedCtx("ext-user-1"),
 			req:  &followv1.FollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
-			setup: func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
-				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
-					ID:         "user-uuid-1",
-					ExternalID: "ext-user-1",
-				}, nil)
-				uc.EXPECT().Follow(mock.Anything, "user-uuid-1", artistID).Return(nil).Once()
+			setup: func(uc *ucmocks.MockFollowUseCase) {
+				uc.EXPECT().Follow(mock.Anything, "ext-user-1", artistID).Return(nil).Once()
 			},
 			wantErr: false,
 		},
@@ -52,7 +47,7 @@ func TestFollowHandler_Follow(t *testing.T) {
 			name:     "error - unauthenticated",
 			ctx:      context.Background(),
 			req:      &followv1.FollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
-			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			setup:    func(_ *ucmocks.MockFollowUseCase) {},
 			wantCode: connect.CodeUnauthenticated,
 			wantErr:  true,
 		},
@@ -60,18 +55,8 @@ func TestFollowHandler_Follow(t *testing.T) {
 			name:     "error - missing artist_id",
 			ctx:      followAuthedCtx("ext-user-1"),
 			req:      &followv1.FollowRequest{ArtistId: nil},
-			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			setup:    func(_ *ucmocks.MockFollowUseCase) {},
 			wantCode: connect.CodeInvalidArgument,
-			wantErr:  true,
-		},
-		{
-			name: "error - user not found",
-			ctx:  followAuthedCtx("ext-user-1"),
-			req:  &followv1.FollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
-			setup: func(_ *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
-				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
-			},
-			wantCode: connect.CodeNotFound,
 			wantErr:  true,
 		},
 	}
@@ -84,9 +69,8 @@ func TestFollowHandler_Follow(t *testing.T) {
 			require.NoError(t, err)
 
 			uc := ucmocks.NewMockFollowUseCase(t)
-			ur := entitymocks.NewMockUserRepository(t)
-			tt.setup(uc, ur)
-			h := handler.NewFollowHandler(uc, ur, logger)
+			tt.setup(uc)
+			h := handler.NewFollowHandler(uc, logger)
 
 			resp, err := h.Follow(tt.ctx, connect.NewRequest(tt.req))
 
@@ -112,7 +96,7 @@ func TestFollowHandler_Unfollow(t *testing.T) {
 		name     string
 		ctx      context.Context
 		req      *followv1.UnfollowRequest
-		setup    func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository)
+		setup    func(uc *ucmocks.MockFollowUseCase)
 		wantCode connect.Code
 		wantErr  bool
 	}{
@@ -120,12 +104,8 @@ func TestFollowHandler_Unfollow(t *testing.T) {
 			name: "success",
 			ctx:  followAuthedCtx("ext-user-1"),
 			req:  &followv1.UnfollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
-			setup: func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
-				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
-					ID:         "user-uuid-1",
-					ExternalID: "ext-user-1",
-				}, nil)
-				uc.EXPECT().Unfollow(mock.Anything, "user-uuid-1", artistID).Return(nil).Once()
+			setup: func(uc *ucmocks.MockFollowUseCase) {
+				uc.EXPECT().Unfollow(mock.Anything, "ext-user-1", artistID).Return(nil).Once()
 			},
 			wantErr: false,
 		},
@@ -133,18 +113,8 @@ func TestFollowHandler_Unfollow(t *testing.T) {
 			name:     "error - unauthenticated",
 			ctx:      context.Background(),
 			req:      &followv1.UnfollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
-			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			setup:    func(_ *ucmocks.MockFollowUseCase) {},
 			wantCode: connect.CodeUnauthenticated,
-			wantErr:  true,
-		},
-		{
-			name: "error - user not found",
-			ctx:  followAuthedCtx("ext-user-1"),
-			req:  &followv1.UnfollowRequest{ArtistId: &entityv1.ArtistId{Value: artistID}},
-			setup: func(_ *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
-				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
-			},
-			wantCode: connect.CodeNotFound,
 			wantErr:  true,
 		},
 	}
@@ -157,9 +127,8 @@ func TestFollowHandler_Unfollow(t *testing.T) {
 			require.NoError(t, err)
 
 			uc := ucmocks.NewMockFollowUseCase(t)
-			ur := entitymocks.NewMockUserRepository(t)
-			tt.setup(uc, ur)
-			h := handler.NewFollowHandler(uc, ur, logger)
+			tt.setup(uc)
+			h := handler.NewFollowHandler(uc, logger)
 
 			resp, err := h.Unfollow(tt.ctx, connect.NewRequest(tt.req))
 
@@ -182,36 +151,23 @@ func TestFollowHandler_ListFollowed(t *testing.T) {
 	tests := []struct {
 		name     string
 		ctx      context.Context
-		setup    func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository)
+		setup    func(uc *ucmocks.MockFollowUseCase)
 		wantCode connect.Code
 		wantErr  bool
 	}{
 		{
 			name: "success",
 			ctx:  followAuthedCtx("ext-user-1"),
-			setup: func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
-				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
-					ID:         "user-uuid-1",
-					ExternalID: "ext-user-1",
-				}, nil)
-				uc.EXPECT().ListFollowed(mock.Anything, "user-uuid-1").Return([]*entity.FollowedArtist{}, nil).Once()
+			setup: func(uc *ucmocks.MockFollowUseCase) {
+				uc.EXPECT().ListFollowed(mock.Anything, "ext-user-1").Return([]*entity.FollowedArtist{}, nil).Once()
 			},
 			wantErr: false,
 		},
 		{
 			name:     "error - unauthenticated",
 			ctx:      context.Background(),
-			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			setup:    func(_ *ucmocks.MockFollowUseCase) {},
 			wantCode: connect.CodeUnauthenticated,
-			wantErr:  true,
-		},
-		{
-			name: "error - user not found",
-			ctx:  followAuthedCtx("ext-user-1"),
-			setup: func(_ *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
-				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
-			},
-			wantCode: connect.CodeNotFound,
 			wantErr:  true,
 		},
 	}
@@ -224,9 +180,8 @@ func TestFollowHandler_ListFollowed(t *testing.T) {
 			require.NoError(t, err)
 
 			uc := ucmocks.NewMockFollowUseCase(t)
-			ur := entitymocks.NewMockUserRepository(t)
-			tt.setup(uc, ur)
-			h := handler.NewFollowHandler(uc, ur, logger)
+			tt.setup(uc)
+			h := handler.NewFollowHandler(uc, logger)
 
 			resp, err := h.ListFollowed(tt.ctx, connect.NewRequest(&followv1.ListFollowedRequest{}))
 
@@ -252,7 +207,7 @@ func TestFollowHandler_SetHype(t *testing.T) {
 		name     string
 		ctx      context.Context
 		req      *followv1.SetHypeRequest
-		setup    func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository)
+		setup    func(uc *ucmocks.MockFollowUseCase)
 		wantCode connect.Code
 		wantErr  bool
 	}{
@@ -263,12 +218,8 @@ func TestFollowHandler_SetHype(t *testing.T) {
 				ArtistId: &entityv1.ArtistId{Value: artistID},
 				Hype:     entityv1.HypeType_HYPE_TYPE_HOME,
 			},
-			setup: func(uc *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
-				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
-					ID:         "user-uuid-1",
-					ExternalID: "ext-user-1",
-				}, nil)
-				uc.EXPECT().SetHype(mock.Anything, "user-uuid-1", artistID, mock.Anything).Return(nil).Once()
+			setup: func(uc *ucmocks.MockFollowUseCase) {
+				uc.EXPECT().SetHype(mock.Anything, "ext-user-1", artistID, mock.Anything).Return(nil).Once()
 			},
 			wantErr: false,
 		},
@@ -276,7 +227,7 @@ func TestFollowHandler_SetHype(t *testing.T) {
 			name:     "error - unauthenticated",
 			ctx:      context.Background(),
 			req:      &followv1.SetHypeRequest{ArtistId: &entityv1.ArtistId{Value: artistID}, Hype: entityv1.HypeType_HYPE_TYPE_HOME},
-			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			setup:    func(_ *ucmocks.MockFollowUseCase) {},
 			wantCode: connect.CodeUnauthenticated,
 			wantErr:  true,
 		},
@@ -284,21 +235,8 @@ func TestFollowHandler_SetHype(t *testing.T) {
 			name:     "error - missing artist_id",
 			ctx:      followAuthedCtx("ext-user-1"),
 			req:      &followv1.SetHypeRequest{ArtistId: nil, Hype: entityv1.HypeType_HYPE_TYPE_HOME},
-			setup:    func(_ *ucmocks.MockFollowUseCase, _ *entitymocks.MockUserRepository) {},
+			setup:    func(_ *ucmocks.MockFollowUseCase) {},
 			wantCode: connect.CodeInvalidArgument,
-			wantErr:  true,
-		},
-		{
-			name: "error - user not found",
-			ctx:  followAuthedCtx("ext-user-1"),
-			req: &followv1.SetHypeRequest{
-				ArtistId: &entityv1.ArtistId{Value: artistID},
-				Hype:     entityv1.HypeType_HYPE_TYPE_HOME,
-			},
-			setup: func(_ *ucmocks.MockFollowUseCase, ur *entitymocks.MockUserRepository) {
-				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(nil, nil)
-			},
-			wantCode: connect.CodeNotFound,
 			wantErr:  true,
 		},
 	}
@@ -311,9 +249,8 @@ func TestFollowHandler_SetHype(t *testing.T) {
 			require.NoError(t, err)
 
 			uc := ucmocks.NewMockFollowUseCase(t)
-			ur := entitymocks.NewMockUserRepository(t)
-			tt.setup(uc, ur)
-			h := handler.NewFollowHandler(uc, ur, logger)
+			tt.setup(uc)
+			h := handler.NewFollowHandler(uc, logger)
 
 			resp, err := h.SetHype(tt.ctx, connect.NewRequest(tt.req))
 

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -244,7 +244,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		},
 		func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return followconnect.NewFollowServiceHandler(
-				rpc.NewFollowHandler(followUC, userRepo, logger),
+				rpc.NewFollowHandler(followUC, logger),
 				opts...,
 			)
 		},


### PR DESCRIPTION
## Summary

- Removes double ID resolution in `FollowHandler` introduced by PR #246
- `FollowUseCase` already resolves `external_id` to `users.id` internally via `resolveUserID()` — passing `user.ID` (UUID) from the handler caused a second `GetByExternalID(uuid)` call returning `not_found`
- Handler now passes `claims.Sub` directly to the use case (Pattern A: use-case-layer resolution)
- Removes `userRepo` dependency from `FollowHandler` entirely

## Root Cause

PR #246 applied Pattern B (handler-layer resolution) to `FollowHandler`, which already used Pattern A (use-case-layer resolution). This caused:
1. Handler calls `GetByExternalID("363866558482624523")` → returns `user.ID = "some-uuid"`
2. Handler passes `"some-uuid"` to `FollowUseCase.Follow()`
3. UseCase `resolveUserID()` calls `GetByExternalID("some-uuid")` → `not_found`

## Test plan

- [ ] All unit tests pass (`make check`)
- [ ] `FollowService/ListFollowed` returns 200 after deploy
