### PR TITLE
fix(k8s): add devURL to Atlas migration dev overlay

### DIFF
--- a/k8s/atlas/overlays/dev/kustomization.yaml
+++ b/k8s/atlas/overlays/dev/kustomization.yaml
@@ -14,6 +14,11 @@ patches:
     - op: replace
       path: /spec/credentials/host
       value: "6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog"
+    # dev-only: devURL is required when devDB is provided.
+    # The operator replaces the hostname with the actual pod IP at runtime.
+    - op: add
+      path: /spec/devURL
+      value: "postgres://postgres:postgres@localhost:5432/dev"
     # dev-only: Atlas Operator generates devDB pods without nodeSelector by default.
     # The dev cluster is GKE Standard with Spot VMs (label: cloud.google.com/gke-spot=true),
     # so the pod would be scheduled on on-demand nodes without this patch.


### PR DESCRIPTION
## Summary

- Add `devURL` to the Atlas migration dev overlay — required when `devDB` is specified

## Why

Atlas Operator v0.7.x requires `devURL` to be explicitly set when a custom `devDB` is provided. Without it the operator enters a `GettingDevDB` error loop (`devURL is required when devDB is provided`) and migrations never run. The hostname in `devURL` is a placeholder — the operator replaces it with the actual pod IP at runtime.

## Test plan

- [ ] ArgoCD `backend-migrations` app syncs and becomes Healthy
- [ ] `AtlasMigration` `backend-migration` becomes `Ready=True`
- [ ] Atlas devDB pod is scheduled on a `gke-spot=true` node
