### PR TITLE
fix(messaging): enable AckAsync and explicit ACK policy for JetStream subscriber

### DIFF
--- a/internal/infrastructure/messaging/subscriber.go
+++ b/internal/infrastructure/messaging/subscriber.go
@@ -40,6 +40,11 @@ func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goCh
 			DurableCalculator: func(_, topic string) string {
 				return strings.ReplaceAll(topic, ".", "_")
 			},
+			AckAsync: true,
+			SubscribeOptions: []nats.SubOpt{
+				nats.AckExplicit(),
+				nats.DeliverAll(),
+			},
 		},
 	}, wmLogger)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `AckAsync: true` to `JetStreamConfig` so NATS ACKs are sent asynchronously (`m.Ack()` instead of `m.AckSync()`), eliminating a shutdown race condition with `s.closing`
- Add `nats.AckExplicit()` and `nats.DeliverAll()` to `SubscribeOptions`, matching the official watermill-nats test suite patterns

## Problem

When KEDA scaled down the consumer pod, a race condition in `watermill-nats/pkg/nats.Subscriber.processMessage()` caused NATS ACKs to be silently dropped:

```go
select {
case <-msg.Acked():
    m.AckSync()   // ← never reached when shutdown wins
case <-s.closing: // ← SIGTERM closes this
    return        // ← ACK not sent; NATS redelivers on next startup
}
```

This caused duplicate `SendEmailCode` calls and multiple verification emails sent to the same user.

## Fix

`AckAsync: true` replaces the blocking `m.AckSync()` with a non-blocking `m.Ack()`, effectively closing the window where `s.closing` wins the race.

## Test plan

- [x] `make check` passes (all unit tests green)
- [ ] Deploy to dev, sign up new user → confirm exactly one verification email received
- [ ] Confirm KEDA scale-down/up cycle does not trigger redelivery (Cloud Logging)
