### PR TITLE
fix(k8s): update Atlas devDB nodeSelector for GKE Standard Spot cluster

### DIFF
--- a/k8s/atlas/overlays/dev/kustomization.yaml
+++ b/k8s/atlas/overlays/dev/kustomization.yaml
@@ -15,20 +15,15 @@ patches:
       path: /spec/credentials/host
       value: "6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog"
     # dev-only: Atlas Operator generates devDB pods without nodeSelector by default.
-    # The dev cluster is spot-only (taint: cloud.google.com/compute-class=autopilot-spot:NoSchedule),
-    # so the pod would stay Pending indefinitely without this patch.
-    # Also right-sizes resources for the ephemeral schema-diffing workload (vs Autopilot default 500m/2Gi).
+    # The dev cluster is GKE Standard with Spot VMs (label: cloud.google.com/gke-spot=true),
+    # so the pod would be scheduled on on-demand nodes without this patch.
+    # Also right-sizes resources for the ephemeral schema-diffing workload.
     - op: add
       path: /spec/devDB
       value:
         spec:
           nodeSelector:
-            cloud.google.com/compute-class: autopilot-spot
-          tolerations:
-          - key: cloud.google.com/compute-class
-            operator: Equal
-            value: autopilot-spot
-            effect: NoSchedule
+            cloud.google.com/gke-spot: "true"
           containers:
           - name: postgres
             image: postgres:16


### PR DESCRIPTION
## Summary

- Update Atlas Operator devDB `nodeSelector` from `compute-class: autopilot-spot` to `gke-spot: "true"` to match the GKE Standard Spot cluster
- Remove the `autopilot-spot` toleration — GKE Standard Spot nodes do not use this taint

## Why

The dev cluster was migrated from GKE Autopilot to GKE Standard with Spot node pools (liverty-music/cloud-provisioning#180). Standard Spot VMs use `cloud.google.com/gke-spot: "true"` as the scheduling label, not `cloud.google.com/compute-class: autopilot-spot`. Without this fix, the Atlas devDB pod would be scheduled on the on-demand NAP node instead of the Spot pool.

## Test plan

- [ ] Verify `AtlasMigration` becomes `Ready=True` after ArgoCD syncs the change to dev
- [ ] Confirm devDB pod is scheduled on a `gke-spot=true` node
