### PR TITLE
feat(user): require user_id match on UserService per-user RPCs + idempotent Create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ tool (
 )
 
 require (
-	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260416062534-4c1f4812e678.2
-	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260416062534-4c1f4812e678.1
+	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260417090337-40bc5aa2dcee.2
+	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260417090337-40bc5aa2dcee.1
 	cloud.google.com/go/cloudsqlconn v1.20.0
 	connectrpc.com/authn v0.2.0
 	connectrpc.com/connect v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,10 @@ buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57
 buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57e197.1/go.mod h1:eGjb9P6sl1irS46NKyXnxkyozT2aWs3BF4tbYWQuCsw=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1 h1:q+tABqEH2Cpcp8fO9TBZlvKok7zorHGy+/UyywXaAKo=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1/go.mod h1:Y3m+VD8IH6JTgnFYggPHvFul/ry6dL3QDliy8xH7610=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260416062534-4c1f4812e678.2 h1:g7r1TiN1G4glDyGsFw5zFJqvbx/oboQX4eTeoBwTd9c=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260416062534-4c1f4812e678.2/go.mod h1:PMVII9EoKsKoOYg/y28FcUivwypJv97gbttcYeXVjm0=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260416062534-4c1f4812e678.1 h1:XANzRIuCa5T5XGjc2xYbWbXQy9AAzv2VMH8/Q6OCjvo=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260416062534-4c1f4812e678.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260417090337-40bc5aa2dcee.2 h1:zHwij9p+HIieCnf4j4A+sHnZpBqAs5e5whPBcEpz8tU=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260417090337-40bc5aa2dcee.2/go.mod h1:87cbSdIuTExY1VW6ZL9Lz0rc46F5KmNpbL4kzKOki4A=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260417090337-40bc5aa2dcee.1 h1:DdzRYHvljLC1uF8q3O/1giM9cPPJAa1V1pbNtwU9w/k=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260417090337-40bc5aa2dcee.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1 h1:KuP+b+in6LGh2ukof5KgDCD8hPXotEq6EVOo13Wg1pE=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1/go.mod h1:dV1Kz6zdmyXt7QWm5OXby44OFpyLemllUDBUG5HMLio=
 buf.build/go/app v0.1.0 h1:nlqD/h0rhIN73ZoiDElprrPiO2N6JV+RmNK34K29Ihg=

--- a/internal/adapter/rpc/mapper/user_test.go
+++ b/internal/adapter/rpc/mapper/user_test.go
@@ -74,3 +74,51 @@ func TestGetExternalUserID(t *testing.T) {
 		})
 	}
 }
+
+func TestRequireUserIDMatch(t *testing.T) {
+	t.Parallel()
+
+	const callerUserID = "11111111-1111-1111-1111-111111111111"
+
+	tests := []struct {
+		name      string
+		reqUserID string
+		wantErr   bool
+		wantCode  connect.Code
+	}{
+		{
+			name:      "matching user_id passes",
+			reqUserID: callerUserID,
+			wantErr:   false,
+		},
+		{
+			name:      "mismatched user_id returns PermissionDenied",
+			reqUserID: "22222222-2222-2222-2222-222222222222",
+			wantErr:   true,
+			wantCode:  connect.CodePermissionDenied,
+		},
+		{
+			name:      "empty user_id returns InvalidArgument",
+			reqUserID: "",
+			wantErr:   true,
+			wantCode:  connect.CodeInvalidArgument,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := mapper.RequireUserIDMatch(callerUserID, tt.reqUserID)
+
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+			var connectErr *connect.Error
+			assert.ErrorAs(t, err, &connectErr)
+			assert.Equal(t, tt.wantCode, connectErr.Code())
+		})
+	}
+}

