### PR TITLE
refactor(usecase): decompose MintTicket into focused sub-methods

### DIFF
--- a/internal/usecase/export_test.go
+++ b/internal/usecase/export_test.go
@@ -21,3 +21,25 @@ var ExportedDetermineJourneyStatus = func(uc TicketEmailUseCase, te *entity.Tick
 var ExportedProfileLogoColor = func(uc ArtistImageSyncUseCase, ctx context.Context, fanart *entity.Fanart, artistID string) {
 	uc.(*artistImageSyncUseCase).profileLogoColor(ctx, fanart, artistID)
 }
+
+// ExportedValidateMintParams exposes validateMintParams for black-box tests.
+var ExportedValidateMintParams = func(uc TicketUseCase, params *MintTicketParams) error {
+	return uc.(*ticketUseCase).validateMintParams(params)
+}
+
+// ExportedCheckExistingTicket exposes checkExistingTicket for black-box tests.
+var ExportedCheckExistingTicket = func(uc TicketUseCase, ctx context.Context, eventID, userID string) (*entity.Ticket, bool, error) {
+	return uc.(*ticketUseCase).checkExistingTicket(ctx, eventID, userID)
+}
+
+// ExportedMintOrReconcile exposes mintOrReconcile for black-box tests.
+// Returns only txHash and error; tokenID is an internal implementation detail.
+var ExportedMintOrReconcile = func(uc TicketUseCase, ctx context.Context, params *MintTicketParams) (string, error) {
+	txHash, _, err := uc.(*ticketUseCase).mintOrReconcile(ctx, params)
+	return txHash, err
+}
+
+// ExportedPersistTicket exposes persistTicket for black-box tests.
+var ExportedPersistTicket = func(uc TicketUseCase, ctx context.Context, params *MintTicketParams, tokenID uint64, txHash string) (*entity.Ticket, error) {
+	return uc.(*ticketUseCase).persistTicket(ctx, params, tokenID, txHash)
+}

--- a/internal/usecase/ticket_mint_uc_test.go
+++ b/internal/usecase/ticket_mint_uc_test.go
@@ -1,0 +1,290 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/liverty-music/backend/internal/entity"
+	"github.com/liverty-music/backend/internal/entity/mocks"
+	"github.com/liverty-music/backend/internal/usecase"
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/pannpers/go-apperr/apperr/codes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	mintTestEventID   = "event-123"
+	mintTestUserID    = "user-456"
+	mintTestAddress   = "0xAbCdEf0123456789AbCdEf0123456789AbCdEf01"
+	mintTestTokenID   = uint64(42)
+	mintTestTxHash    = "0xdeadbeef"
+	mintPlaceholderTx = "0x0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+func validMintParams() *usecase.MintTicketParams {
+	return &usecase.MintTicketParams{
+		EventID:          mintTestEventID,
+		UserID:           mintTestUserID,
+		RecipientAddress: mintTestAddress,
+	}
+}
+
+func newTicketUC(t *testing.T, repo *mocks.MockTicketRepository, minter *mocks.MockTicketMinter) usecase.TicketUseCase {
+	t.Helper()
+	return usecase.NewTicketUseCase(repo, minter, newTestLogger(t))
+}
+
+// --- validateMintParams ---
+
+func TestTicketUseCase_ValidateMintParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  *usecase.MintTicketParams
+		wantErr error
+	}{
+		{
+			name:    "nil params returns InvalidArgument",
+			params:  nil,
+			wantErr: apperr.ErrInvalidArgument,
+		},
+		{
+			name:    "empty EventID returns InvalidArgument",
+			params:  &usecase.MintTicketParams{UserID: mintTestUserID, RecipientAddress: mintTestAddress},
+			wantErr: apperr.ErrInvalidArgument,
+		},
+		{
+			name:    "empty UserID returns InvalidArgument",
+			params:  &usecase.MintTicketParams{EventID: mintTestEventID, RecipientAddress: mintTestAddress},
+			wantErr: apperr.ErrInvalidArgument,
+		},
+		{
+			name:    "invalid Ethereum address returns InvalidArgument",
+			params:  &usecase.MintTicketParams{EventID: mintTestEventID, UserID: mintTestUserID, RecipientAddress: "not-an-address"},
+			wantErr: apperr.ErrInvalidArgument,
+		},
+		{
+			name:    "valid params returns nil",
+			params:  validMintParams(),
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			uc := usecase.NewTicketUseCase(nil, nil, newTestLogger(t))
+
+			err := usecase.ExportedValidateMintParams(uc, tt.params)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// --- checkExistingTicket ---
+
+func TestTicketUseCase_CheckExistingTicket(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	existingTicket := &entity.Ticket{ID: "ticket-1", EventID: mintTestEventID, UserID: mintTestUserID}
+
+	tests := []struct {
+		name      string
+		setup     func(*mocks.MockTicketRepository)
+		wantFound bool
+		wantErr   error
+	}{
+		{
+			name: "ticket exists returns ticket and found=true",
+			setup: func(r *mocks.MockTicketRepository) {
+				r.EXPECT().GetByEventAndUser(ctx, mintTestEventID, mintTestUserID).Return(existingTicket, nil).Once()
+			},
+			wantFound: true,
+		},
+		{
+			name: "ticket not found and event exists returns found=false",
+			setup: func(r *mocks.MockTicketRepository) {
+				r.EXPECT().GetByEventAndUser(ctx, mintTestEventID, mintTestUserID).Return(nil, apperr.ErrNotFound).Once()
+				r.EXPECT().EventExists(ctx, mintTestEventID).Return(true, nil).Once()
+			},
+			wantFound: false,
+		},
+		{
+			name: "ticket not found and event missing returns NotFound",
+			setup: func(r *mocks.MockTicketRepository) {
+				r.EXPECT().GetByEventAndUser(ctx, mintTestEventID, mintTestUserID).Return(nil, apperr.ErrNotFound).Once()
+				r.EXPECT().EventExists(ctx, mintTestEventID).Return(false, nil).Once()
+			},
+			wantErr: apperr.ErrNotFound,
+		},
+		{
+			name: "database error propagates",
+			setup: func(r *mocks.MockTicketRepository) {
+				r.EXPECT().GetByEventAndUser(ctx, mintTestEventID, mintTestUserID).
+					Return(nil, apperr.New(codes.Internal, "db error")).Once()
+			},
+			wantErr: apperr.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			repo := mocks.NewMockTicketRepository(t)
+			tt.setup(repo)
+			uc := newTicketUC(t, repo, mocks.NewMockTicketMinter(t))
+
+			ticket, found, err := usecase.ExportedCheckExistingTicket(uc, ctx, mintTestEventID, mintTestUserID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				assert.Equal(t, existingTicket, ticket)
+			} else {
+				assert.Nil(t, ticket)
+			}
+		})
+	}
+}
+
+// --- mintOrReconcile ---
+
+func TestTicketUseCase_MintOrReconcile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		setup      func(*mocks.MockTicketMinter)
+		wantTxHash string
+		wantErr    error
+	}{
+		{
+			name: "fresh mint returns txHash from minter",
+			setup: func(m *mocks.MockTicketMinter) {
+				m.EXPECT().IsTokenMinted(ctx, mock.AnythingOfType("uint64")).Return(false, nil).Once()
+				m.EXPECT().Mint(ctx, mintTestAddress, mock.AnythingOfType("uint64")).Return(mintTestTxHash, nil).Once()
+			},
+			wantTxHash: mintTestTxHash,
+		},
+		{
+			name: "reconcile with correct owner returns placeholder txHash",
+			setup: func(m *mocks.MockTicketMinter) {
+				m.EXPECT().IsTokenMinted(ctx, mock.AnythingOfType("uint64")).Return(true, nil).Once()
+				m.EXPECT().OwnerOf(ctx, mock.AnythingOfType("uint64")).Return(mintTestAddress, nil).Once()
+			},
+			wantTxHash: mintPlaceholderTx,
+		},
+		{
+			name: "reconcile with wrong owner returns PermissionDenied",
+			setup: func(m *mocks.MockTicketMinter) {
+				m.EXPECT().IsTokenMinted(ctx, mock.AnythingOfType("uint64")).Return(true, nil).Once()
+				m.EXPECT().OwnerOf(ctx, mock.AnythingOfType("uint64")).
+					Return("0x0000000000000000000000000000000000000000", nil).Once()
+			},
+			wantErr: apperr.ErrPermissionDenied,
+		},
+		{
+			name: "on-chain check failure propagates error",
+			setup: func(m *mocks.MockTicketMinter) {
+				m.EXPECT().IsTokenMinted(ctx, mock.AnythingOfType("uint64")).
+					Return(false, apperr.New(codes.Internal, "rpc error")).Once()
+			},
+			wantErr: apperr.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			minter := mocks.NewMockTicketMinter(t)
+			tt.setup(minter)
+			uc := newTicketUC(t, mocks.NewMockTicketRepository(t), minter)
+
+			txHash, err := usecase.ExportedMintOrReconcile(uc, ctx, validMintParams())
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTxHash, txHash)
+		})
+	}
+}
+
+// --- persistTicket ---
+
+func TestTicketUseCase_PersistTicket(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	savedTicket := &entity.Ticket{ID: "ticket-new", EventID: mintTestEventID, UserID: mintTestUserID}
+	existingTicket := &entity.Ticket{ID: "ticket-existing", EventID: mintTestEventID, UserID: mintTestUserID}
+
+	tests := []struct {
+		name       string
+		setup      func(*mocks.MockTicketRepository)
+		wantTicket *entity.Ticket
+		wantErr    error
+	}{
+		{
+			name: "successful insert returns ticket",
+			setup: func(r *mocks.MockTicketRepository) {
+				r.EXPECT().Create(ctx, mock.AnythingOfType("*entity.NewTicket")).
+					Return(savedTicket, nil).Once()
+			},
+			wantTicket: savedTicket,
+		},
+		{
+			name: "concurrent duplicate returns existing ticket",
+			setup: func(r *mocks.MockTicketRepository) {
+				r.EXPECT().Create(ctx, mock.AnythingOfType("*entity.NewTicket")).
+					Return(nil, apperr.ErrAlreadyExists).Once()
+				r.EXPECT().GetByEventAndUser(ctx, mintTestEventID, mintTestUserID).
+					Return(existingTicket, nil).Once()
+			},
+			wantTicket: existingTicket,
+		},
+		{
+			name: "database write error propagates",
+			setup: func(r *mocks.MockTicketRepository) {
+				r.EXPECT().Create(ctx, mock.AnythingOfType("*entity.NewTicket")).
+					Return(nil, apperr.New(codes.Internal, "write error")).Once()
+			},
+			wantErr: apperr.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			repo := mocks.NewMockTicketRepository(t)
+			tt.setup(repo)
+			uc := newTicketUC(t, repo, mocks.NewMockTicketMinter(t))
+
+			ticket, err := usecase.ExportedPersistTicket(uc, ctx, validMintParams(), mintTestTokenID, mintTestTxHash)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTicket, ticket)
+		})
+	}
+}

