### PR TITLE
docs: document dev DB access via Cloud SQL Auth Proxy port-forward

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,4 +94,37 @@ make check             # Full pre-commit check (lint + test)
 
 Integration tests under `internal/infrastructure/database/rdb/` require a local PostgreSQL instance. `make test` handles DB startup automatically via `docker compose up -d postgres --wait`.
 
+### Dev DB Access (Cloud SQL via port-forward)
+
+To connect directly to the **dev Cloud SQL instance** (e.g., for ad-hoc queries, schema inspection, or data debugging), use the Cloud SQL Auth Proxy Pod deployed in the dev GKE cluster.
+
+> **This is for the dev Cloud SQL instance only.** For integration tests and local development, use the Docker Compose PostgreSQL instance (`docker compose up -d postgres`).
+
+**Step 1 — Forward the proxy port:**
+
+```bash
+kubectl port-forward deployment/cloud-sql-proxy 5432:5432 -n backend
+```
+
+Keep this terminal open. The tunnel closes when you exit.
+
+**Step 2 — Connect with psql:**
+
+```bash
+psql "host=localhost port=5432 user=backend-app@liverty-music-dev.iam dbname=liverty-music sslmode=disable options='-c search_path=app'"
+```
+
+No password is required — authentication is handled by IAM via the proxy.
+
+**Connection parameters:**
+
+| Parameter | Value |
+|-----------|-------|
+| Host | `localhost` |
+| Port | `5432` |
+| User | `backend-app@liverty-music-dev.iam` |
+| Database | `liverty-music` |
+| Schema | `app` |
+| SSL Mode | `disable` (proxy handles encryption) |
+
 </agent-rules>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,35 +96,8 @@ Integration tests under `internal/infrastructure/database/rdb/` require a local 
 
 ### Dev DB Access (Cloud SQL via port-forward)
 
-To connect directly to the **dev Cloud SQL instance** (e.g., for ad-hoc queries, schema inspection, or data debugging), use the Cloud SQL Auth Proxy Pod deployed in the dev GKE cluster.
+**Dev Cloud SQL only** — for integration tests use `docker compose up -d postgres` instead.
 
-> **This is for the dev Cloud SQL instance only.** For integration tests and local development, use the Docker Compose PostgreSQL instance (`docker compose up -d postgres`).
-
-**Step 1 — Forward the proxy port:**
-
-```bash
-kubectl port-forward deployment/cloud-sql-proxy 5432:5432 -n backend
-```
-
-Keep this terminal open. The tunnel closes when you exit.
-
-**Step 2 — Connect with psql:**
-
-```bash
-psql "host=localhost port=5432 user=backend-app@liverty-music-dev.iam dbname=liverty-music sslmode=disable options='-c search_path=app'"
-```
-
-No password is required — authentication is handled by IAM via the proxy.
-
-**Connection parameters:**
-
-| Parameter | Value |
-|-----------|-------|
-| Host | `localhost` |
-| Port | `5432` |
-| User | `backend-app@liverty-music-dev.iam` |
-| Database | `liverty-music` |
-| Schema | `app` |
-| SSL Mode | `disable` (proxy handles encryption) |
+See [docs/dev-db-access.md](docs/dev-db-access.md) for port-forward command and psql connection string.
 
 </agent-rules>

--- a/docs/dev-db-access.md
+++ b/docs/dev-db-access.md
@@ -1,0 +1,32 @@
+# Dev DB Access (Cloud SQL via port-forward)
+
+To connect directly to the **dev Cloud SQL instance** (e.g., for ad-hoc queries, schema inspection, or data debugging), use the Cloud SQL Auth Proxy Pod deployed in the dev GKE cluster.
+
+> **This is for the dev Cloud SQL instance only.** For integration tests and local development, use the Docker Compose PostgreSQL instance (`docker compose up -d postgres`).
+
+**Step 1 — Forward the proxy port:**
+
+```bash
+kubectl port-forward deployment/cloud-sql-proxy 5432:5432 -n backend
+```
+
+Keep this terminal open. The tunnel closes when you exit.
+
+**Step 2 — Connect with psql:**
+
+```bash
+psql "host=localhost port=5432 user=backend-app@liverty-music-dev.iam dbname=liverty-music sslmode=disable options='-c search_path=app'"
+```
+
+No password is required — authentication is handled by IAM via the proxy.
+
+**Connection parameters:**
+
+| Parameter | Value |
+|-----------|-------|
+| Host | `localhost` |
+| Port | `5432` |
+| User | `backend-app@liverty-music-dev.iam` |
+| Database | `liverty-music` |
+| Schema | `app` |
+| SSL Mode | `disable` (proxy handles encryption) |


### PR DESCRIPTION
## Summary

- Add "Dev DB Access" section to `AGENTS.md` documenting how to connect to the dev Cloud SQL instance via kubectl port-forward

## Motivation

The dev Cloud SQL instance is PSC-only. After the companion cloud-provisioning PR (#194) deploys the Cloud SQL Auth Proxy pod, developers and Claude Code agents need to know the exact commands to:

1. Set up port-forwarding
2. Connect with psql

Without this documentation, agents have no context for DB connection parameters and would need external lookup.

## Connection procedure (documented in AGENTS.md)

```
kubectl port-forward deployment/cloud-sql-proxy 5432:5432 -n backend
psql "host=localhost port=5432 user=backend-app@liverty-music-dev.iam dbname=liverty-music sslmode=disable options='-c search_path=app'"
```

## Test plan

- [ ] Confirm section renders correctly in AGENTS.md
- [ ] Confirm port-forward command works after cloud-provisioning#194 is merged and synced
