### PR TITLE
fix(compose): move local postgres listen port to 15432

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,9 +7,9 @@
       "Bash(docker info)",
       "Bash(podman port postgres)",
       "Bash(PGPASSWORD=\"\" psql -U test-user -h localhost -d test-db -c \"SELECT 1\")",
-      "Bash(atlas migrate diff --dev-url \"postgres://test-user@localhost:5432/atlas_dev_temp?sslmode=disable&search_path=app,public\" --dir \"file://k8s/atlas/base/migrations\" --to \"file://internal/infrastructure/database/rdb/schema/schema.sql\" drop_notifications_table)",
-      "Bash(atlas migrate diff --dev-url \"postgres://test-user@localhost:5432/atlas_dev_temp?sslmode=disable&search_path=public\" --dir \"file://k8s/atlas/base/migrations\" --to \"file://internal/infrastructure/database/rdb/schema/schema.sql\" drop_notifications_table)",
-      "Bash(atlas migrate diff --dev-url \"postgres://test-user@localhost:5432/atlas_dev_temp?sslmode=disable&search_path=app\" --dir \"file://k8s/atlas/base/migrations\" --to \"file://internal/infrastructure/database/rdb/schema/schema.sql\" drop_notifications_table)"
+      "Bash(atlas migrate diff --dev-url \"postgres://test-user@localhost:15432/atlas_dev_temp?sslmode=disable&search_path=app,public\" --dir \"file://k8s/atlas/base/migrations\" --to \"file://internal/infrastructure/database/rdb/schema/schema.sql\" drop_notifications_table)",
+      "Bash(atlas migrate diff --dev-url \"postgres://test-user@localhost:15432/atlas_dev_temp?sslmode=disable&search_path=public\" --dir \"file://k8s/atlas/base/migrations\" --to \"file://internal/infrastructure/database/rdb/schema/schema.sql\" drop_notifications_table)",
+      "Bash(atlas migrate diff --dev-url \"postgres://test-user@localhost:15432/atlas_dev_temp?sslmode=disable&search_path=app\" --dir \"file://k8s/atlas/base/migrations\" --to \"file://internal/infrastructure/database/rdb/schema/schema.sql\" drop_notifications_table)"
     ],
     "additionalDirectories": [
       "/home/pannpers/dev/src/github.com/liverty-music/backend",

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,6 @@
 # Test environment configuration
 DATABASE_HOST=postgres
-DATABASE_PORT=5432
+DATABASE_PORT=15432
 DATABASE_NAME=test-db
 DATABASE_USER=test-user
 DATABASE_SSL_MODE=disable

--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DATABASE_URL: "postgres://postgres:password@localhost:5432/postgres?sslmode=disable"
+  DATABASE_URL: "postgres://postgres:password@localhost:15432/postgres?sslmode=disable"
 
 jobs:
   changes:
@@ -49,7 +49,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - 15432:5432
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - 15432:5432
 
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
         uses: ariga/setup-atlas@v0
 
       - name: Apply database migrations
-        run: atlas migrate apply --url "postgres://test-user@localhost:5432/test-db?sslmode=disable" --dir "file://k8s/atlas/base/migrations"
+        run: atlas migrate apply --url "postgres://test-user@localhost:15432/test-db?sslmode=disable" --dir "file://k8s/atlas/base/migrations"
 
       - name: Run integration tests
         run: make test-integration GOTEST_FLAGS="-v -coverprofile=coverage.out -covermode=atomic"
@@ -216,7 +216,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - 15432:5432
 
     steps:
       - uses: actions/checkout@v4
@@ -233,7 +233,7 @@ jobs:
         uses: ariga/setup-atlas@v0
 
       - name: Apply database migrations
-        run: atlas migrate apply --url "postgres://test-user@localhost:5432/test-db?sslmode=disable" --dir "file://k8s/atlas/base/migrations"
+        run: atlas migrate apply --url "postgres://test-user@localhost:15432/test-db?sslmode=disable" --dir "file://k8s/atlas/base/migrations"
 
       - name: Run benchmarks
         run: go test -bench=. -benchmem -run=^$ ./...

--- a/atlas.hcl
+++ b/atlas.hcl
@@ -1,7 +1,7 @@
 // Define the "local" environment for development.
 env "local" {
   // The actual database to apply migrations to, matching compose.yml.
-  url = "postgres://test-user@localhost:5432/test-db?sslmode=disable"
+  url = "postgres://test-user@localhost:15432/test-db?sslmode=disable"
 
   // A temporary database for schema analysis (diffing, linting).
   // Use a temporary database container for schema analysis to ensure a clean environment.

--- a/compose.yml
+++ b/compose.yml
@@ -5,6 +5,7 @@ services:
     image: postgres:18
     container_name: postgres
     network_mode: host
+    command: ["postgres", "-p", "15432"]
     environment:
       POSTGRES_USER: test-user
       POSTGRES_DB: test-db
@@ -12,7 +13,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U test-user -d test-db"]
+      test: ["CMD-SHELL", "pg_isready -U test-user -d test-db -p 15432"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/internal/infrastructure/database/rdb/setup_test.go
+++ b/internal/infrastructure/database/rdb/setup_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 func setupTestDatabase() *rdb.Database {
 	dbCfg := config.DatabaseConfig{
 		Host:              "localhost",
-		Port:              5432,
+		Port:              15432,
 		Name:              "test-db",
 		User:              "test-user",
 		SSLMode:           "disable",


### PR DESCRIPTION
## Summary

- Moves the local Docker Compose `postgres` listen port from `5432` to `15432`, so liverty-music local development can coexist with other projects' PostgreSQL instances on the default port.
- Updates all developer-facing references to match (`.env.test`, `atlas.hcl` env `"local"`, `.claude/settings.json` allowlist, integration test setup).
- Preserves `network_mode: host` — this is the Podman/WSL2 workaround from `1faa575`; reverting would reintroduce the bridge-networking bug.
- `DatabaseConfig.Port` default stays at `5432` (upstream PostgreSQL standard; dev/prod Cloud SQL targets unchanged).

Spec companion: liverty-music/specification#412

## Post-merge action for developers

After pulling `main`, recreate the local postgres container so the new listen port takes effect:

```bash
docker compose down postgres
docker compose up -d postgres --wait
```

The `postgres_data` volume is preserved across the recreate.

Any developer-local scripts, `.pgpass`, psql bookmarks, or IDE DB connections pointing at `localhost:5432` (for liverty-music) need to move to `15432`.

## Test plan

- [x] `docker compose up -d postgres --wait` succeeds on the new config
- [x] `atlas migrate apply --env local` succeeds against `localhost:15432`
- [x] `make test` passes (unit + integration)
- [x] `make check` passes (lint + schema lint + modernize + test)
- [ ] CI passes on the PR
