### PR TITLE
feat(ticket,entry)!: require user_id match on per-user RPCs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ tool (
 )
 
 require (
-	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260417090337-40bc5aa2dcee.2
-	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260417090337-40bc5aa2dcee.1
+	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260421074642-d769c71c8006.2
+	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260421074642-d769c71c8006.1
 	cloud.google.com/go/cloudsqlconn v1.20.0
 	connectrpc.com/authn v0.2.0
 	connectrpc.com/connect v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,12 @@ buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4b
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1/go.mod h1:Y3m+VD8IH6JTgnFYggPHvFul/ry6dL3QDliy8xH7610=
 buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260417090337-40bc5aa2dcee.2 h1:zHwij9p+HIieCnf4j4A+sHnZpBqAs5e5whPBcEpz8tU=
 buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260417090337-40bc5aa2dcee.2/go.mod h1:87cbSdIuTExY1VW6ZL9Lz0rc46F5KmNpbL4kzKOki4A=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260421074642-d769c71c8006.2 h1:6Po2HaD1UC33SyPv/HSk6GqppugvR8yi7SSS5gsAvsc=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.19.1-20260421074642-d769c71c8006.2/go.mod h1:RpSfXXYgjIfG5vsKiWBgTx+mSs7raaeBV7I+FCszoUc=
 buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260417090337-40bc5aa2dcee.1 h1:DdzRYHvljLC1uF8q3O/1giM9cPPJAa1V1pbNtwU9w/k=
 buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260417090337-40bc5aa2dcee.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260421074642-d769c71c8006.1 h1:Ba8/nCo2ZSjJ9aE3IJqYqF6AgPHIEmOkzF7+b5CEXas=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260421074642-d769c71c8006.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1 h1:KuP+b+in6LGh2ukof5KgDCD8hPXotEq6EVOo13Wg1pE=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1/go.mod h1:dV1Kz6zdmyXt7QWm5OXby44OFpyLemllUDBUG5HMLio=
 buf.build/go/app v0.1.0 h1:nlqD/h0rhIN73ZoiDElprrPiO2N6JV+RmNK34K29Ihg=

--- a/internal/adapter/rpc/entry_handler.go
+++ b/internal/adapter/rpc/entry_handler.go
@@ -62,13 +62,14 @@ func (h *EntryHandler) VerifyEntry(
 }
 
 // GetMerklePath retrieves the Merkle path for a user at an event.
+//
+// The request-supplied user_id is verified against the JWT-derived userID;
+// mismatches are rejected with PERMISSION_DENIED per the rpc-auth-scoping
+// convention.
 func (h *EntryHandler) GetMerklePath(
 	ctx context.Context,
 	req *connect.Request[entryv1.GetMerklePathRequest],
 ) (*connect.Response[entryv1.GetMerklePathResponse], error) {
-	// Resolve user ID from JWT claims for authorization safety.
-	// The request body user_id is intentionally ignored to prevent users from
-	// querying other users' Merkle paths.
 	externalID, err := mapper.GetExternalUserID(ctx)
 	if err != nil {
 		return nil, err
@@ -76,6 +77,10 @@ func (h *EntryHandler) GetMerklePath(
 
 	user, err := h.userRepo.GetByExternalID(ctx, externalID)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := mapper.RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue()); err != nil {
 		return nil, err
 	}
 

--- a/internal/adapter/rpc/entry_handler_test.go
+++ b/internal/adapter/rpc/entry_handler_test.go
@@ -116,6 +116,7 @@ func TestEntryHandler_GetMerklePath(t *testing.T) {
 			ctx:  entryAuthedCtx("ext-user-1"),
 			req: &entryv1.GetMerklePathRequest{
 				EventId: &entityv1.EventId{Value: "event-1"},
+				UserId:  &entityv1.UserId{Value: "user-uuid-1"},
 			},
 			setup: func(uc *ucmocks.MockEntryUseCase, ur *mocks.MockUserRepository) {
 				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
@@ -130,6 +131,37 @@ func TestEntryHandler_GetMerklePath(t *testing.T) {
 				}, nil)
 			},
 			wantErr: false,
+		},
+		{
+			name: "permission_denied - user_id mismatch",
+			ctx:  entryAuthedCtx("ext-user-1"),
+			req: &entryv1.GetMerklePathRequest{
+				EventId: &entityv1.EventId{Value: "event-1"},
+				UserId:  &entityv1.UserId{Value: "other-user-uuid"},
+			},
+			setup: func(_ *ucmocks.MockEntryUseCase, ur *mocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+			},
+			wantCode: connect.CodePermissionDenied,
+			wantErr:  true,
+		},
+		{
+			name: "invalid_argument - missing user_id",
+			ctx:  entryAuthedCtx("ext-user-1"),
+			req: &entryv1.GetMerklePathRequest{
+				EventId: &entityv1.EventId{Value: "event-1"},
+			},
+			setup: func(_ *ucmocks.MockEntryUseCase, ur *mocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+			},
+			wantCode: connect.CodeInvalidArgument,
+			wantErr:  true,
 		},
 		{
 			name:     "unauthenticated",

--- a/internal/adapter/rpc/ticket_handler.go
+++ b/internal/adapter/rpc/ticket_handler.go
@@ -35,6 +35,10 @@ func NewTicketHandler(ticketUseCase usecase.TicketUseCase, userRepo entity.UserR
 }
 
 // MintTicket mints a soulbound ticket for the authenticated user.
+//
+// The request-supplied user_id is verified against the JWT-derived userID;
+// mismatches are rejected with PERMISSION_DENIED per the rpc-auth-scoping
+// convention.
 func (h *TicketHandler) MintTicket(
 	ctx context.Context,
 	req *connect.Request[ticketv1.MintTicketRequest],
@@ -51,6 +55,10 @@ func (h *TicketHandler) MintTicket(
 	// not the identity-provider-specific external_id.
 	user, err := h.userRepo.GetByExternalID(ctx, externalID)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := mapper.RequireUserIDMatch(user.ID, msg.GetUserId().GetValue()); err != nil {
 		return nil, err
 	}
 
@@ -96,10 +104,13 @@ func (h *TicketHandler) GetTicket(
 }
 
 // ListTickets retrieves all tickets for the authenticated user.
-// The user ID is resolved from the JWT claims for authorization safety.
+//
+// The request-supplied user_id is verified against the JWT-derived userID;
+// mismatches are rejected with PERMISSION_DENIED per the rpc-auth-scoping
+// convention.
 func (h *TicketHandler) ListTickets(
 	ctx context.Context,
-	_ *connect.Request[ticketv1.ListTicketsRequest],
+	req *connect.Request[ticketv1.ListTicketsRequest],
 ) (*connect.Response[ticketv1.ListTicketsResponse], error) {
 	externalID, err := mapper.GetExternalUserID(ctx)
 	if err != nil {
@@ -112,8 +123,10 @@ func (h *TicketHandler) ListTickets(
 		return nil, err
 	}
 
-	// Use the authenticated user's internal ID from the resolved user record,
-	// not the request body, to prevent users from listing other users' tickets.
+	if err := mapper.RequireUserIDMatch(user.ID, req.Msg.GetUserId().GetValue()); err != nil {
+		return nil, err
+	}
+
 	tickets, err := h.ticketUseCase.ListTicketsForUser(ctx, user.ID)
 	if err != nil {
 		return nil, err

--- a/internal/adapter/rpc/ticket_handler_test.go
+++ b/internal/adapter/rpc/ticket_handler_test.go
@@ -40,6 +40,7 @@ func TestTicketHandler_MintTicket(t *testing.T) {
 			ctx:  ticketAuthedCtx("ext-user-1"),
 			req: &ticketv1.MintTicketRequest{
 				EventId: &entityv1.EventId{Value: "event-123"},
+				UserId:  &entityv1.UserId{Value: "user-uuid-1"},
 			},
 			setup: func(uc *ucmocks.MockTicketUseCase, ur *mocks.MockUserRepository) {
 				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
@@ -57,6 +58,37 @@ func TestTicketHandler_MintTicket(t *testing.T) {
 				}, nil)
 			},
 			wantErr: false,
+		},
+		{
+			name: "permission_denied - user_id mismatch",
+			ctx:  ticketAuthedCtx("ext-user-1"),
+			req: &ticketv1.MintTicketRequest{
+				EventId: &entityv1.EventId{Value: "event-123"},
+				UserId:  &entityv1.UserId{Value: "other-user-uuid"},
+			},
+			setup: func(_ *ucmocks.MockTicketUseCase, ur *mocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+			},
+			wantCode: connect.CodePermissionDenied,
+			wantErr:  true,
+		},
+		{
+			name: "invalid_argument - missing user_id",
+			ctx:  ticketAuthedCtx("ext-user-1"),
+			req: &ticketv1.MintTicketRequest{
+				EventId: &entityv1.EventId{Value: "event-123"},
+			},
+			setup: func(_ *ucmocks.MockTicketUseCase, ur *mocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+			},
+			wantCode: connect.CodeInvalidArgument,
+			wantErr:  true,
 		},
 		{
 			name:     "unauthenticated",
@@ -175,7 +207,9 @@ func TestTicketHandler_ListTickets(t *testing.T) {
 		{
 			name: "success with tickets",
 			ctx:  ticketAuthedCtx("ext-user-1"),
-			req:  &ticketv1.ListTicketsRequest{},
+			req: &ticketv1.ListTicketsRequest{
+				UserId: &entityv1.UserId{Value: "user-uuid-1"},
+			},
 			setup: func(uc *ucmocks.MockTicketUseCase, ur *mocks.MockUserRepository) {
 				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
 					ID:         "user-uuid-1",
@@ -188,6 +222,34 @@ func TestTicketHandler_ListTickets(t *testing.T) {
 			},
 			wantErr: false,
 			wantLen: 2,
+		},
+		{
+			name: "permission_denied - user_id mismatch",
+			ctx:  ticketAuthedCtx("ext-user-1"),
+			req: &ticketv1.ListTicketsRequest{
+				UserId: &entityv1.UserId{Value: "other-user-uuid"},
+			},
+			setup: func(_ *ucmocks.MockTicketUseCase, ur *mocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+			},
+			wantCode: connect.CodePermissionDenied,
+			wantErr:  true,
+		},
+		{
+			name: "invalid_argument - missing user_id",
+			ctx:  ticketAuthedCtx("ext-user-1"),
+			req:  &ticketv1.ListTicketsRequest{},
+			setup: func(_ *ucmocks.MockTicketUseCase, ur *mocks.MockUserRepository) {
+				ur.EXPECT().GetByExternalID(mock.Anything, "ext-user-1").Return(&entity.User{
+					ID:         "user-uuid-1",
+					ExternalID: "ext-user-1",
+				}, nil)
+			},
+			wantCode: connect.CodeInvalidArgument,
+			wantErr:  true,
 		},
 		{
 			name:     "unauthenticated",


### PR DESCRIPTION
## 🔗 Related Issue

Follows `liverty-music/specification#418` (merged as v0.39.0). Implements the backend side of the `align-ticket-rpcs-with-auth-scoping` OpenSpec change.

## 📝 Summary of Changes

**BREAKING** — `MintTicket`, `ListTickets`, and `GetMerklePath` handlers now require an explicit `user_id` in the request body and reject mismatches against the JWT-derived userID with `PERMISSION_DENIED` via the existing `mapper.RequireUserIDMatch` helper. This brings the ticket / entry RPC surface onto the cross-service `rpc-auth-scoping` convention established by `standardize-user-scoped-rpc-auth`.

Deliberately **unchanged**:
- `GetTicket` — identifier-scoped (keyed by `ticket_id`); the `rpc-auth-scoping` convention does not apply.
- `VerifyEntry` — explicitly unauthenticated (the ZK proof is the authentication); no JWT to match against.

### Dependency bumps

- `buf.build/gen/go/liverty-music/schema/protocolbuffers/go` → `v1.36.11-20260421074642-d769c71c8006.1`
- `buf.build/gen/go/liverty-music/schema/connectrpc/go` → `v1.19.1-20260421074642-d769c71c8006.2`

Both correspond to specification v0.39.0, which added the required `user_id` field to `MintTicketRequest`, `ListTicketsRequest`, and `GetMerklePathRequest`.

### Test coverage

Handler tests expanded to cover three paths per affected RPC:

- matching `user_id` → happy path
- mismatched `user_id` → `PERMISSION_DENIED` (repo lookup still happens, use case never invoked)
- missing `user_id` → `INVALID_ARGUMENT`

Existing `UNAUTHENTICATED` cases remain covered (middleware still fails first when JWT is absent).

## 📋 Commit Log

- `feat(ticket,entry)!: require user_id match on per-user RPCs`

## ✅ Self-Checklist

- [x] `make check` passes locally (gofmt, golangci-lint, schema-lint, modernizers, full test suite against docker-compose postgres)
- [x] Tests added for all three new auth paths per RPC
- [x] No changes to use case, repository, entity, or infrastructure layers — check lives entirely in the adapter
- [x] Unused code / no dead comments; doc comments updated on all three affected handlers

## 📸 Screenshots or Logs

<details>
<summary><code>make check</code> excerpt — all 0 issues, all packages ok</summary>

```
==> Checking gofmt...
==> Running golangci-lint...
golangci-lint run --timeout=3m --build-tags=integration ./...
0 issues.
bash scripts/lint-schema.sh
OK: Schema lint passed.
==> Checking go fix modernizers...
ok  	github.com/liverty-music/backend/internal/adapter/rpc	0.059s
...
```

</details>
