### PR TITLE
fix(zitadel): add required API scope to fix AUTH-7fs1e on gRPC calls

### DIFF
--- a/internal/infrastructure/zitadel/email_verifier.go
+++ b/internal/infrastructure/zitadel/email_verifier.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/middleware"
 	userv2 "github.com/zitadel/zitadel-go/v3/pkg/client/user/v2"
 	zitadelconn "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel"
@@ -63,7 +64,7 @@ func NewEmailVerifier(ctx context.Context, issuerURL, keyPath string, logger *lo
 		ctx,
 		issuerURL,
 		apiEndpoint,
-		nil,
+		[]string{oidc.ScopeOpenID, zitadelconn.ScopeZitadelAPI()},
 		connOpts...,
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix `ResendEmailVerification` and `SendVerification` returning 500 (Internal Server Error) in production
- Root cause: missing `ScopeZitadelAPI()` scope in `NewEmailVerifier`

## Root Cause

`NewEmailVerifier` called `userv2.NewClient` with `nil` scopes:

```go
// Before (broken)
userClient, err := userv2.NewClient(ctx, issuerURL, apiEndpoint, nil, connOpts...)
```

Without the `urn:zitadel:iam:org:project:id:zitadel:aud` scope (`ScopeZitadelAPI()`), the obtained JWT access token does not include the Zitadel project in its `aud` claim. Zitadel's gRPC API rejects every call with `AUTH-7fs1e` (Errors.Token.Invalid).

The REST token endpoint itself accepted the JWT assertion (because REST auth uses the `sub` claim), which made it appear the key was valid. Only the gRPC call was failing.

## Fix

Pass `openid` + `ScopeZitadelAPI()` as required scopes:

```go
// After (fixed)
userClient, err := userv2.NewClient(
    ctx, issuerURL, apiEndpoint,
    []string{oidc.ScopeOpenID, zitadelconn.ScopeZitadelAPI()},
    connOpts...,
)
```

This matches the pattern shown in the Zitadel SDK examples (`example/auth/using_jwt_profile/main.go`).

## Verification

- Infrastructure verified correct: Secret Manager key valid, K8s Secret synced, volume mounted, ConfigMap env vars set
- JWT auth via REST confirmed working (Python test obtained Bearer token and called `/auth/v1/users/me` successfully)
- Only gRPC path was failing due to missing audience scope

Refs: #240
