### PR TITLE
fix(messaging): switch to SyncAck and DeliverNew for JetStream subscriber

### DIFF
--- a/internal/infrastructure/messaging/subscriber.go
+++ b/internal/infrastructure/messaging/subscriber.go
@@ -40,10 +40,9 @@ func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goCh
 			DurableCalculator: func(_, topic string) string {
 				return strings.ReplaceAll(topic, ".", "_")
 			},
-			AckAsync: true,
 			SubscribeOptions: []nats.SubOpt{
 				nats.AckExplicit(),
-				nats.DeliverAll(),
+				nats.DeliverNew(),
 			},
 		},
 	}, wmLogger)


### PR DESCRIPTION
## Summary

Fix an infinite NATS JetStream message redelivery loop that has been causing Places API overcalls since 2026-04-03 (¥323,198 confirmed charge).

Two bugs in `internal/infrastructure/messaging/subscriber.go`:

1. **Remove `AckAsync: true`** — Switches from fire-and-forget `m.Ack()` to synchronous `m.AckSync()`. When KEDA deactivated both consumer pods simultaneously, Acks in the network buffer were lost before `conn.Drain()` completed. NATS kept the messages as unacknowledged, JetStream lag stayed > 0, and KEDA re-activated pods 30 seconds later — confirmed by production GKE event logs showing a continuous deactivate→reactivate cycle.

2. **Replace `DeliverAll()` with `DeliverNew()`** — After the GKE cluster migration on 2026-04-01, NATS started with a fresh PVC (no consumer history). When the durable consumer `CONCERT_discovered` was recreated on 2026-04-03, `DeliverAll` delivered all historical `concert.created` events from the stream's beginning. Each event triggered a Places API call. `DeliverNew` limits delivery to messages published after consumer creation, preventing redelivery of historical events on any future state-loss event.

## Changes

- `internal/infrastructure/messaging/subscriber.go`: remove `AckAsync: true`, change `nats.DeliverAll()` → `nats.DeliverNew()`

close: #275