--- a/internal/adapter/rpc/resend_email_verification_test.go
+++ b/internal/adapter/rpc/resend_email_verification_test.go
@@ -6,6 +6,7 @@ import (
 	userv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/user/v1"
 	"connectrpc.com/connect"
 	"github.com/liverty-music/backend/internal/adapter/rpc"
+	"github.com/liverty-music/backend/internal/entity"
 	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/pannpers/go-logging/logging"
@@ -17,7 +18,9 @@ import (
 func TestUserHandler_ResendEmailVerification(t *testing.T) {
 	t.Parallel()
 
-	t.Run("success", func(t *testing.T) {
+	existingUser := &entity.User{ID: testCallerUserID, ExternalID: testCallerExtID}
+
+	t.Run("success when user_id matches JWT", func(t *testing.T) {
 		t.Parallel()
 		logger, err := logging.New()
 		require.NoError(t, err)
@@ -25,15 +28,63 @@ func TestUserHandler_ResendEmailVerification(t *testing.T) {
 		verifier := ucmocks.NewMockEmailVerifier(t)
 		h := rpc.NewUserHandler(userUC, verifier, logger)
 
-		verifier.EXPECT().ResendVerification(mock.Anything, "ext-123").Return(nil).Once()
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(existingUser, nil).Once()
+		verifier.EXPECT().ResendVerification(mock.Anything, testCallerExtID).Return(nil).Once()
 
-		ctx := authedCtx("ext-123")
-		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{})
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{
+			UserId: newUserIDProto(testCallerUserID),
+		})
 
 		resp, err := h.ResendEmailVerification(ctx, req)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+	})
+
+	t.Run("returns PermissionDenied on user_id mismatch — verifier not invoked", func(t *testing.T) {
+		t.Parallel()
+		logger, err := logging.New()
+		require.NoError(t, err)
+		userUC := ucmocks.NewMockUserUseCase(t)
+		verifier := ucmocks.NewMockEmailVerifier(t)
+		h := rpc.NewUserHandler(userUC, verifier, logger)
+
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(existingUser, nil).Once()
+		// ResendVerification must NOT be called.
+
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{
+			UserId: newUserIDProto(testForeignUserID),
+		})
+
+		resp, err := h.ResendEmailVerification(ctx, req)
+
+		assert.Nil(t, resp)
+		var connectErr *connect.Error
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodePermissionDenied, connectErr.Code())
+	})
+
+	t.Run("returns InvalidArgument when user_id is empty", func(t *testing.T) {
+		t.Parallel()
+		logger, err := logging.New()
+		require.NoError(t, err)
+		userUC := ucmocks.NewMockUserUseCase(t)
+		verifier := ucmocks.NewMockEmailVerifier(t)
+		h := rpc.NewUserHandler(userUC, verifier, logger)
+
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(existingUser, nil).Once()
+
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{})
+
+		resp, err := h.ResendEmailVerification(ctx, req)
+
+		assert.Nil(t, resp)
+		var connectErr *connect.Error
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
 	})
 
 	t.Run("unavailable when verifier is nil", func(t *testing.T) {
@@ -43,12 +94,13 @@ func TestUserHandler_ResendEmailVerification(t *testing.T) {
 		userUC := ucmocks.NewMockUserUseCase(t)
 		h := rpc.NewUserHandler(userUC, nil, logger)
 
-		ctx := authedCtx("ext-123")
-		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{})
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{
+			UserId: newUserIDProto(testCallerUserID),
+		})
 
 		resp, err := h.ResendEmailVerification(ctx, req)
 
-		assert.Error(t, err)
 		assert.Nil(t, resp)
 		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
 	})
@@ -61,15 +113,17 @@ func TestUserHandler_ResendEmailVerification(t *testing.T) {
 		verifier := ucmocks.NewMockEmailVerifier(t)
 		h := rpc.NewUserHandler(userUC, verifier, logger)
 
-		verifier.EXPECT().ResendVerification(mock.Anything, "ext-123").
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(existingUser, nil).Once()
+		verifier.EXPECT().ResendVerification(mock.Anything, testCallerExtID).
 			Return(apperr.New(apperr.ErrFailedPrecondition.Code, "email is already verified")).Once()
 
-		ctx := authedCtx("ext-123")
-		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{})
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{
+			UserId: newUserIDProto(testCallerUserID),
+		})
 
 		resp, err := h.ResendEmailVerification(ctx, req)
 