--- a/internal/usecase/ticket_uc.go
+++ b/internal/usecase/ticket_uc.go
@@ -48,8 +48,6 @@ type MintTicketParams struct {
 	UserID string
 	// RecipientAddress is the EVM address (Safe or EOA) that receives the SBT.
 	RecipientAddress string
-	// TokenID is no longer accepted from callers. It is generated internally
-	// by generateTokenID to prevent client-controlled token ID assignment.
 }
 
 // ticketUseCase implements the TicketUseCase interface.
@@ -75,81 +73,88 @@ func NewTicketUseCase(
 	}
 }
 
-// MintTicket mints a soulbound ticket, with idempotency via DB + on-chain checks.
-func (uc *ticketUseCase) MintTicket(ctx context.Context, params *MintTicketParams) (*entity.Ticket, error) {
+// validateMintParams checks all required input fields for a mint request.
+// Returns InvalidArgument if any field is missing or invalid.
+func (uc *ticketUseCase) validateMintParams(params *MintTicketParams) error {
 	if params == nil {
-		return nil, apperr.New(codes.InvalidArgument, "params cannot be nil")
+		return apperr.New(codes.InvalidArgument, "params cannot be nil")
 	}
 
 	if params.EventID == "" {
-		return nil, apperr.New(codes.InvalidArgument, "event_id is required")
+		return apperr.New(codes.InvalidArgument, "event_id is required")
 	}
 
 	if params.UserID == "" {
-		return nil, apperr.New(codes.InvalidArgument, "user_id is required")
+		return apperr.New(codes.InvalidArgument, "user_id is required")
 	}
 
 	if params.RecipientAddress == "" {
-		return nil, apperr.New(codes.InvalidArgument, "recipient_address is required")
+		return apperr.New(codes.InvalidArgument, "recipient_address is required")
 	}
 
 	if !ethAddressRe.MatchString(params.RecipientAddress) {
-		return nil, apperr.New(codes.InvalidArgument, "recipient_address must be a valid Ethereum address (0x followed by 40 hex characters)")
+		return apperr.New(codes.InvalidArgument, "recipient_address must be a valid Ethereum address (0x followed by 40 hex characters)")
 	}
 
-	// Idempotency check 1: check the database for an existing ticket record.
-	existing, err := uc.ticketRepo.GetByEventAndUser(ctx, params.EventID, params.UserID)
+	return nil
+}
+
+// checkExistingTicket queries the database for an existing ticket by event and user,
+// then verifies the event exists before allowing a mint.
+// Returns (ticket, true, nil) when a ticket is already present,
+// (nil, false, nil) when not found and the event exists,
+// and (nil, false, err) on any error.
+func (uc *ticketUseCase) checkExistingTicket(ctx context.Context, eventID, userID string) (*entity.Ticket, bool, error) {
+	ticket, err := uc.ticketRepo.GetByEventAndUser(ctx, eventID, userID)
 	if err == nil {
-		uc.logger.Info(ctx, "ticket already exists in database, returning existing record",
-			slog.String("ticket_id", existing.ID),
-			slog.String("event_id", params.EventID),
-			slog.String("user_id", params.UserID),
-		)
-		return existing, nil
+		return ticket, true, nil
 	}
-
 	if !errors.Is(err, apperr.ErrNotFound) {
-		return nil, err
+		return nil, false, err
 	}
 
 	// Validate that the event exists before triggering an irreversible on-chain mint.
-	eventExists, err := uc.ticketRepo.EventExists(ctx, params.EventID)
+	eventExists, err := uc.ticketRepo.EventExists(ctx, eventID)
 	if err != nil {
-		return nil, apperr.Wrap(err, codes.Internal, "failed to check event existence")
+		return nil, false, apperr.Wrap(err, codes.Internal, "failed to check event existence")
 	}
 	if !eventExists {
-		return nil, apperr.New(codes.NotFound, fmt.Sprintf("event %s does not exist", params.EventID))
+		return nil, false, apperr.New(codes.NotFound, fmt.Sprintf("event %s does not exist", eventID))
 	}
 
+	return nil, false, nil
+}
+
+// mintOrReconcile generates a token ID, checks on-chain state, and either mints
+// a new token or reconciles an existing one.
+func (uc *ticketUseCase) mintOrReconcile(ctx context.Context, params *MintTicketParams) (string, uint64, error) {
 	// Generate a backend-controlled token ID from a UUIDv7.
 	// Using the high 64 bits (timestamp + random) gives a monotonically increasing,
 	// collision-resistant value without accepting client input.
 	tokenID, err := entity.GenerateTokenID()
 	if err != nil {
-		return nil, apperr.Wrap(err, codes.Internal, "failed to generate token ID")
+		return "", 0, apperr.Wrap(err, codes.Internal, "failed to generate token ID")
 	}
 
 	// Idempotency check 2: check on-chain whether tokenID is already minted.
 	alreadyMinted, err := uc.minter.IsTokenMinted(ctx, tokenID)
 	if err != nil {
-		return nil, apperr.Wrap(err, codes.Internal, "failed to check on-chain token status",
+		return "", 0, apperr.Wrap(err, codes.Internal, "failed to check on-chain token status",
 			slog.Uint64("token_id", tokenID),
 		)
 	}
-
-	var txHash string
 
 	if alreadyMinted {
 		// Token exists on-chain but no DB record — verify ownership before reconciling.
 		owner, err := uc.minter.OwnerOf(ctx, tokenID)
 		if err != nil {
-			return nil, apperr.Wrap(err, codes.Internal, "failed to fetch on-chain owner for reconciliation",
+			return "", 0, apperr.Wrap(err, codes.Internal, "failed to fetch on-chain owner for reconciliation",
 				slog.Uint64("token_id", tokenID),
 			)
 		}
 
 		if !strings.EqualFold(owner, params.RecipientAddress) {
-			return nil, apperr.New(codes.PermissionDenied,
+			return "", 0, apperr.New(codes.PermissionDenied,
 				fmt.Sprintf("token %d is already owned by %s, not %s", tokenID, owner, params.RecipientAddress),
 			)
 		}
@@ -159,25 +164,29 @@ func (uc *ticketUseCase) MintTicket(ctx context.Context, params *MintTicketParam
 			slog.String("event_id", params.EventID),
 			slog.String("user_id", params.UserID),
 		)
-		txHash = "0x0000000000000000000000000000000000000000000000000000000000000000"
-	} else {
-		// Submit the mint transaction. Retry logic is inside the minter implementation.
-		txHash, err = uc.minter.Mint(ctx, params.RecipientAddress, tokenID)
-		if err != nil {
-			return nil, apperr.Wrap(err, codes.Internal, "failed to mint ticket on-chain",
-				slog.String("event_id", params.EventID),
-				slog.String("user_id", params.UserID),
-				slog.Uint64("token_id", tokenID),
-			)
-		}
+		return "0x0000000000000000000000000000000000000000000000000000000000000000", tokenID, nil
+	}
 
-		uc.logger.Info(ctx, "ticket minted on-chain",
-			slog.String("tx_hash", txHash),
+	// Submit the mint transaction. Retry logic is inside the minter implementation.
+	txHash, err := uc.minter.Mint(ctx, params.RecipientAddress, tokenID)
+	if err != nil {
+		return "", 0, apperr.Wrap(err, codes.Internal, "failed to mint ticket on-chain",
+			slog.String("event_id", params.EventID),
+			slog.String("user_id", params.UserID),
 			slog.Uint64("token_id", tokenID),
 		)
 	}
 
-	// Store the minted ticket in the database.
+	uc.logger.Info(ctx, "ticket minted on-chain",
+		slog.String("tx_hash", txHash),
+		slog.Uint64("token_id", tokenID),
+	)
+	return txHash, tokenID, nil
+}
+
+// persistTicket inserts a minted ticket into the database.
+// On concurrent duplicate (AlreadyExists), fetches and returns the winning record.
+func (uc *ticketUseCase) persistTicket(ctx context.Context, params *MintTicketParams, tokenID uint64, txHash string) (*entity.Ticket, error) {
 	ticket, err := uc.ticketRepo.Create(ctx, &entity.NewTicket{
 		EventID: params.EventID,
 		UserID:  params.UserID,
@@ -189,7 +198,6 @@ func (uc *ticketUseCase) MintTicket(ctx context.Context, params *MintTicketParam
 		if errors.Is(err, apperr.ErrAlreadyExists) {
 			return uc.ticketRepo.GetByEventAndUser(ctx, params.EventID, params.UserID)
 		}
-
 		return nil, err
 	}
 
@@ -198,8 +206,35 @@ func (uc *ticketUseCase) MintTicket(ctx context.Context, params *MintTicketParam
 		slog.String("event_id", params.EventID),
 		slog.String("user_id", params.UserID),
 	)
-
 	return ticket, nil
+}
+
+// MintTicket mints a soulbound ticket, with idempotency via DB + on-chain checks.
+func (uc *ticketUseCase) MintTicket(ctx context.Context, params *MintTicketParams) (*entity.Ticket, error) {
+	if err := uc.validateMintParams(params); err != nil {
+		return nil, err
+	}
+
+	// Idempotency check 1: check the database for an existing ticket record.
+	existing, found, err := uc.checkExistingTicket(ctx, params.EventID, params.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		uc.logger.Info(ctx, "ticket already exists in database, returning existing record",
+			slog.String("ticket_id", existing.ID),
+			slog.String("event_id", params.EventID),
+			slog.String("user_id", params.UserID),
+		)
+		return existing, nil
+	}
+
+	txHash, tokenID, err := uc.mintOrReconcile(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return uc.persistTicket(ctx, params, tokenID, txHash)
 }
 
 // GetTicket retrieves a ticket by ID.


### PR DESCRIPTION
## Summary

- Decompose `MintTicket` (125-line method) into 4 focused private sub-methods: `validateMintParams`, `checkExistingTicket`, `mintOrReconcile`, `persistTicket`
- `MintTicket` is now a pure ~25-line orchestrator with no inline business logic
- Add `ticket_mint_uc_test.go` with 16 table-driven unit tests covering all sub-methods via `export_test.go` wrappers

## Test plan

- [ ] `TestTicketUseCase_ValidateMintParams` — 5 scenarios (nil params, empty fields, invalid address, valid)
- [ ] `TestTicketUseCase_CheckExistingTicket` — 4 scenarios (found, not found + event exists, not found + event missing, DB error)
- [ ] `TestTicketUseCase_MintOrReconcile` — 4 scenarios (fresh mint, reconcile correct owner, reconcile wrong owner, on-chain error)
- [ ] `TestTicketUseCase_PersistTicket` — 3 scenarios (success, concurrent duplicate, DB write error)
- [ ] All existing `MintTicket` integration-style tests pass unchanged
