### PR TITLE
feat: add DB-first venue lookup to skip redundant Google Maps API calls

### DIFF
--- a/internal/entity/mocks/mock_VenueRepository.go
+++ b/internal/entity/mocks/mock_VenueRepository.go
@@ -128,6 +128,66 @@ func (_c *MockVenueRepository_Get_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// GetByListedName provides a mock function with given fields: ctx, listedVenueName, adminArea
+func (_m *MockVenueRepository) GetByListedName(ctx context.Context, listedVenueName string, adminArea *string) (*entity.Venue, error) {
+	ret := _m.Called(ctx, listedVenueName, adminArea)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetByListedName")
+	}
+
+	var r0 *entity.Venue
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *string) (*entity.Venue, error)); ok {
+		return rf(ctx, listedVenueName, adminArea)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *string) *entity.Venue); ok {
+		r0 = rf(ctx, listedVenueName, adminArea)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entity.Venue)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *string) error); ok {
+		r1 = rf(ctx, listedVenueName, adminArea)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockVenueRepository_GetByListedName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetByListedName'
+type MockVenueRepository_GetByListedName_Call struct {
+	*mock.Call
+}
+
+// GetByListedName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - listedVenueName string
+//   - adminArea *string
+func (_e *MockVenueRepository_Expecter) GetByListedName(ctx interface{}, listedVenueName interface{}, adminArea interface{}) *MockVenueRepository_GetByListedName_Call {
+	return &MockVenueRepository_GetByListedName_Call{Call: _e.mock.On("GetByListedName", ctx, listedVenueName, adminArea)}
+}
+
+func (_c *MockVenueRepository_GetByListedName_Call) Run(run func(ctx context.Context, listedVenueName string, adminArea *string)) *MockVenueRepository_GetByListedName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*string))
+	})
+	return _c
+}
+
+func (_c *MockVenueRepository_GetByListedName_Call) Return(_a0 *entity.Venue, _a1 error) *MockVenueRepository_GetByListedName_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockVenueRepository_GetByListedName_Call) RunAndReturn(run func(context.Context, string, *string) (*entity.Venue, error)) *MockVenueRepository_GetByListedName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetByPlaceID provides a mock function with given fields: ctx, placeID
 func (_m *MockVenueRepository) GetByPlaceID(ctx context.Context, placeID string) (*entity.Venue, error) {
 	ret := _m.Called(ctx, placeID)

--- a/internal/entity/venue.go
+++ b/internal/entity/venue.go
@@ -19,6 +19,10 @@ type Venue struct {
 	GooglePlaceID *string
 	// Coordinates is the WGS 84 geographic position of the venue.
 	Coordinates *Coordinates
+	// ListedVenueName is the raw scraped venue name as returned by Gemini.
+	// Used for DB-first lookup to avoid redundant Places API calls.
+	// Nil for venues created before this field was introduced.
+	ListedVenueName *string
 }
 
 // VenuePlace represents a resolved canonical venue from an external place search service.
@@ -65,4 +69,13 @@ type VenueRepository interface {
 	//
 	//  - NotFound: If no venue with that place ID exists.
 	GetByPlaceID(ctx context.Context, placeID string) (*Venue, error)
+
+	// GetByListedName retrieves a venue by its exact listed venue name and optional admin area.
+	// This is used for a DB-first lookup to avoid redundant Google Places API calls
+	// when the same venue has been resolved in a previous discovery batch.
+	//
+	// # Possible errors
+	//
+	//  - NotFound: If no venue with that listed name and admin area combination exists.
+	GetByListedName(ctx context.Context, listedVenueName string, adminArea *string) (*Venue, error)
 }

--- a/internal/infrastructure/database/rdb/schema/schema.sql
+++ b/internal/infrastructure/database/rdb/schema/schema.sql
@@ -99,6 +99,7 @@ CREATE TABLE IF NOT EXISTS venues (
     google_place_id TEXT,
     latitude DOUBLE PRECISION,
     longitude DOUBLE PRECISION,
+    listed_venue_name TEXT,
     CONSTRAINT chk_venues_name_not_empty CHECK (name <> ''),
     CONSTRAINT chk_venues_id_uuidv7 CHECK (substring(id::text, 15, 1) = '7')
 );
@@ -110,6 +111,7 @@ COMMENT ON COLUMN venues.admin_area IS 'ISO 3166-2 subdivision code (e.g., JP-13
 COMMENT ON COLUMN venues.google_place_id IS 'Google Maps Place ID for the canonical venue record';
 COMMENT ON COLUMN venues.latitude IS 'WGS 84 latitude of the venue from Google Places API';
 COMMENT ON COLUMN venues.longitude IS 'WGS 84 longitude of the venue from Google Places API';
+COMMENT ON COLUMN venues.listed_venue_name IS 'Raw scraped venue name as returned by Gemini; used for DB-first lookup to avoid redundant Places API calls';
 
 -- Events table
 CREATE TABLE IF NOT EXISTS events (

--- a/internal/infrastructure/database/rdb/venue_repo.go
+++ b/internal/infrastructure/database/rdb/venue_repo.go
@@ -14,18 +14,25 @@ type VenueRepository struct {
 
 const (
 	insertVenueQuery = `
-		INSERT INTO venues (id, name, admin_area, google_place_id, latitude, longitude)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO venues (id, name, admin_area, google_place_id, latitude, longitude, listed_venue_name)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 	`
 	getVenueQuery = `
-		SELECT id, name, admin_area, google_place_id, latitude, longitude
+		SELECT id, name, admin_area, google_place_id, latitude, longitude, listed_venue_name
 		FROM venues
 		WHERE id = $1
 	`
 	getVenueByPlaceIDQuery = `
-		SELECT id, name, admin_area, google_place_id, latitude, longitude
+		SELECT id, name, admin_area, google_place_id, latitude, longitude, listed_venue_name
 		FROM venues
 		WHERE google_place_id = $1
+	`
+	getVenueByListedNameQuery = `
+		SELECT id, name, admin_area, google_place_id, latitude, longitude, listed_venue_name
+		FROM venues
+		WHERE listed_venue_name = $1
+		  AND (admin_area = $2 OR (admin_area IS NULL AND $2 IS NULL))
+		LIMIT 1
 	`
 )
 
@@ -41,7 +48,7 @@ func (r *VenueRepository) Create(ctx context.Context, venue *entity.Venue) error
 		lat = &venue.Coordinates.Latitude
 		lng = &venue.Coordinates.Longitude
 	}
-	_, err := r.db.Pool.Exec(ctx, insertVenueQuery, venue.ID, venue.Name, venue.AdminArea, venue.GooglePlaceID, lat, lng)
+	_, err := r.db.Pool.Exec(ctx, insertVenueQuery, venue.ID, venue.Name, venue.AdminArea, venue.GooglePlaceID, lat, lng, venue.ListedVenueName)
 	if err != nil {
 		if IsUniqueViolation(err) {
 			r.db.logger.Warn(ctx, "duplicate venue",
@@ -67,7 +74,7 @@ func (r *VenueRepository) Get(ctx context.Context, id string) (*entity.Venue, er
 	var lat, lng *float64
 	err := r.db.Pool.QueryRow(ctx, getVenueQuery, id).Scan(
 		&v.ID, &v.Name, &v.AdminArea, &v.GooglePlaceID,
-		&lat, &lng,
+		&lat, &lng, &v.ListedVenueName,
 	)
 	if err != nil {
 		return nil, toAppErr(err, "failed to get venue", slog.String("venue_id", id))
@@ -84,10 +91,28 @@ func (r *VenueRepository) GetByPlaceID(ctx context.Context, placeID string) (*en
 	var lat, lng *float64
 	err := r.db.Pool.QueryRow(ctx, getVenueByPlaceIDQuery, placeID).Scan(
 		&v.ID, &v.Name, &v.AdminArea, &v.GooglePlaceID,
-		&lat, &lng,
+		&lat, &lng, &v.ListedVenueName,
 	)
 	if err != nil {
 		return nil, toAppErr(err, "failed to get venue by place ID", slog.String("place_id", placeID))
+	}
+	if lat != nil && lng != nil {
+		v.Coordinates = &entity.Coordinates{Latitude: *lat, Longitude: *lng}
+	}
+	return &v, nil
+}
+
+// GetByListedName retrieves a venue by the exact raw scraped name and optional admin area.
+// Returns NotFound when no match exists.
+func (r *VenueRepository) GetByListedName(ctx context.Context, listedVenueName string, adminArea *string) (*entity.Venue, error) {
+	var v entity.Venue
+	var lat, lng *float64
+	err := r.db.Pool.QueryRow(ctx, getVenueByListedNameQuery, listedVenueName, adminArea).Scan(
+		&v.ID, &v.Name, &v.AdminArea, &v.GooglePlaceID,
+		&lat, &lng, &v.ListedVenueName,
+	)
+	if err != nil {
+		return nil, toAppErr(err, "failed to get venue by listed name", slog.String("listed_venue_name", listedVenueName))
 	}
 	if lat != nil && lng != nil {
 		v.Coordinates = &entity.Coordinates{Latitude: *lat, Longitude: *lng}

--- a/internal/infrastructure/database/rdb/venue_repo_test.go
+++ b/internal/infrastructure/database/rdb/venue_repo_test.go
@@ -167,6 +167,81 @@ func TestVenueRepository_Get(t *testing.T) {
 	}
 }
 
+func TestVenueRepository_GetByListedName(t *testing.T) {
+	cleanDatabase(t)
+	repo := rdb.NewVenueRepository(testDB)
+	ctx := context.Background()
+
+	adminArea := "JP-13"
+	listedName := "武道館"
+
+	// Seed: venue with listed_venue_name and admin_area.
+	seededWithArea := &entity.Venue{
+		ID:              "018b2f19-e591-7d12-bf9e-f0e74f1b50a1",
+		Name:            "Nippon Budokan",
+		AdminArea:       &adminArea,
+		GooglePlaceID:   new("ChIJbudokan001"),
+		ListedVenueName: &listedName,
+	}
+	require.NoError(t, repo.Create(ctx, seededWithArea))
+
+	// Seed: venue with listed_venue_name and NULL admin_area.
+	listedNameNoArea := "Zepp DiverCity"
+	seededNoArea := &entity.Venue{
+		ID:              "018b2f19-e591-7d12-bf9e-f0e74f1b50a2",
+		Name:            "Zepp DiverCity Tokyo",
+		GooglePlaceID:   new("ChIJzepp001"),
+		ListedVenueName: &listedNameNoArea,
+	}
+	require.NoError(t, repo.Create(ctx, seededNoArea))
+
+	type args struct {
+		listedVenueName string
+		adminArea       *string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantID  string
+		wantErr error
+	}{
+		{
+			name:   "found by listed name and admin area",
+			args:   args{listedVenueName: "武道館", adminArea: &adminArea},
+			wantID: seededWithArea.ID,
+		},
+		{
+			name:   "found by listed name with NULL admin area",
+			args:   args{listedVenueName: "Zepp DiverCity", adminArea: nil},
+			wantID: seededNoArea.ID,
+		},
+		{
+			name:    "not found: unknown listed name",
+			args:    args{listedVenueName: "Unknown Hall", adminArea: nil},
+			wantErr: apperr.ErrNotFound,
+		},
+		{
+			name:    "not found: correct name but wrong admin area",
+			args:    args{listedVenueName: "武道館", adminArea: new("JP-27")},
+			wantErr: apperr.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := repo.GetByListedName(ctx, tt.args.listedVenueName, tt.args.adminArea)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantID, got.ID)
+		})
+	}
+}
+
 func TestVenueRepository_GetByPlaceID(t *testing.T) {
 	cleanDatabase(t)
 	repo := rdb.NewVenueRepository(testDB)

--- a/internal/usecase/concert_creation_uc.go
+++ b/internal/usecase/concert_creation_uc.go
@@ -82,7 +82,7 @@ func (uc *concertCreationUseCase) CreateFromDiscovered(ctx context.Context, data
 		}
 
 		if venue != nil {
-			newVenues[*venue.GooglePlaceID] = venue
+			newVenues[sc.ListedVenueName] = venue
 		}
 
 		id, err := uuid.NewV7()
@@ -121,13 +121,14 @@ func (uc *concertCreationUseCase) CreateFromDiscovered(ctx context.Context, data
 	return nil
 }
 
-// resolveVenue resolves a venue for a scraped concert via Google Places API.
+// resolveVenue resolves a venue for a scraped concert.
 //
 // Resolution strategy:
-//  1. Call Google Places API to get canonical place_id.
-//  2. Check batch-local cache by place_id.
-//  3. Look up existing venue by google_place_id in the database.
-//  4. If not found, create a new venue from the Places result.
+//  1. Check batch-local cache by listed_venue_name (avoids any I/O for same-batch duplicates).
+//  2. Look up existing venue by listed_venue_name in the database (avoids Places API for known venues).
+//  3. Call Google Places API to get canonical place_id.
+//  4. Look up existing venue by google_place_id in the database (dedup across different listed names).
+//  5. If not found, create a new venue from the Places result.
 //
 // Returns skip=true when Places API returns NotFound, signalling the caller
 // to skip the concert. Non-nil *Venue is returned only when a new venue was created.
@@ -137,11 +138,25 @@ func (uc *concertCreationUseCase) resolveVenue(
 	adminArea *string,
 	newVenues map[string]*entity.Venue,
 ) (string, *entity.Venue, bool, error) {
+	// Step 1: Check batch-local cache by listed_venue_name.
+	if v, ok := newVenues[name]; ok {
+		return v.ID, nil, false, nil
+	}
+
+	// Step 2: Look up existing venue by listed_venue_name in DB (skips Places API).
+	existing, err := uc.venueRepo.GetByListedName(ctx, name, adminArea)
+	if err == nil {
+		return existing.ID, nil, false, nil
+	}
+	if !errors.Is(err, apperr.ErrNotFound) {
+		return "", nil, false, fmt.Errorf("get venue by listed name: %w", err)
+	}
+
+	// Step 3: Call Google Places API.
 	area := ""
 	if adminArea != nil {
 		area = *adminArea
 	}
-
 	place, err := uc.placeSearcher.SearchPlace(ctx, name, area)
 	if err != nil {
 		if errors.Is(err, apperr.ErrNotFound) {
@@ -150,21 +165,16 @@ func (uc *concertCreationUseCase) resolveVenue(
 		return "", nil, false, fmt.Errorf("search place %q: %w", name, err)
 	}
 
-	// Check batch-local cache by place_id.
-	if v, ok := newVenues[place.ExternalID]; ok {
-		return v.ID, nil, false, nil
-	}
-
-	// Look up existing venue by google_place_id.
-	existing, err := uc.venueRepo.GetByPlaceID(ctx, place.ExternalID)
+	// Step 4: Look up existing venue by google_place_id (handles different listed names for same place).
+	existingByPlaceID, err := uc.venueRepo.GetByPlaceID(ctx, place.ExternalID)
 	if err == nil {
-		return existing.ID, nil, false, nil
+		return existingByPlaceID.ID, nil, false, nil
 	}
 	if !errors.Is(err, apperr.ErrNotFound) {
 		return "", nil, false, fmt.Errorf("get venue by place ID: %w", err)
 	}
 
-	// Create new venue from Places API result.
+	// Step 5: Create new venue from Places API result.
 	id, venue, err := uc.createVenueFromPlace(ctx, name, adminArea, place)
 	if err != nil {
 		return "", nil, false, err
@@ -185,11 +195,12 @@ func (uc *concertCreationUseCase) createVenueFromPlace(
 	}
 
 	venue := &entity.Venue{
-		ID:            id.String(),
-		Name:          place.Name,
-		AdminArea:     adminArea,
-		GooglePlaceID: &place.ExternalID,
-		Coordinates:   place.Coordinates,
+		ID:              id.String(),
+		Name:            place.Name,
+		AdminArea:       adminArea,
+		GooglePlaceID:   &place.ExternalID,
+		Coordinates:     place.Coordinates,
+		ListedVenueName: &listedName,
 	}
 
 	if err := uc.venueRepo.Create(ctx, venue); err != nil {

--- a/internal/usecase/concert_creation_uc.go
+++ b/internal/usecase/concert_creation_uc.go
@@ -82,7 +82,7 @@ func (uc *concertCreationUseCase) CreateFromDiscovered(ctx context.Context, data
 		}
 
 		if venue != nil {
-			newVenues[sc.ListedVenueName] = venue
+			newVenues[venueKey(sc.ListedVenueName, sc.AdminArea)] = venue
 		}
 
 		id, err := uuid.NewV7()
@@ -138,8 +138,8 @@ func (uc *concertCreationUseCase) resolveVenue(
 	adminArea *string,
 	newVenues map[string]*entity.Venue,
 ) (string, *entity.Venue, bool, error) {
-	// Step 1: Check batch-local cache by listed_venue_name.
-	if v, ok := newVenues[name]; ok {
+	// Step 1: Check batch-local cache by listed_venue_name + admin_area.
+	if v, ok := newVenues[venueKey(name, adminArea)]; ok {
 		return v.ID, nil, false, nil
 	}
 
@@ -220,4 +220,14 @@ func (uc *concertCreationUseCase) createVenueFromPlace(
 // publishEvent publishes data as a CloudEvent to the given subject.
 func (uc *concertCreationUseCase) publishEvent(ctx context.Context, subject string, data any) error {
 	return uc.publisher.PublishEvent(ctx, subject, data)
+}
+
+// venueKey returns a composite cache key for the batch-local venue map.
+// It combines listed_venue_name and admin_area to prevent collision between
+// venues sharing the same name in different regions (e.g. "Zepp" in JP-13 vs JP-27).
+func venueKey(name string, adminArea *string) string {
+	if adminArea == nil {
+		return name + "|"
+	}
+	return name + "|" + *adminArea
 }

--- a/internal/usecase/concert_creation_uc_test.go
+++ b/internal/usecase/concert_creation_uc_test.go
@@ -52,6 +52,21 @@ func (r *fakeVenueRepo) GetByPlaceID(_ context.Context, placeID string) (*entity
 	return nil, apperr.New(codes.NotFound, "venue not found")
 }
 
+func (r *fakeVenueRepo) GetByListedName(_ context.Context, listedVenueName string, adminArea *string) (*entity.Venue, error) {
+	for _, v := range r.venues {
+		if v.ListedVenueName == nil || *v.ListedVenueName != listedVenueName {
+			continue
+		}
+		if adminArea == nil && v.AdminArea == nil {
+			return v, nil
+		}
+		if adminArea != nil && v.AdminArea != nil && *adminArea == *v.AdminArea {
+			return v, nil
+		}
+	}
+	return nil, apperr.New(codes.NotFound, "venue not found")
+}
+
 type fakeConcertRepo struct {
 	created []*entity.Concert
 }
@@ -296,6 +311,119 @@ func TestConcertCreationUseCase_CreateFromDiscovered(t *testing.T) {
 
 		assert.Empty(t, venueRepo.created)
 		assert.Empty(t, concertRepo.created)
+	})
+}
+
+func TestConcertCreationUseCase_ResolveVenue_DBFirstLookup(t *testing.T) {
+	t.Parallel()
+
+	localDate := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	t.Run("DB hit by listed name: Places API not called", func(t *testing.T) {
+		t.Parallel()
+		venueRepo := newFakeVenueRepo()
+		listedName := "武道館"
+		placeID := "place-budokan"
+		// Pre-seed a venue with listed_venue_name set.
+		venueRepo.venues["Nippon Budokan"] = &entity.Venue{
+			ID:              "budokan-id",
+			Name:            "Nippon Budokan",
+			GooglePlaceID:   &placeID,
+			ListedVenueName: &listedName,
+		}
+		concertRepo := &fakeConcertRepo{}
+		pub := newGoChannelPub(t)
+		// placeSearcher has no entry for 武道館; if called it returns NotFound → concert would be skipped.
+		ps := newStubPlaceSearcher()
+		uc := usecase.NewConcertCreationUseCase(venueRepo, concertRepo, ps, messaging.NewEventPublisher(pub), newTestLogger(t))
+
+		data := entity.ConcertDiscoveredData{
+			ArtistID:   "artist-db-hit",
+			ArtistName: "DB Hit Artist",
+			Concerts: entity.ScrapedConcerts{
+				{
+					Title:           "Budokan Show",
+					ListedVenueName: "武道館",
+					LocalDate:       localDate,
+					SourceURL:       "https://example.com/budokan",
+				},
+			},
+		}
+
+		err := uc.CreateFromDiscovered(context.Background(), data)
+		require.NoError(t, err)
+
+		// Concert created using the DB-found venue, no new venue created.
+		assert.Empty(t, venueRepo.created)
+		require.Len(t, concertRepo.created, 1)
+		assert.Equal(t, "budokan-id", concertRepo.created[0].VenueID)
+	})
+
+	t.Run("DB miss by listed name: Places API called, new venue created", func(t *testing.T) {
+		t.Parallel()
+		venueRepo := newFakeVenueRepo()
+		concertRepo := &fakeConcertRepo{}
+		pub := newGoChannelPub(t)
+		ps := newStubPlaceSearcher()
+		ps.places["Zepp Tokyo"] = &entity.VenuePlace{ExternalID: "place-zepp-tokyo", Name: "Zepp DiverCity Tokyo"}
+		uc := usecase.NewConcertCreationUseCase(venueRepo, concertRepo, ps, messaging.NewEventPublisher(pub), newTestLogger(t))
+
+		data := entity.ConcertDiscoveredData{
+			ArtistID:   "artist-api-hit",
+			ArtistName: "API Hit Artist",
+			Concerts: entity.ScrapedConcerts{
+				{
+					Title:           "Zepp Show",
+					ListedVenueName: "Zepp Tokyo",
+					LocalDate:       localDate,
+					SourceURL:       "https://example.com/zepp",
+				},
+			},
+		}
+
+		err := uc.CreateFromDiscovered(context.Background(), data)
+		require.NoError(t, err)
+
+		require.Len(t, venueRepo.created, 1)
+		assert.Equal(t, "Zepp DiverCity Tokyo", venueRepo.created[0].Name)
+		require.Len(t, concertRepo.created, 1)
+	})
+
+	t.Run("batch-local cache hit: same listed name deduped within batch without DB or API", func(t *testing.T) {
+		t.Parallel()
+		venueRepo := newFakeVenueRepo()
+		concertRepo := &fakeConcertRepo{}
+		pub := newGoChannelPub(t)
+		ps := newStubPlaceSearcher()
+		ps.places["Zepp Osaka"] = &entity.VenuePlace{ExternalID: "place-zepp-osaka", Name: "Zepp Namba Osaka"}
+		uc := usecase.NewConcertCreationUseCase(venueRepo, concertRepo, ps, messaging.NewEventPublisher(pub), newTestLogger(t))
+
+		data := entity.ConcertDiscoveredData{
+			ArtistID:   "artist-batch",
+			ArtistName: "Batch Artist",
+			Concerts: entity.ScrapedConcerts{
+				{
+					Title:           "Night 1",
+					ListedVenueName: "Zepp Osaka",
+					LocalDate:       localDate,
+					SourceURL:       "https://example.com/n1",
+				},
+				{
+					Title:           "Night 2",
+					ListedVenueName: "Zepp Osaka",
+					LocalDate:       localDate.AddDate(0, 0, 1),
+					SourceURL:       "https://example.com/n2",
+				},
+			},
+		}
+
+		err := uc.CreateFromDiscovered(context.Background(), data)
+		require.NoError(t, err)
+
+		// Only one venue created for two concerts with the same listed name.
+		assert.Len(t, venueRepo.created, 1)
+		require.Len(t, concertRepo.created, 2)
+		assert.Equal(t, concertRepo.created[0].VenueID, concertRepo.created[1].VenueID)
 	})
 }
 

--- a/k8s/atlas/base/kustomization.yaml
+++ b/k8s/atlas/base/kustomization.yaml
@@ -64,3 +64,4 @@ configMapGenerator:
   - migrations/20260318120000_create_ticket_journeys.sql
   - migrations/20260319120000_create_ticket_emails.sql
   - migrations/20260324120000_consolidate_ticket_email_status.sql
+  - migrations/20260406120000_add_venue_listed_name_index.sql

--- a/k8s/atlas/base/migrations/20260406120000_add_venue_listed_name_index.sql
+++ b/k8s/atlas/base/migrations/20260406120000_add_venue_listed_name_index.sql
@@ -1,0 +1,10 @@
+-- Add listed_venue_name column to venues to store the raw scraped name alongside
+-- the canonical Google Places name. This enables a DB-first lookup in the concert
+-- creation pipeline, avoiding redundant Places API calls for known venues.
+ALTER TABLE venues ADD COLUMN listed_venue_name TEXT;
+
+-- Unique index on (listed_venue_name, admin_area) for efficient lookup.
+-- NULLS NOT DISTINCT ensures two NULLs are treated as equal (same unknown venue).
+CREATE UNIQUE INDEX idx_venues_listed_name_admin_area
+    ON venues (listed_venue_name, admin_area) NULLS NOT DISTINCT
+    WHERE listed_venue_name IS NOT NULL;

--- a/k8s/atlas/base/migrations/atlas.sum
+++ b/k8s/atlas/base/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:CO9VSNCEM//4s5ubOoO7GZh4PstlMuWT9uz4RqFGOLc=
+h1:P3U7EvBOMU9e+5aycwCWpbEpEG+xV8Kgb4RefxZsDoY=
 20250726000000_bootstrap_app_schema.sql h1:nKAFSMmbY+9pdhajenyx25jK6t5SAHc5x/JpNt9EgFM=
 20250726081442_initial_schema.sql h1:cWOx1AMHpgE784lJBtFmEj1oXRBkeqv56bKw1XV8ThI=
 20250726101741_add_foreign_key_to_posts.sql h1:Yq6yocwX7/UQHaMneA16MoHzImLamXDe7PvGYiGWudw=
@@ -50,3 +50,4 @@ h1:CO9VSNCEM//4s5ubOoO7GZh4PstlMuWT9uz4RqFGOLc=
 20260318120000_create_ticket_journeys.sql h1:EwRQNfsh2TMRds8wXqkKLCXewOa2RvlYloUHApLduA8=
 20260319120000_create_ticket_emails.sql h1:6lgvs8T5Gtr+Sjo5kjVZXJ33uwvAkiDRKZdjXMbUttg=
 20260324120000_consolidate_ticket_email_status.sql h1:BL0f7xaE4MXzF6H29RJ25sAkcr2pS3g3edRlv7zEy50=
+20260406120000_add_venue_listed_name_index.sql h1:Ufe7vfOM9zLLK9hixGFJrgCr+u7FNeId7s1I9hv2wNU=


### PR DESCRIPTION
## Summary

- Add `listed_venue_name` column to `venues` table (migration + schema) to store the raw scraped name alongside the canonical Google Places name.
- Implement `VenueRepository.GetByListedName` for exact-match DB lookup on `(listed_venue_name, admin_area)`.
- Update `ConcertCreationUseCase.resolveVenue()` to perform a DB-first lookup before calling the Google Places API, eliminating pay-per-request charges for any venue resolved in a previous discovery batch.

## Motivation

`resolveVenue()` previously called the Google Places Text Search API ($32 / 1000 requests) for every scraped concert, even when the same venue had already been resolved and persisted. The batch-local `newVenues` map only deduplicated within a single invocation. This change adds a persistent DB layer that short-circuits the API call for all known venues.

## Resolution order after this change

1. Batch-local cache (keyed by `listed_venue_name`) — zero I/O
2. `VenueRepository.GetByListedName` — DB only, no API call
3. Google Places API (pay-per-request)
4. `VenueRepository.GetByPlaceID` — handles same physical venue with different scraped names
5. Create new venue (stores `listed_venue_name` for future lookups)

## Test plan

- [ ] `TestVenueRepository_GetByListedName`: found, not found, NULL admin_area cases (integration)
- [ ] `TestConcertCreationUseCase_ResolveVenue_DBFirstLookup`: DB hit skips API, DB miss hits API, batch-local cache dedup (unit)
- [ ] Existing `TestConcertCreationUseCase_CreateFromDiscovered` suite still green
- [ ] `make test` passes end-to-end