-		assert.Error(t, err)
 		assert.Nil(t, resp)
 		assert.ErrorIs(t, err, apperr.ErrFailedPrecondition)
 	})
@@ -82,21 +136,25 @@ func TestUserHandler_ResendEmailVerification(t *testing.T) {
 		verifier := ucmocks.NewMockEmailVerifier(t)
 		h := rpc.NewUserHandler(userUC, verifier, logger)
 
-		verifier.EXPECT().ResendVerification(mock.Anything, "ext-rate").Return(nil).Times(3)
+		const rateExtID = "ext-rate"
+		const rateUserID = "user-rate"
+		rateUser := &entity.User{ID: rateUserID, ExternalID: rateExtID}
 
-		ctx := authedCtx("ext-rate")
-		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{})
+		userUC.EXPECT().GetByExternalID(mock.Anything, rateExtID).Return(rateUser, nil).Times(4)
+		verifier.EXPECT().ResendVerification(mock.Anything, rateExtID).Return(nil).Times(3)
 
-		// First 3 requests succeed.
+		ctx := authedCtx(rateExtID)
+		req := connect.NewRequest(&userv1.ResendEmailVerificationRequest{
+			UserId: newUserIDProto(rateUserID),
+		})
+
 		for range 3 {
 			resp, err := h.ResendEmailVerification(ctx, req)
 			assert.NoError(t, err)
 			assert.NotNil(t, resp)
 		}
 
-		// 4th request is rate limited.
 		resp, err := h.ResendEmailVerification(ctx, req)
-		assert.Error(t, err)
 		assert.Nil(t, resp)
 		assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
 	})

--- a/internal/adapter/rpc/user_handler.go
+++ b/internal/adapter/rpc/user_handler.go
@@ -40,17 +40,23 @@ func NewUserHandler(userUseCase usecase.UserUseCase, emailVerifier usecase.Email
 	}
 }
 
