### PR TITLE
feat(observability): capture HTTP error response body in outbound clients

### DIFF
--- a/docs/debug-rpc-notify-new-concerts.md
+++ b/docs/debug-rpc-notify-new-concerts.md
@@ -44,6 +44,37 @@ grpcurl \
   liverty_music.rpc.push_notification.v1.PushNotificationService/NotifyNewConcerts
 ```
 
+## How to verify delivery succeeded
+
+An HTTP 200 RPC response means **the delivery pipeline ran** — it does NOT mean notifications were delivered. Per-subscription delivery results are only visible in server-app logs and metrics.
+
+### Step 1: Tail server-app logs in parallel
+
+```bash
+kubectl logs -n backend -l app=server -f --tail=0
+```
+
+### Step 2: Call the RPC (see example above)
+
+### Step 3: Check per-subscription log lines
+
+For each push subscription, the use case emits exactly one of:
+
+| Log pattern | Meaning |
+|---|---|
+| `RecordPushSend` with `"success"` | Push delivered to the push service (FCM/Mozilla). Does not guarantee device delivery, but the push service accepted it. |
+| `RecordPushSend` with `"gone"` | Subscription endpoint returned 410 Gone. The stale row was auto-deleted from DB. Re-subscribe from the browser. |
+| `"failed to send push notification"` with `responseBody` attr | Push service rejected the request. The `responseBody` field contains the upstream diagnostic message (e.g., "Your client does not have permission" = PGA blocking; see Troubleshooting). |
+
+### Troubleshooting
+
+| responseBody content | Root cause | Fix |
+|---|---|---|
+| "Your client does not have permission to get URL ... from this server. That's all we know." | GCP Private Google Access restricted VIP is blocking a non-VPC-SC service (e.g., FCM) | Switch PGA DNS zone from `restricted.googleapis.com` to `private.googleapis.com` in cloud-provisioning |
+| "push subscription has unsubscribed or expired." | Browser unsubscribed or FCM token expired | Expected for stale subscriptions; 410 handler auto-cleans |
+| Empty body with 401 status | VAPID JWT rejected by push service | Verify VAPID key pair consistency (Secret Manager private ↔ ConfigMap public ↔ frontend .env public) |
+| Timeout / connection refused | Pod cannot reach `fcm.googleapis.com` at all | Check DNS resolution + Cloud NAT egress + network policies |
+
 ## Related
 
 - Spec: `openspec/specs/push-notification-service/spec.md` (Requirement: NotifyNewConcerts debug RPC for deterministic invocation).

--- a/internal/infrastructure/music/fanarttv/logo_fetcher.go
+++ b/internal/infrastructure/music/fanarttv/logo_fetcher.go
@@ -6,11 +6,13 @@ import (
 	"image"
 	_ "image/png" // Register PNG decoder.
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/liverty-music/backend/internal/entity"
+	"github.com/liverty-music/backend/pkg/httpx"
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/pannpers/go-apperr/apperr/codes"
 )
@@ -36,6 +38,10 @@ func NewLogoFetcher(httpClient *http.Client) *LogoFetcher {
 	return &LogoFetcher{httpClient: httpClient}
 }
 
+// validateLogoURLFn is the URL validator used by FetchImage. It is a package-level
+// variable so that tests can substitute a no-op validator via export_test.go.
+var validateLogoURLFn = validateLogoURL
+
 // FetchImage downloads the image at the given URL and decodes it as PNG.
 // Returns nil without error when the server returns HTTP 404.
 //
@@ -43,7 +49,7 @@ func NewLogoFetcher(httpClient *http.Client) *LogoFetcher {
 // SSRF, and the response body is capped at maxLogoBytes to guard against
 // decompression bombs.
 func (f *LogoFetcher) FetchImage(ctx context.Context, logoURL string) (image.Image, error) {
-	if err := validateLogoURL(logoURL); err != nil {
+	if err := validateLogoURLFn(logoURL); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +68,11 @@ func (f *LogoFetcher) FetchImage(ctx context.Context, logoURL string) (image.Ima
 		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, apperr.New(codes.Unavailable, fmt.Sprintf("logo fetch returned HTTP %d", resp.StatusCode))
+		var attrs []slog.Attr
+		if body := httpx.CaptureResponseBody(resp.Body); body != "" {
+			attrs = append(attrs, slog.String("responseBody", body))
+		}
+		return nil, apperr.New(codes.Unavailable, fmt.Sprintf("logo fetch returned HTTP %d", resp.StatusCode), attrs...)
 	}
 
 	img, _, err := image.Decode(io.LimitReader(resp.Body, maxLogoBytes))

--- a/internal/infrastructure/music/fanarttv/logo_fetcher_test.go
+++ b/internal/infrastructure/music/fanarttv/logo_fetcher_test.go
@@ -19,17 +19,33 @@ func TestLogoFetcher_FetchImage(t *testing.T) {
 		body       string
 		wantNil    bool
 		wantErr    error
+		// check performs additional assertions beyond wantErr matching.
+		check func(t *testing.T, err error)
 	}{
 		{
-			name:       "not found - HTTP 404 returns nil image without error",
+			name:       "return nil image without error when server returns 404",
 			statusCode: http.StatusNotFound,
 			wantNil:    true,
 			wantErr:    nil,
 		},
 		{
-			name:       "error - HTTP 500 returns unavailable error",
+			name:       "return ErrUnavailable when server returns 500",
 			statusCode: http.StatusInternalServerError,
 			wantErr:    apperr.ErrUnavailable,
+		},
+		{
+			name:       "return ErrUnavailable with responseBody attr when server returns 403 with body",
+			statusCode: http.StatusForbidden,
+			body:       "Access denied by CDN policy",
+			wantErr:    apperr.ErrUnavailable,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				var appErr *apperr.AppErr
+				if assert.ErrorAs(t, err, &appErr) {
+					assert.Contains(t, appErr.Msg, "403", "error message should include status code")
+					assert.NotEmpty(t, appErr.Attrs, "responseBody attr should be captured for non-200/non-404 responses with body")
+				}
+			},
 		},
 	}
 
@@ -67,12 +83,15 @@ func TestLogoFetcher_FetchImage(t *testing.T) {
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
 				assert.Nil(t, img)
-				return
+			} else {
+				require.NoError(t, err)
+				if tt.wantNil {
+					assert.Nil(t, img)
+				}
 			}
 
-			require.NoError(t, err)
-			if tt.wantNil {
-				assert.Nil(t, img)
+			if tt.check != nil {
+				tt.check(t, err)
 			}
 		})
 	}

--- a/internal/infrastructure/webpush/sender.go
+++ b/internal/infrastructure/webpush/sender.go
@@ -4,11 +4,13 @@ package webpush
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
 	wpush "github.com/SherClockHolmes/webpush-go"
 	"github.com/liverty-music/backend/internal/entity"
+	"github.com/liverty-music/backend/pkg/httpx"
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/pannpers/go-apperr/apperr/codes"
 )
@@ -56,7 +58,11 @@ func (s *Sender) Send(_ context.Context, payload []byte, sub *entity.PushSubscri
 			return apperr.New(codes.NotFound, "push subscription is no longer valid")
 		}
 		if resp.StatusCode >= http.StatusBadRequest {
-			return apperr.New(codes.Internal, fmt.Sprintf("push service returned status %d", resp.StatusCode))
+			var attrs []slog.Attr
+			if body := httpx.CaptureResponseBody(resp.Body); body != "" {
+				attrs = append(attrs, slog.String("responseBody", body))
+			}
+			return apperr.New(codes.Internal, fmt.Sprintf("push service returned status %d", resp.StatusCode), attrs...)
 		}
 	}
 

--- a/internal/infrastructure/webpush/sender_test.go
+++ b/internal/infrastructure/webpush/sender_test.go
@@ -27,11 +27,11 @@ func testSubscription(t *testing.T, endpointURL string) *entity.PushSubscription
 	}
 }
 
-// TestSender_Send tests the Send method of the webpush Sender across the three
+// TestSender_Send tests the Send method of the webpush Sender across the
 // relevant HTTP response paths.
 func TestSender_Send(t *testing.T) {
 	// VAPID test keys: the private key is the same short value used by
-	// the upstream webpush-go test suite.  It decodes to a valid P-256
+	// the upstream webpush-go test suite. It decodes to a valid P-256
 	// scalar so VAPID JWT signing succeeds without needing real keys.
 	const (
 		testVAPIDPublic  = "testPublic"
@@ -40,24 +40,56 @@ func TestSender_Send(t *testing.T) {
 	)
 
 	tests := []struct {
-		name       string
-		statusCode int
-		wantErr    error
+		name         string
+		statusCode   int
+		responseBody string
+		wantErr      error
+		// check performs additional assertions beyond wantErr matching.
+		check func(t *testing.T, err error)
 	}{
 		{
-			name:       "success - server returns 201 Created",
+			name:       "return nil when server returns 201 Created",
 			statusCode: http.StatusCreated,
 			wantErr:    nil,
 		},
 		{
-			name:       "not found - server returns 410 Gone",
+			name:       "return ErrNotFound when server returns 410 Gone",
 			statusCode: http.StatusGone,
 			wantErr:    apperr.ErrNotFound,
 		},
 		{
-			name:       "internal error - server returns 500",
+			name:       "return ErrInternal when server returns 500",
 			statusCode: http.StatusInternalServerError,
 			wantErr:    apperr.ErrInternal,
+		},
+		{
+			name:         "return ErrInternal with responseBody attr when server returns 400 with body",
+			statusCode:   http.StatusBadRequest,
+			responseBody: "invalid subscription endpoint",
+			wantErr:      apperr.ErrInternal,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				var appErr *apperr.AppErr
+				if assert.ErrorAs(t, err, &appErr) {
+					assert.Contains(t, appErr.Msg, "400", "error message should include status code")
+					assert.NotEmpty(t, appErr.Attrs, "responseBody attr should be present for 4xx with body")
+				}
+			},
+		},
+		{
+			name: "return ErrNotFound without body attrs when server returns 410 Gone",
+			// Body is intentionally non-empty to confirm the 410 path returns early
+			// before body capture, so Attrs must remain empty.
+			statusCode:   http.StatusGone,
+			responseBody: "gone",
+			wantErr:      apperr.ErrNotFound,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				var appErr *apperr.AppErr
+				if assert.ErrorAs(t, err, &appErr) {
+					assert.Empty(t, appErr.Attrs, "410 Gone path should not capture response body")
+				}
+			},
 		},
 	}
 
@@ -65,6 +97,9 @@ func TestSender_Send(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.statusCode)
+				if tt.responseBody != "" {
+					_, _ = w.Write([]byte(tt.responseBody))
+				}
 			}))
 			defer server.Close()
 
@@ -75,10 +110,13 @@ func TestSender_Send(t *testing.T) {
 
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
-				return
+			} else {
+				assert.NoError(t, err)
 			}
 
-			assert.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, err)
+			}
 		})
 	}
 }

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/liverty-music/backend/pkg/httpx"
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/pannpers/go-apperr/apperr/codes"
 )
@@ -59,6 +60,12 @@ func FromHTTP(err error, resp *http.Response, msg string, attrs ...slog.Attr) er
 			code = codes.Unavailable
 		} else if resp.StatusCode >= 400 {
 			code = codes.InvalidArgument
+		}
+	}
+
+	if resp.StatusCode >= 400 && resp.Body != nil {
+		if body := httpx.CaptureResponseBody(resp.Body); body != "" {
+			attrs = append(attrs, slog.String("responseBody", body))
 		}
 	}
 

--- a/pkg/httpx/body.go
+++ b/pkg/httpx/body.go
@@ -44,19 +44,21 @@ func CaptureResponseBody(r io.Reader) string {
 	return sanitized
 }
 
-// sanitizeBody replaces non-printable bytes (below 0x20 except \t, \n, \r and
-// above 0x7E) with the Unicode replacement character U+FFFD.
+// sanitizeBody replaces control characters and invalid UTF-8 with U+FFFD while
+// preserving valid multi-byte Unicode (e.g., Japanese, accented Latin).
+// Iterating via range string(b) auto-decodes UTF-8 runes; invalid byte
+// sequences become U+FFFD during decoding.
 func sanitizeBody(b []byte) string {
 	var out bytes.Buffer
 	out.Grow(len(b))
-	for _, c := range b {
+	for _, r := range string(b) {
 		switch {
-		case c == '\t' || c == '\n' || c == '\r':
-			out.WriteByte(c)
-		case c < 0x20 || c >= 0x7F:
+		case r == '\t' || r == '\n' || r == '\r':
+			out.WriteRune(r)
+		case r < 0x20 || r == 0x7F:
 			out.WriteRune('\uFFFD')
 		default:
-			out.WriteByte(c)
+			out.WriteRune(r)
 		}
 	}
 	return out.String()

--- a/pkg/httpx/body.go
+++ b/pkg/httpx/body.go
@@ -1,0 +1,63 @@
+package httpx
+
+import (
+	"bytes"
+	"io"
+)
+
+// maxBodyCaptureBytes is the maximum number of bytes read from an error response body.
+const maxBodyCaptureBytes = 1024
+
+// CaptureResponseBody reads up to 1024 bytes from r, sanitizes non-printable
+// bytes by replacing them with U+FFFD, and appends "…" (U+2026) when the
+// original stream contained more than 1024 bytes.
+//
+// The caller retains responsibility for closing the underlying body. This
+// function only reads from r and drains the remainder into [io.Discard] for
+// connection reuse; it never closes r.
+//
+// If the read fails, CaptureResponseBody returns an empty string so the caller
+// can proceed without masking the original error.
+func CaptureResponseBody(r io.Reader) string {
+	buf := make([]byte, maxBodyCaptureBytes+1)
+	n, err := io.ReadFull(io.LimitReader(r, int64(len(buf))), buf)
+	// io.ReadFull returns io.ErrUnexpectedEOF when fewer bytes than the buffer
+	// length were available, which is the normal case. Any other error means
+	// the read failed and we should not surface a partial body.
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return ""
+	}
+
+	truncated := n > maxBodyCaptureBytes
+	if truncated {
+		n = maxBodyCaptureBytes
+	}
+
+	sanitized := sanitizeBody(buf[:n])
+
+	// Drain remaining bytes so the underlying TCP connection can be reused.
+	_, _ = io.Copy(io.Discard, r)
+
+	if truncated {
+		return sanitized + "…"
+	}
+	return sanitized
+}
+
+// sanitizeBody replaces non-printable bytes (below 0x20 except \t, \n, \r and
+// above 0x7E) with the Unicode replacement character U+FFFD.
+func sanitizeBody(b []byte) string {
+	var out bytes.Buffer
+	out.Grow(len(b))
+	for _, c := range b {
+		switch {
+		case c == '\t' || c == '\n' || c == '\r':
+			out.WriteByte(c)
+		case c < 0x20 || c >= 0x7F:
+			out.WriteRune('\uFFFD')
+		default:
+			out.WriteByte(c)
+		}
+	}
+	return out.String()
+}

--- a/pkg/httpx/body_test.go
+++ b/pkg/httpx/body_test.go
@@ -1,0 +1,83 @@
+package httpx_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/liverty-music/backend/pkg/httpx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCaptureResponseBody(t *testing.T) {
+	t.Parallel()
+
+	const maxBytes = 1024
+
+	tests := []struct {
+		name string
+		args struct {
+			r io.Reader
+		}
+		want string
+	}{
+		{
+			name: "return empty string when body is empty",
+			args: struct{ r io.Reader }{r: strings.NewReader("")},
+			want: "",
+		},
+		{
+			name: "return exact string when body is smaller than max bytes",
+			args: struct{ r io.Reader }{r: strings.NewReader("error message")},
+			want: "error message",
+		},
+		{
+			name: "return string without truncation indicator when body is exactly max bytes",
+			args: struct{ r io.Reader }{r: strings.NewReader(strings.Repeat("a", maxBytes))},
+			want: strings.Repeat("a", maxBytes),
+		},
+		{
+			name: "return first 1024 bytes with ellipsis when body exceeds max bytes",
+			args: struct{ r io.Reader }{r: strings.NewReader(strings.Repeat("b", 2000))},
+			want: strings.Repeat("b", maxBytes) + "…",
+		},
+		{
+			name: "replace non-printable bytes with replacement character",
+			args: struct{ r io.Reader }{r: strings.NewReader("\x00\x01\x02\xff")},
+			want: "\uFFFD\uFFFD\uFFFD\uFFFD",
+		},
+		{
+			name: "return empty string when reader returns an error",
+			args: struct{ r io.Reader }{r: iotest.ErrReader(errors.New("broken"))},
+			want: "",
+		},
+		{
+			name: "preserve printable whitespace characters such as tab newline and space",
+			args: struct{ r io.Reader }{r: strings.NewReader("line1\nline2\ttabbed line3 with space")},
+			want: "line1\nline2\ttabbed line3 with space",
+		},
+		{
+			name: "replace high non-ASCII bytes and keep printable ASCII intact",
+			args: struct{ r io.Reader }{r: strings.NewReader("ok\x7fnotok")},
+			want: "ok\uFFFDnotok",
+		},
+		{
+			name: "truncate with ellipsis and replace non-printable bytes when body is large with binary data",
+			args: struct{ r io.Reader }{r: strings.NewReader("\x00" + strings.Repeat("a", 2000))},
+			// First byte becomes replacement char, next 1023 are 'a', then ellipsis
+			want: "\uFFFD" + strings.Repeat("a", maxBytes-1) + "…",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := httpx.CaptureResponseBody(tt.args.r)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/httpx/body_test.go
+++ b/pkg/httpx/body_test.go
@@ -64,6 +64,16 @@ func TestCaptureResponseBody(t *testing.T) {
 			want: "ok\uFFFDnotok",
 		},
 		{
+			name: "valid UTF-8 multi-byte characters are preserved",
+			args: struct{ r io.Reader }{r: strings.NewReader("権限がありません: FCM rejected")},
+			want: "権限がありません: FCM rejected",
+		},
+		{
+			name: "mixed valid UTF-8 and control characters",
+			args: struct{ r io.Reader }{r: strings.NewReader("error\x00日本語\x01ok")},
+			want: "error\uFFFD日本語\uFFFDok",
+		},
+		{
 			name: "truncate with ellipsis and replace non-printable bytes when body is large with binary data",
 			args: struct{ r io.Reader }{r: strings.NewReader("\x00" + strings.Repeat("a", 2000))},
 			// First byte becomes replacement char, next 1023 are 'a', then ellipsis


### PR DESCRIPTION
## Summary

- **New**: `pkg/httpx.CaptureResponseBody` helper captures up to 1024 bytes of error response body, sanitizes non-printable chars, and drains remainder for connection reuse
- **Fix**: `pkg/api.FromHTTP` now attaches captured body as `slog.Attr("responseBody")` — covers Google Maps, fanart.tv, Last.fm, MusicBrainz clients (4 call sites)
- **Fix**: `webpush/sender.go` and `fanarttv/logo_fetcher.go` apply same capture in their custom error paths (preserving 410/404 semantics)
- **Docs**: Debug RPC runbook updated with "How to verify delivery succeeded" section + PGA troubleshooting table

Part of OpenSpec change `unblock-fcm-via-private-vip`. Ships independently of the cloud-provisioning PGA VIP switch.

## Motivation

During FCM 403 investigation, the decisive diagnostic body ("Your client does not have permission to get URL ... from this server") was invisible in production logs because all outbound HTTP clients discarded error bodies. Hours of manual investigation were required to surface it via external CLI replication.

## Test plan

- [x] `pkg/httpx/body_test.go`: 9 boundary cases (empty, truncation, binary, reader error)
- [x] `pkg/api/errors_test.go`: 4 cases (200 nil, 403+body, 500 empty)
- [x] `webpush/sender_test.go`: +2 cases (400+body, 410 no body attr)
- [x] `fanarttv/logo_fetcher_test.go`: +1 case (403+body)
- [x] `make lint` passes
- [ ] CI (Lint, Test, Vulnerability Check, claude-review)

Refs: #281