-// Get retrieves the authenticated user's profile using their JWT identity.
-func (h *UserHandler) Get(ctx context.Context, _ *connect.Request[userv1.GetRequest]) (*connect.Response[userv1.GetResponse], error) {
-	// Extract user identity from JWT context.
+// Get retrieves the authenticated user's profile.
+//
+// The request-supplied user_id is verified against the JWT-derived userID;
+// mismatches are rejected with PERMISSION_DENIED per the rpc-auth-scoping
+// convention.
+func (h *UserHandler) Get(ctx context.Context, req *connect.Request[userv1.GetRequest]) (*connect.Response[userv1.GetResponse], error) {
 	externalID, err := mapper.GetExternalUserID(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Resolve the user by their external identity provider ID (JWT sub claim).
 	user, err := h.userUseCase.GetByExternalID(ctx, externalID)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := mapper.RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue()); err != nil {
 		return nil, err
 	}
 
@@ -86,20 +92,26 @@ func (h *UserHandler) Create(ctx context.Context, req *connect.Request[userv1.Cr
 }
 
 // UpdateHome sets or changes the authenticated user's home area.
+//
+// The request-supplied user_id is verified against the JWT-derived userID;
+// mismatches are rejected with PERMISSION_DENIED per the rpc-auth-scoping
+// convention.
 func (h *UserHandler) UpdateHome(ctx context.Context, req *connect.Request[userv1.UpdateHomeRequest]) (*connect.Response[userv1.UpdateHomeResponse], error) {
-	// Extract user identity from JWT context.
 	externalID, err := mapper.GetExternalUserID(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Resolve the internal users.id from the JWT sub claim (Zitadel external_id).
 	user, err := h.userUseCase.GetByExternalID(ctx, externalID)
 	if err != nil {
 		return nil, err
 	}
 
-	home := mapper.ProtoHomeToEntity(req.Msg.Home)
+	if err := mapper.RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue()); err != nil {
+		return nil, err
+	}
+
+	home := mapper.ProtoHomeToEntity(req.Msg.GetHome())
 	updatedUser, err := h.userUseCase.UpdateHome(ctx, user.ID, home)
 	if err != nil {
 		return nil, err
@@ -112,6 +124,10 @@ func (h *UserHandler) UpdateHome(ctx context.Context, req *connect.Request[userv
 
 // ResendEmailVerification triggers a new email verification message for the
 // authenticated user via the Zitadel API.
+//
+// The request-supplied user_id is verified against the JWT-derived userID;
+// mismatches are rejected with PERMISSION_DENIED before any Zitadel API call
+// is made, per the rpc-auth-scoping convention.
 func (h *UserHandler) ResendEmailVerification(ctx context.Context, req *connect.Request[userv1.ResendEmailVerificationRequest]) (*connect.Response[userv1.ResendEmailVerificationResponse], error) {
 	if h.emailVerifier == nil {
 		return nil, connect.NewError(connect.CodeUnavailable, errors.New("email verification service is not configured"))
@@ -119,6 +135,15 @@ func (h *UserHandler) ResendEmailVerification(ctx context.Context, req *connect.
 
 	claims, err := mapper.GetClaimsFromContext(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	user, err := h.userUseCase.GetByExternalID(ctx, claims.Sub)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := mapper.RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue()); err != nil {
 		return nil, err
 	}
 

--- a/internal/adapter/rpc/user_handler_test.go
+++ b/internal/adapter/rpc/user_handler_test.go
@@ -3,6 +3,7 @@ package rpc_test
 import (
 	"testing"
 
+	entitypb "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/entity/v1"
 	userv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/user/v1"
 	"connectrpc.com/connect"
 	"github.com/liverty-music/backend/internal/adapter/rpc"
@@ -15,33 +16,88 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testCallerUserID  = "user-1"
+	testCallerExtID   = "ext-123"
+	testForeignUserID = "user-999"
+)
+
+func newUserIDProto(id string) *entitypb.UserId {
+	return &entitypb.UserId{Value: id}
+}
+
 func TestUserHandler_Get(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns user when found", func(t *testing.T) {
+	t.Run("returns user when user_id matches JWT", func(t *testing.T) {
 		t.Parallel()
 		logger, err := logging.New()
 		require.NoError(t, err)
 		userUC := mocks.NewMockUserUseCase(t)
 		h := rpc.NewUserHandler(userUC, nil, logger)
 
-		userUC.EXPECT().GetByExternalID(mock.Anything, "ext-123").Return(&entity.User{
-			ID:         "user-1",
-			ExternalID: "ext-123",
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(&entity.User{
+			ID:         testCallerUserID,
+			ExternalID: testCallerExtID,
 			Email:      "test@example.com",
 			Name:       "Test User",
 		}, nil).Once()
 
-		ctx := authedCtx("ext-123")
-		req := connect.NewRequest(&userv1.GetRequest{})
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.GetRequest{UserId: newUserIDProto(testCallerUserID)})
 
 		resp, err := h.Get(ctx, req)
 
 		assert.NoError(t, err)
-		assert.NotNil(t, resp)
-		assert.NotNil(t, resp.Msg.User)
-		assert.Equal(t, "user-1", resp.Msg.User.Id.Value)
+		require.NotNil(t, resp)
+		assert.Equal(t, testCallerUserID, resp.Msg.User.Id.Value)
 		assert.Equal(t, "test@example.com", resp.Msg.User.Email.Value)
+	})
+
+	t.Run("returns PermissionDenied when user_id mismatches JWT", func(t *testing.T) {
+		t.Parallel()
+		logger, err := logging.New()
+		require.NoError(t, err)
+		userUC := mocks.NewMockUserUseCase(t)
+		h := rpc.NewUserHandler(userUC, nil, logger)
+
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(&entity.User{
+			ID:         testCallerUserID,
+			ExternalID: testCallerExtID,
+		}, nil).Once()
+
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.GetRequest{UserId: newUserIDProto(testForeignUserID)})
+
+		resp, err := h.Get(ctx, req)
+
+		assert.Nil(t, resp)
+		var connectErr *connect.Error
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodePermissionDenied, connectErr.Code())
+	})
+
+	t.Run("returns InvalidArgument when user_id is empty", func(t *testing.T) {
+		t.Parallel()
+		logger, err := logging.New()
+		require.NoError(t, err)
+		userUC := mocks.NewMockUserUseCase(t)
+		h := rpc.NewUserHandler(userUC, nil, logger)
+
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(&entity.User{
+			ID:         testCallerUserID,
+			ExternalID: testCallerExtID,
+		}, nil).Once()
+
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.GetRequest{})
+
+		resp, err := h.Get(ctx, req)
+
+		assert.Nil(t, resp)
+		var connectErr *connect.Error
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
 	})
 
 	t.Run("returns error when user not found", func(t *testing.T) {
@@ -56,12 +112,88 @@ func TestUserHandler_Get(t *testing.T) {
 		).Once()
 
 		ctx := authedCtx("ext-unknown")
-		req := connect.NewRequest(&userv1.GetRequest{})
+		req := connect.NewRequest(&userv1.GetRequest{UserId: newUserIDProto(testCallerUserID)})
 
 		resp, err := h.Get(ctx, req)
 
-		assert.Error(t, err)
 		assert.Nil(t, resp)
 		assert.ErrorIs(t, err, apperr.ErrNotFound)
+	})
+}
+
+func TestUserHandler_UpdateHome(t *testing.T) {
+	t.Parallel()
+
+	existingUser := &entity.User{ID: testCallerUserID, ExternalID: testCallerExtID}
+	updatedHome := &entity.Home{CountryCode: "JP", Level1: "JP-13"}
+	updatedUser := &entity.User{ID: testCallerUserID, ExternalID: testCallerExtID, Home: updatedHome}
+
+	homeProto := &entitypb.Home{CountryCode: "JP", Level_1: "JP-13"}
+
+	t.Run("updates home when user_id matches JWT", func(t *testing.T) {
+		t.Parallel()
+		logger, err := logging.New()
+		require.NoError(t, err)
+		userUC := mocks.NewMockUserUseCase(t)
+		h := rpc.NewUserHandler(userUC, nil, logger)
+
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(existingUser, nil).Once()
+		userUC.EXPECT().UpdateHome(mock.Anything, testCallerUserID, mock.Anything).Return(updatedUser, nil).Once()
+
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.UpdateHomeRequest{
+			UserId: newUserIDProto(testCallerUserID),
+			Home:   homeProto,
+		})
+
+		resp, err := h.UpdateHome(ctx, req)
+
+		assert.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, testCallerUserID, resp.Msg.User.Id.Value)
+	})
+
+	t.Run("returns PermissionDenied on user_id mismatch", func(t *testing.T) {
+		t.Parallel()
+		logger, err := logging.New()
+		require.NoError(t, err)
+		userUC := mocks.NewMockUserUseCase(t)
+		h := rpc.NewUserHandler(userUC, nil, logger)
+
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(existingUser, nil).Once()
+		// UpdateHome must NOT be called.
+
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.UpdateHomeRequest{
+			UserId: newUserIDProto(testForeignUserID),
+			Home:   homeProto,
+		})
+
+		resp, err := h.UpdateHome(ctx, req)
+
+		assert.Nil(t, resp)
+		var connectErr *connect.Error
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodePermissionDenied, connectErr.Code())
+	})
+
+	t.Run("returns InvalidArgument when user_id empty", func(t *testing.T) {
+		t.Parallel()
+		logger, err := logging.New()
+		require.NoError(t, err)
+		userUC := mocks.NewMockUserUseCase(t)
+		h := rpc.NewUserHandler(userUC, nil, logger)
+
+		userUC.EXPECT().GetByExternalID(mock.Anything, testCallerExtID).Return(existingUser, nil).Once()
+
+		ctx := authedCtx(testCallerExtID)
+		req := connect.NewRequest(&userv1.UpdateHomeRequest{Home: homeProto})
+
+		resp, err := h.UpdateHome(ctx, req)
+
+		assert.Nil(t, resp)
+		var connectErr *connect.Error
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
 	})
 }

--- a/internal/usecase/user_uc.go
+++ b/internal/usecase/user_uc.go
@@ -3,6 +3,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/liverty-music/backend/internal/entity"
@@ -13,13 +14,22 @@ import (
 
 // UserUseCase defines the interface for user-related business logic.
 type UserUseCase interface {
-	// Create registers a new user.
-	// If params.Home is non-nil, the home area is validated and persisted atomically.
+	// Create registers a new user, or returns the existing user when the
+	// caller's external_id is already provisioned.
+	//
+	// Idempotent behavior: when the underlying repository reports a unique
+	// violation and a user already exists for the supplied external_id, the
+	// existing entity is returned with no error and no UserCreated event is
+	// published. The existing row's email, name, and home fields are NOT
+	// overwritten — the duplicate call is a read, not an upsert.
+	//
+	// A unique violation on email by a different external_id is NOT
+	// idempotent and is surfaced as AlreadyExists.
 	//
 	// # Possible errors
 	//
 	//  - InvalidArgument: If email or name is invalid, or home is malformed.
-	//  - AlreadyExists: If a user with the same email already exists.
+	//  - AlreadyExists: If the email is already claimed by a different identity.
 	Create(ctx context.Context, params *entity.NewUser) (*entity.User, error)
 
 	// Get retrieves a user by their unique ID.
@@ -73,7 +83,8 @@ func NewUserUseCase(userRepo entity.UserRepository, publisher EventPublisher, lo
 	}
 }
 
-// Create creates a new user.
+// Create creates a new user, or returns the existing user on duplicate
+// external_id (idempotent).
 func (uc *userUseCase) Create(ctx context.Context, params *entity.NewUser) (*entity.User, error) {
 	if params.Home != nil {
 		if err := params.Home.Validate(); err != nil {
@@ -83,6 +94,23 @@ func (uc *userUseCase) Create(ctx context.Context, params *entity.NewUser) (*ent
 
 	user, err := uc.userRepo.Create(ctx, params)
 	if err != nil {
+		// On AlreadyExists, distinguish between (a) same caller retrying the
+		// Create (duplicate external_id) — treat as idempotent success — and
+		// (b) a different identity claiming the same email — surface the
+		// original error. GetByExternalID resolves which case we are in.
+		if errors.Is(err, apperr.ErrAlreadyExists) {
+			existing, getErr := uc.userRepo.GetByExternalID(ctx, params.ExternalID)
+			if getErr != nil {
+				// external_id was NOT the conflicting column — propagate the
+				// original AlreadyExists to signal the email collision.
+				return nil, err
+			}
+			uc.logger.Info(ctx, "Create returned existing user (idempotent on duplicate external_id)",
+				slog.String("user_id", existing.ID),
+				slog.String("external_id", existing.ExternalID),
+			)
+			return existing, nil
+		}
 		return nil, err
 	}
 

--- a/internal/usecase/user_uc_test.go
+++ b/internal/usecase/user_uc_test.go
@@ -163,6 +163,57 @@ func TestUserUseCase_CreateUser(t *testing.T) {
 		assert.Nil(t, result)
 		assert.ErrorIs(t, err, apperr.ErrInternal)
 	})
+
+	t.Run("idempotent — duplicate external_id returns existing user", func(t *testing.T) {
+		t.Parallel()
+		d := newUserTestDeps(t)
+
+		params := &entity.NewUser{
+			ExternalID: "ext-existing",
+			Email:      "existing@example.com",
+			Name:       "Existing User",
+		}
+		existingUser := &entity.User{
+			ID:         "user-existing-1",
+			ExternalID: "ext-existing",
+			Email:      "existing@example.com",
+			Name:       "Existing User",
+		}
+
+		d.repo.EXPECT().Create(ctx, params).
+			Return(nil, apperr.New(codes.AlreadyExists, "duplicate user")).Once()
+		d.repo.EXPECT().GetByExternalID(ctx, "ext-existing").
+			Return(existingUser, nil).Once()
+
+		result, err := d.uc.Create(ctx, params)
+
+		assert.NoError(t, err)
+		assert.Equal(t, existingUser, result)
+	})
+
+	t.Run("duplicate email with different external_id surfaces AlreadyExists", func(t *testing.T) {
+		t.Parallel()
+		d := newUserTestDeps(t)
+
+		params := &entity.NewUser{
+			ExternalID: "ext-new-caller",
+			Email:      "taken@example.com",
+			Name:       "New Caller",
+		}
+
+		d.repo.EXPECT().Create(ctx, params).
+			Return(nil, apperr.New(codes.AlreadyExists, "duplicate email")).Once()
+		// GetByExternalID returns NotFound because the caller's external_id is not
+		// the conflicting column — the email was claimed by a different identity.
+		d.repo.EXPECT().GetByExternalID(ctx, "ext-new-caller").
+			Return(nil, apperr.New(codes.NotFound, "user not found")).Once()
+
+		result, err := d.uc.Create(ctx, params)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, apperr.ErrAlreadyExists)
+	})
 }
 
 func TestUserUseCase_GetUser(t *testing.T) {


### PR DESCRIPTION
## Summary

Adopts the rpc-auth-scoping convention for `UserService` (per specification PR liverty-music/specification#411, Release v0.38.0). Every authenticated per-user RPC now verifies the supplied `user_id` against the JWT-derived userID; mismatches are rejected with `PERMISSION_DENIED`.

`UserService.Create` remains exempt from the `user_id` requirement (the caller's internal user_id does not yet exist) and additionally becomes idempotent on duplicate `external_id` — the use case catches `apperr.ErrAlreadyExists`, fetches the existing user via `GetByExternalID`, and returns it as a successful response. A duplicate that surfaces from a different `external_id` (email collision) still propagates as `AlreadyExists`.

Refs liverty-music/specification#410.

## Changes

### `internal/usecase/user_uc.go`
- `Create` is idempotent on duplicate `external_id` — returns the existing user as a successful response, skips the `UserCreated` event publish on the idempotent path
- Differentiates external_id duplicate (idempotent return) vs. email duplicate (still surfaces `AlreadyExists`) by attempting `GetByExternalID` after a unique-violation error

### `internal/adapter/rpc/user_handler.go`
- `Get`, `UpdateHome`, `ResendEmailVerification` resolve the caller's internal user via `GetByExternalID` and call `mapper.RequireUserIDMatch` before any business logic
- `ResendEmailVerification` now resolves the caller user (previously read JWT claims directly) so the user_id check has something to match against
- `Create` handler is unchanged — exemption preserved

### `go.mod` / `go.sum`
- Bumps `buf.build/gen/go/liverty-music/schema/protocolbuffers/go` and `.../connectrpc/go` to the v0.38.0 BSR push (pseudo-version `1.36.11-20260417090337-40bc5aa2dcee.1`)

### Tests
- `mapper/user_test.go` — adds `TestRequireUserIDMatch` covering match / mismatch / empty
- `user_handler_test.go` — `Get` and `UpdateHome` now exercise match / mismatch / empty / not-found scenarios
- `resend_email_verification_test.go` — extends existing tests to cover the new `user_id` field and adds mismatch / empty / Unavailable / FailedPrecondition / rate-limit cases that wire `GetByExternalID` mocks
- `user_uc_test.go` — adds `idempotent — duplicate external_id returns existing user` and `duplicate email with different external_id surfaces AlreadyExists` cases

## Test plan

- [x] `make check` (lint + golangci-lint + schema-lint + modernizers + unit + integration) all pass
- [ ] Verify CI passes after push
- [ ] Manually exercise dev environment after deploy: cache-miss boot calls `Create` and gets existing user; mismatched `user_id` returns `PERMISSION_DENIED`; empty `user_id` returns `INVALID_ARGUMENT`
