### PR TITLE
feat(webhook): add Zitadel Actions v2 handlers on internal-only port

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -61,11 +61,20 @@ func run() error {
 		return err
 	}
 
-	// Start server in a goroutine
-	errChan := make(chan error, 1)
+	// Start both the Connect-RPC server and the Zitadel webhook listener in
+	// separate goroutines. The webhook listener runs on a distinct port
+	// (default 9090) that is only exposed by the internal-only
+	// `server-webhook-svc` Service — not by the public Gateway.
+	errChan := make(chan error, 2)
 
 	go func() {
 		if err := app.Server.Start(); err != nil {
+			errChan <- err
+		}
+	}()
+
+	go func() {
+		if err := app.WebhookServer.Start(); err != nil {
 			errChan <- err
 		}
 	}()

--- a/internal/adapter/webhook/auto_verify_email_handler.go
+++ b/internal/adapter/webhook/auto_verify_email_handler.go
@@ -1,0 +1,91 @@
+package webhook
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	"github.com/pannpers/go-logging/logging"
+)
+
+// AutoVerifyEmailHandler serves `POST /auto-verify-email`. It is bound to the
+// Zitadel Actions v2 ExecutionRequest on
+// `/zitadel.user.v2.UserService/AddHumanUser`: Zitadel invokes it with the
+// intercepted gRPC request payload before creating the user, and expects the
+// handler to return a mutated payload that Zitadel then persists.
+//
+// This handler force-sets `email.is_verified = true` so Self-Registration via
+// passkey does not trap the user in the Hosted Login OTP step (the default
+// verification step Zitadel injects when SMTP is configured and the email is
+// unverified). See identity-management spec "Auto-Verify Email on
+// Self-Registration" for the full rationale.
+//
+// NOTE: The exact Zitadel v4 ExecutionRequest response shape for mutating an
+// AddHumanUser request is not fully public-documented as of 2026-04. This
+// handler returns a JSON merge-patch-style object whose shape matches the
+// request structure. At cutover time, verify the response shape against the
+// actual Zitadel v4 behavior and adjust if needed.
+type AutoVerifyEmailHandler struct {
+	validator *auth.WebhookValidator
+	logger    *logging.Logger
+}
+
+// NewAutoVerifyEmailHandler constructs a handler bound to the given validator.
+// The validator's `expectedAudience` MUST be the webhook-specific audience
+// registered on the Zitadel Target (e.g.
+// `urn:liverty-music:webhook:auto-verify-email`).
+func NewAutoVerifyEmailHandler(validator *auth.WebhookValidator, logger *logging.Logger) *AutoVerifyEmailHandler {
+	return &AutoVerifyEmailHandler{validator: validator, logger: logger}
+}
+
+// autoVerifyEmailResponse is the JSON merge-patch Zitadel applies to the
+// intercepted AddHumanUser request. Only `email.is_verified` is set; all
+// other fields pass through unchanged.
+type autoVerifyEmailResponse struct {
+	Email struct {
+		IsVerified bool `json:"is_verified"`
+	} `json:"email"`
+}
+
+// ServeHTTP implements http.Handler.
+func (h *AutoVerifyEmailHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.logger.Warn(ctx, "auto-verify-email: failed to read body", slog.String("error", err.Error()))
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if len(body) == 0 {
+		h.logger.Warn(ctx, "auto-verify-email: empty body")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	if _, err := h.validator.ValidateWebhookToken(ctx, string(body)); err != nil {
+		h.logger.Warn(ctx, "auto-verify-email: webhook JWT validation failed",
+			slog.String("error", err.Error()),
+		)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	resp := autoVerifyEmailResponse{}
+	resp.Email.IsVerified = true
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil && !errors.Is(err, http.ErrHandlerTimeout) {
+		h.logger.Error(ctx, "auto-verify-email: failed to encode response", fmt.Errorf("encode: %w", err))
+	}
+}

--- a/internal/adapter/webhook/auto_verify_email_handler_test.go
+++ b/internal/adapter/webhook/auto_verify_email_handler_test.go
@@ -1,0 +1,94 @@
+package webhook_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liverty-music/backend/internal/adapter/webhook"
+)
+
+const testAutoVerifyAud = "urn:liverty-music:webhook:auto-verify-email"
+
+func TestAutoVerifyEmailHandler_ValidJWT_ReturnsVerifiedTrue(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewAutoVerifyEmailHandler(
+		fixture.newValidator(t, testAutoVerifyAud),
+		newLogger(t),
+	)
+
+	body := fixture.signWebhookJWT(t, testIssuer, testAutoVerifyAud, map[string]any{
+		"request": map[string]any{
+			"email": map[string]any{
+				"address":     "alice@example.com",
+				"is_verified": false,
+			},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/auto-verify-email", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Email struct {
+			IsVerified bool `json:"is_verified"`
+		} `json:"email"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.True(t, resp.Email.IsVerified)
+}
+
+func TestAutoVerifyEmailHandler_WrongAudience_Returns401(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewAutoVerifyEmailHandler(
+		fixture.newValidator(t, testAutoVerifyAud),
+		newLogger(t),
+	)
+
+	// Re-use the pre-access-token audience — should be rejected.
+	body := fixture.signWebhookJWT(t, testIssuer, testPreAccessAud, map[string]any{
+		"request": map[string]any{"email": map[string]any{"address": "x@x"}},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/auto-verify-email", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestAutoVerifyEmailHandler_EmptyBody_Returns400(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewAutoVerifyEmailHandler(
+		fixture.newValidator(t, testAutoVerifyAud),
+		newLogger(t),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/auto-verify-email", bytes.NewBuffer(nil))
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAutoVerifyEmailHandler_GET_ReturnsMethodNotAllowed(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewAutoVerifyEmailHandler(
+		fixture.newValidator(t, testAutoVerifyAud),
+		newLogger(t),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auto-verify-email", nil)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	assert.Equal(t, http.MethodPost, rec.Header().Get("Allow"))
+}

--- a/internal/adapter/webhook/pre_access_token_handler.go
+++ b/internal/adapter/webhook/pre_access_token_handler.go
@@ -1,0 +1,128 @@
+// Package webhook provides HTTP handlers for Zitadel Actions v2 webhook
+// Targets. Handlers receive PAYLOAD_TYPE_JWT bodies — the request body is a
+// JWT whose claims carry the Actions v2 function payload (user, org, etc.).
+// Handlers verify the JWT against a distinct webhook audience and return a
+// response that Zitadel merges into the in-flight OIDC/gRPC flow.
+package webhook
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	"github.com/pannpers/go-logging/logging"
+)
+
+// PreAccessTokenHandler serves `POST /pre-access-token`. It is bound to the
+// Zitadel Actions v2 function `preaccesstoken`: Zitadel invokes it once per
+// token issuance before signing, and expects a JSON response with an
+// `append_claims` array whose entries are merged into the outgoing access
+// token's claim set.
+//
+// Per identity-management spec, every issued access token MUST carry the
+// authenticated user's `email` claim. This handler extracts `email` from the
+// webhook payload's `user.human.email` field and returns it as an
+// `append_claims` entry. Machine users (no `user.human.email`) are passed
+// through with an empty `append_claims` so token issuance still succeeds.
+type PreAccessTokenHandler struct {
+	validator *auth.WebhookValidator
+	logger    *logging.Logger
+}
+
+// NewPreAccessTokenHandler constructs a handler bound to the given validator.
+// The validator's `expectedAudience` MUST be the webhook-specific audience
+// registered on the Zitadel Target (e.g.
+// `urn:liverty-music:webhook:pre-access-token`).
+func NewPreAccessTokenHandler(validator *auth.WebhookValidator, logger *logging.Logger) *PreAccessTokenHandler {
+	return &PreAccessTokenHandler{validator: validator, logger: logger}
+}
+
+// preAccessTokenPayload captures the subset of the Actions v2 payload this
+// handler consumes. Unknown fields are ignored by json.Unmarshal, so the rest
+// of the payload (org, user_metadata, user_grants, …) does not need to be
+// modeled here.
+type preAccessTokenPayload struct {
+	User struct {
+		Human *struct {
+			Email string `json:"email"`
+		} `json:"human,omitempty"`
+	} `json:"user"`
+}
+
+// appendClaim is one entry of the `append_claims` response array.
+type appendClaim struct {
+	Key   string `json:"key"`
+	Value any    `json:"value"`
+}
+
+// preAccessTokenResponse is the JSON shape Zitadel expects back: it merges
+// the listed claims into the outgoing access token.
+type preAccessTokenResponse struct {
+	AppendClaims []appendClaim `json:"append_claims"`
+}
+
+// ServeHTTP implements http.Handler.
+func (h *PreAccessTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.logger.Warn(ctx, "pre-access-token: failed to read body", slog.String("error", err.Error()))
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if len(body) == 0 {
+		h.logger.Warn(ctx, "pre-access-token: empty body")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	token, err := h.validator.ValidateWebhookToken(ctx, string(body))
+	if err != nil {
+		h.logger.Warn(ctx, "pre-access-token: webhook JWT validation failed",
+			slog.String("error", err.Error()),
+		)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Private claims carry the Actions v2 payload. Round-trip through JSON
+	// so we can target nested `user.human.email` without walking the claim
+	// map manually.
+	rawClaims, err := json.Marshal(token.PrivateClaims())
+	if err != nil {
+		h.logger.Error(ctx, "pre-access-token: failed to marshal private claims", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	var payload preAccessTokenPayload
+	if err := json.Unmarshal(rawClaims, &payload); err != nil {
+		h.logger.Error(ctx, "pre-access-token: failed to unmarshal payload", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := preAccessTokenResponse{AppendClaims: []appendClaim{}}
+	if payload.User.Human != nil && payload.User.Human.Email != "" {
+		resp.AppendClaims = append(resp.AppendClaims, appendClaim{
+			Key:   "email",
+			Value: payload.User.Human.Email,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil && !errors.Is(err, http.ErrHandlerTimeout) {
+		// Response partially written; can't do much but log.
+		h.logger.Error(ctx, "pre-access-token: failed to encode response", fmt.Errorf("encode: %w", err))
+	}
+}

--- a/internal/adapter/webhook/pre_access_token_handler_test.go
+++ b/internal/adapter/webhook/pre_access_token_handler_test.go
@@ -1,0 +1,229 @@
+package webhook_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liverty-music/backend/internal/adapter/webhook"
+	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	"github.com/pannpers/go-logging/logging"
+)
+
+const (
+	testIssuer       = "https://auth.test.liverty-music.app"
+	testPreAccessAud = "urn:liverty-music:webhook:pre-access-token"
+)
+
+// jwksFixture wires up an in-memory RSA key + a JWKS endpoint backed by
+// httptest so a jwk.Cache (and therefore a JWTValidator + WebhookValidator)
+// can refresh against it.
+type jwksFixture struct {
+	server     *httptest.Server
+	privateKey *rsa.PrivateKey
+	jwks       jwk.Set
+}
+
+func newJWKSFixture(t *testing.T) *jwksFixture {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	public, err := jwk.FromRaw(privateKey.PublicKey)
+	require.NoError(t, err)
+	require.NoError(t, public.Set(jwk.KeyIDKey, "test-key-id"))
+	require.NoError(t, public.Set(jwk.AlgorithmKey, jwa.RS256))
+
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(public))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(set)
+	}))
+	t.Cleanup(server.Close)
+
+	return &jwksFixture{server: server, privateKey: privateKey, jwks: set}
+}
+
+// newValidator returns a WebhookValidator that expects the given `aud` and
+// trusts the fixture's JWKS endpoint via a freshly constructed JWTValidator.
+func (f *jwksFixture) newValidator(t *testing.T, expectedAud string) *auth.WebhookValidator {
+	t.Helper()
+	v, err := auth.NewJWTValidator(testIssuer, f.server.URL, 15*time.Minute)
+	require.NoError(t, err)
+	return v.NewWebhookValidator(expectedAud)
+}
+
+// signWebhookJWT builds a signed webhook JWT with the given issuer, audience,
+// and arbitrary private claims. Useful for building handler inputs.
+func (f *jwksFixture) signWebhookJWT(
+	t *testing.T,
+	issuer, audience string,
+	privateClaims map[string]any,
+) string {
+	t.Helper()
+	tok := jwt.New()
+	require.NoError(t, tok.Set(jwt.IssuerKey, issuer))
+	require.NoError(t, tok.Set(jwt.AudienceKey, []string{audience}))
+	require.NoError(t, tok.Set(jwt.IssuedAtKey, time.Now()))
+	require.NoError(t, tok.Set(jwt.ExpirationKey, time.Now().Add(1*time.Minute)))
+	for k, v := range privateClaims {
+		require.NoError(t, tok.Set(k, v))
+	}
+	// Set `kid` on the protected headers so the JWKS-based validator can
+	// look up the matching public key from the set.
+	protected := jws.NewHeaders()
+	require.NoError(t, protected.Set(jws.KeyIDKey, "test-key-id"))
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, f.privateKey, jws.WithProtectedHeaders(protected)))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+func newLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	l, err := logging.New()
+	require.NoError(t, err)
+	return l
+}
+
+func TestPreAccessTokenHandler_HumanUser_InjectsEmailClaim(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewPreAccessTokenHandler(
+		fixture.newValidator(t, testPreAccessAud),
+		newLogger(t),
+	)
+
+	body := fixture.signWebhookJWT(t, testIssuer, testPreAccessAud, map[string]any{
+		"user": map[string]any{
+			"human": map[string]any{
+				"email": "alice@example.com",
+			},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pre-access-token", bytes.NewBufferString(body)).
+		WithContext(context.Background())
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		AppendClaims []struct {
+			Key   string `json:"key"`
+			Value any    `json:"value"`
+		} `json:"append_claims"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.AppendClaims, 1)
+	assert.Equal(t, "email", resp.AppendClaims[0].Key)
+	assert.Equal(t, "alice@example.com", resp.AppendClaims[0].Value)
+}
+
+func TestPreAccessTokenHandler_MachineUser_OmitsEmailClaim(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewPreAccessTokenHandler(
+		fixture.newValidator(t, testPreAccessAud),
+		newLogger(t),
+	)
+
+	// Machine users have no `user.human` object at all.
+	body := fixture.signWebhookJWT(t, testIssuer, testPreAccessAud, map[string]any{
+		"user": map[string]any{
+			"id": "312909075212468632",
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pre-access-token", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		AppendClaims []any `json:"append_claims"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp.AppendClaims)
+}
+
+func TestPreAccessTokenHandler_WrongAudience_Returns401(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewPreAccessTokenHandler(
+		fixture.newValidator(t, testPreAccessAud),
+		newLogger(t),
+	)
+
+	// JWT claims a different webhook's audience — exactly the replay case
+	// the `aud` pin is meant to reject.
+	body := fixture.signWebhookJWT(t, testIssuer, "urn:liverty-music:webhook:auto-verify-email", map[string]any{
+		"user": map[string]any{
+			"human": map[string]any{"email": "mallory@example.com"},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pre-access-token", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestPreAccessTokenHandler_WrongIssuer_Returns401(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewPreAccessTokenHandler(
+		fixture.newValidator(t, testPreAccessAud),
+		newLogger(t),
+	)
+
+	body := fixture.signWebhookJWT(t, "https://evil.example.com", testPreAccessAud, map[string]any{
+		"user": map[string]any{"human": map[string]any{"email": "x@x"}},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pre-access-token", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestPreAccessTokenHandler_EmptyBody_Returns400(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewPreAccessTokenHandler(
+		fixture.newValidator(t, testPreAccessAud),
+		newLogger(t),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pre-access-token", bytes.NewBuffer(nil))
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPreAccessTokenHandler_GET_ReturnsMethodNotAllowed(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewPreAccessTokenHandler(
+		fixture.newValidator(t, testPreAccessAud),
+		newLogger(t),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/pre-access-token", nil)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	assert.Equal(t, http.MethodPost, rec.Header().Get("Allow"))
+}

--- a/internal/di/app.go
+++ b/internal/di/app.go
@@ -12,7 +12,12 @@ import (
 // Resource lifecycle is managed by the shutdown package; App itself
 // holds only the references needed by cmd/ entry points.
 type App struct {
-	Server          *server.ConnectServer
+	Server *server.ConnectServer
+	// WebhookServer handles Zitadel Actions v2 callbacks
+	// (/pre-access-token, /auto-verify-email) on a separate internal-only
+	// port. See `internal/infrastructure/server/webhook.go` for the
+	// port-isolation rationale.
+	WebhookServer   *server.WebhookServer
 	Logger          *logging.Logger
 	ShutdownTimeout time.Duration
 }

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
 	"github.com/liverty-music/backend/internal/adapter/rpc"
+	"github.com/liverty-music/backend/internal/adapter/webhook"
 	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/infrastructure/auth"
 	"github.com/liverty-music/backend/internal/infrastructure/blockchain/safe"
@@ -341,10 +342,27 @@ func InitializeApp(ctx context.Context) (*App, error) {
 
 	srv := server.NewConnectServer(cfg.Server, logger, authFunc, rateLimiter, healthHandler, longTimeoutHandlers, handlers...)
 
+	// Zitadel Actions v2 webhook listener — runs on a separate port so the
+	// webhook paths are unreachable via the public GKE Gateway. Validators
+	// share the JWKS cache with `jwtValidator` so there is exactly one
+	// refresh goroutine for all JWT verification.
+	preAccessTokenHandler := webhook.NewPreAccessTokenHandler(
+		jwtValidator.NewWebhookValidator(cfg.Webhook.PreAccessTokenAudience),
+		logger,
+	)
+	autoVerifyEmailHandler := webhook.NewAutoVerifyEmailHandler(
+		jwtValidator.NewWebhookValidator(cfg.Webhook.AutoVerifyEmailAudience),
+		logger,
+	)
+	webhookSrv := server.NewWebhookServer(cfg.Webhook, logger, map[string]http.Handler{
+		"/pre-access-token":  preAccessTokenHandler,
+		"/auto-verify-email": autoVerifyEmailHandler,
+	})
+
 	// Register shutdown phases.
-	// Drain: health → NOT_SERVING, then server drains in-flight requests,
+	// Drain: health → NOT_SERVING, then servers drain in-flight requests,
 	// then cache cleanup goroutine stops.
-	shutdown.AddDrainPhase(healthChecker, srv, rateLimiter, artistCache)
+	shutdown.AddDrainPhase(healthChecker, srv, webhookSrv, rateLimiter, artistCache)
 	shutdown.AddFlushPhase(publisher)
 	externalClosers := []io.Closer{lastfmClient, musicbrainzClient}
 	if sbtCloser != nil {
@@ -356,6 +374,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 
 	return &App{
 		Server:          srv,
+		WebhookServer:   webhookSrv,
 		Logger:          logger,
 		ShutdownTimeout: cfg.ShutdownTimeout,
 	}, nil

--- a/internal/infrastructure/auth/webhook_validator.go
+++ b/internal/infrastructure/auth/webhook_validator.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+)
+
+// WebhookValidator validates Zitadel Actions v2 webhook JWT bodies.
+//
+// Webhook JWTs are signed by the same Zitadel JWKS that signs end-user access
+// tokens, so signature + issuer + expiry checks alone cannot distinguish a
+// user-facing access token from a webhook payload. `expectedAudience` is the
+// decisive check — each webhook Target is registered with a distinct `aud`
+// value (e.g. `urn:liverty-music:webhook:pre-access-token`), and the
+// validator rejects any JWT whose audience list does not include that value.
+//
+// The JWKS cache is shared with the end-user JWTValidator rather than
+// duplicated, so there is exactly one refresh goroutine per instance.
+type WebhookValidator struct {
+	jwks             *jwk.Cache
+	jwksURL          string
+	acceptedIssuers  []string
+	expectedAudience string
+}
+
+// NewWebhookValidator returns a validator that shares the receiver's JWKS
+// cache and accepted-issuer set but pins `expectedAudience` (the `aud` claim)
+// to distinguish webhook JWTs from end-user access tokens.
+func (v *JWTValidator) NewWebhookValidator(expectedAudience string) *WebhookValidator {
+	return &WebhookValidator{
+		jwks:             v.jwks,
+		jwksURL:          v.jwksURL,
+		acceptedIssuers:  slices.Clone(v.acceptedIssuers),
+		expectedAudience: expectedAudience,
+	}
+}
+
+// ValidateWebhookToken verifies the JWT string and returns the parsed token
+// (claims included). Unlike end-user access-token validation, `sub`, `email`,
+// and `name` claims are not required — webhook payload user data is extracted
+// from application-specific private claims by the caller.
+//
+// The validator enforces: signature (via JWKS), issuer in accepted set,
+// expiry not past, audience matches `expectedAudience`.
+func (v *WebhookValidator) ValidateWebhookToken(
+	ctx context.Context,
+	tokenString string,
+) (jwt.Token, error) {
+	keySet, err := v.jwks.Get(ctx, v.jwksURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get JWKS: %w", err)
+	}
+
+	token, err := jwt.Parse(
+		[]byte(tokenString),
+		jwt.WithKeySet(keySet),
+		jwt.WithValidate(true),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to validate webhook token: %w", err)
+	}
+
+	if !slices.Contains(v.acceptedIssuers, token.Issuer()) {
+		return nil, fmt.Errorf("webhook token issuer %q is not in the accepted issuers list", token.Issuer())
+	}
+
+	if !slices.Contains(token.Audience(), v.expectedAudience) {
+		return nil, fmt.Errorf("webhook token audience %v does not contain expected %q", token.Audience(), v.expectedAudience)
+	}
+
+	return token, nil
+}

--- a/internal/infrastructure/server/webhook.go
+++ b/internal/infrastructure/server/webhook.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/liverty-music/backend/pkg/config"
+	"github.com/pannpers/go-logging/logging"
+)
+
+// WebhookServer is a dedicated HTTP server for Zitadel Actions v2 webhooks.
+//
+// It listens on a separate port from the Connect-RPC server so the webhook
+// paths are physically absent from the public Connect-RPC listener, and
+// therefore unreachable via the GKE Gateway / `server-svc` HTTPRoute.
+// The expected topology is: a new internal-only `server-webhook-svc`
+// ClusterIP Service targets this listener directly, and only Zitadel pods
+// call it over in-cluster DNS.
+//
+// The listener has NO authn.Middleware — incoming requests carry their own
+// PAYLOAD_TYPE_JWT body which each handler verifies via WebhookValidator.
+type WebhookServer struct {
+	server  *http.Server
+	logger  *logging.Logger
+	address string
+}
+
+// NewWebhookServer registers the given handlers on a new mux and wraps it
+// with sensible HTTP server defaults. `handlers` maps URL path → handler.
+func NewWebhookServer(
+	cfg config.WebhookSettings,
+	logger *logging.Logger,
+	handlers map[string]http.Handler,
+) *WebhookServer {
+	mux := http.NewServeMux()
+	for path, handler := range handlers {
+		mux.Handle(path, handler)
+	}
+
+	address := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+	return &WebhookServer{
+		server: &http.Server{
+			Addr:              address,
+			Handler:           mux,
+			ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+			ReadTimeout:       cfg.ReadTimeout,
+			IdleTimeout:       cfg.IdleTimeout,
+		},
+		logger:  logger,
+		address: address,
+	}
+}
+
+// Start begins listening. Blocks until the server is stopped; returns
+// http.ErrServerClosed on graceful shutdown.
+func (s *WebhookServer) Start() error {
+	s.logger.Info(context.Background(), fmt.Sprintf("Webhook Server starting on %s", s.address))
+	return s.server.ListenAndServe()
+}
+
+// webhookDrainTimeout bounds how long Shutdown waits for in-flight webhook
+// calls to complete before killing the server. Webhook handlers are fast
+// (single DB-free JWT verify + JSON encode), so 10s is generous.
+const webhookDrainTimeout = 10 * time.Second
+
+// Close gracefully stops the server. Implements io.Closer so the server can
+// be registered with the shutdown package's Drain phase alongside the
+// Connect-RPC server.
+func (s *WebhookServer) Close() error {
+	if s.server == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), webhookDrainTimeout)
+	defer cancel()
+	s.logger.Info(ctx, "draining Webhook server", slog.Duration("timeout", webhookDrainTimeout))
+	return s.server.Shutdown(ctx)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,11 @@ type ServerConfig struct {
 	// Server settings (port, host, timeouts, CORS)
 	Server ServerSettings `envconfig:""`
 
+	// Webhook settings — dedicated listener for Zitadel Actions v2 webhooks.
+	// Runs on a separate port from the public Connect-RPC server so the
+	// webhook paths are physically unreachable via the GKE Gateway.
+	Webhook WebhookSettings `envconfig:""`
+
 	// JWT configuration
 	JWT JWTConfig `envconfig:""`
 
@@ -345,6 +350,41 @@ type JWTConfig struct {
 	JWKSRefreshInterval time.Duration `envconfig:"JWKS_REFRESH_INTERVAL" default:"15m"`
 }
 
+// WebhookSettings is the HTTP server configuration for the Zitadel Actions v2
+// webhook listener. It runs on a separate port and Service (`server-webhook-svc`)
+// from the public Connect-RPC server so the webhook paths are physically
+// absent from the GKE Gateway / `server-svc` HTTPRoute.
+//
+// `PreAccessTokenAudience` and `AutoVerifyEmailAudience` pin the `aud` claim
+// each handler's WebhookValidator requires. They MUST match the values
+// registered on the corresponding Zitadel Targets in Pulumi, otherwise every
+// webhook call fails 401 (signature OK, audience mismatch).
+type WebhookSettings struct {
+	// Port to listen on for webhook traffic.
+	Port int `envconfig:"WEBHOOK_PORT" default:"9090"`
+
+	// Host to bind to.
+	Host string `envconfig:"WEBHOOK_HOST" default:"0.0.0.0"`
+
+	// Read header timeout.
+	ReadHeaderTimeout time.Duration `envconfig:"WEBHOOK_READ_HEADER_TIMEOUT" default:"500ms"`
+
+	// Read timeout.
+	ReadTimeout time.Duration `envconfig:"WEBHOOK_READ_TIMEOUT" default:"5s"`
+
+	// Idle timeout.
+	IdleTimeout time.Duration `envconfig:"WEBHOOK_IDLE_TIMEOUT" default:"30s"`
+
+	// PreAccessTokenAudience is the expected `aud` claim for webhook JWTs
+	// delivered to `POST /pre-access-token`. Must match the audience
+	// registered on the corresponding Zitadel Target.
+	PreAccessTokenAudience string `envconfig:"WEBHOOK_PRE_ACCESS_TOKEN_AUDIENCE" default:"urn:liverty-music:webhook:pre-access-token"`
+
+	// AutoVerifyEmailAudience is the expected `aud` claim for webhook JWTs
+	// delivered to `POST /auto-verify-email`.
+	AutoVerifyEmailAudience string `envconfig:"WEBHOOK_AUTO_VERIFY_EMAIL_AUDIENCE" default:"urn:liverty-music:webhook:auto-verify-email"`
+}
+
 // Loadable constrains the config types that can be loaded from environment variables.
 type Loadable interface {
 	ServerConfig | JobConfig | ConsumerConfig
@@ -429,6 +469,22 @@ func (c *ServerConfig) Validate() error {
 
 	if c.JWT.JWKSRefreshInterval <= 0 {
 		return fmt.Errorf("JWT JWKS refresh interval must be positive")
+	}
+
+	if c.Webhook.Port <= 0 || c.Webhook.Port > 65535 {
+		return fmt.Errorf("invalid webhook port: %d", c.Webhook.Port)
+	}
+
+	if c.Webhook.Port == c.Server.Port {
+		return fmt.Errorf("webhook port %d must differ from server port to keep webhook listener off the public Gateway", c.Webhook.Port)
+	}
+
+	if c.Webhook.PreAccessTokenAudience == "" {
+		return fmt.Errorf("webhook pre-access-token audience is required")
+	}
+
+	if c.Webhook.AutoVerifyEmailAudience == "" {
+		return fmt.Errorf("webhook auto-verify-email audience is required")
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,6 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// validWebhookSettings returns a WebhookSettings that passes Validate.
+// Port is 9090 (distinct from the default server port of 8080) and both
+// audiences are the production defaults.
+func validWebhookSettings() WebhookSettings {
+	return WebhookSettings{
+		Port:                    9090,
+		PreAccessTokenAudience:  "urn:liverty-music:webhook:pre-access-token",
+		AutoVerifyEmailAudience: "urn:liverty-music:webhook:auto-verify-email",
+	}
+}
+
 func TestLoad_ServerConfig(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -64,6 +75,15 @@ func TestLoad_ServerConfig(t *testing.T) {
 					IdleTimeout:           3 * time.Second,
 					AllowedOrigins:        nil,
 					RateLimit:             RateLimitConfig{AuthRPS: 100, AuthBurst: 200, AnonRPS: 30, AnonBurst: 60},
+				},
+				Webhook: WebhookSettings{
+					Port:                    9090,
+					Host:                    "0.0.0.0",
+					ReadHeaderTimeout:       500 * time.Millisecond,
+					ReadTimeout:             5 * time.Second,
+					IdleTimeout:             30 * time.Second,
+					PreAccessTokenAudience:  "urn:liverty-music:webhook:pre-access-token",
+					AutoVerifyEmailAudience: "urn:liverty-music:webhook:auto-verify-email",
 				},
 				GCP: GCPConfig{
 					ProjectID:               "test-project",
@@ -148,6 +168,15 @@ func TestLoad_ServerConfig(t *testing.T) {
 					AllowedOrigins:        nil,
 					RateLimit:             RateLimitConfig{AuthRPS: 100, AuthBurst: 200, AnonRPS: 30, AnonBurst: 60},
 				},
+				Webhook: WebhookSettings{
+					Port:                    9090,
+					Host:                    "0.0.0.0",
+					ReadHeaderTimeout:       500 * time.Millisecond,
+					ReadTimeout:             5 * time.Second,
+					IdleTimeout:             30 * time.Second,
+					PreAccessTokenAudience:  "urn:liverty-music:webhook:pre-access-token",
+					AutoVerifyEmailAudience: "urn:liverty-music:webhook:auto-verify-email",
+				},
 				GCP: GCPConfig{
 					ProjectID:               "custom-project",
 					Location:                "us-central1",
@@ -230,8 +259,9 @@ func TestServerConfig_Validate(t *testing.T) {
 					},
 					Logging: LoggingConfig{Level: "info", Format: "json"},
 				},
-				Server: ServerSettings{Port: 8080, AllowedOrigins: []string{"http://localhost:9000"}},
-				NATS:   NATSConfig{URL: "nats://nats.nats.svc.cluster.local:4222"},
+				Server:  ServerSettings{Port: 8080, AllowedOrigins: []string{"http://localhost:9000"}},
+				Webhook: validWebhookSettings(),
+				NATS:    NATSConfig{URL: "nats://nats.nats.svc.cluster.local:4222"},
 				JWT: JWTConfig{
 					Issuer:              "https://test-issuer.com",
 					JWKSRefreshInterval: 15 * time.Minute,
@@ -297,7 +327,8 @@ func TestServerConfig_Validate(t *testing.T) {
 					Database:    DatabaseConfig{Port: 5432},
 					Logging:     LoggingConfig{Level: "info", Format: "json"},
 				},
-				Server: ServerSettings{Port: 8080},
+				Server:  ServerSettings{Port: 8080},
+				Webhook: validWebhookSettings(),
 				JWT: JWTConfig{
 					Issuer:              "https://test-issuer.com",
 					JWKSRefreshInterval: 15 * time.Minute,


### PR DESCRIPTION
## Summary

Implement the backend side of the Zitadel Actions v2 webhook contract defined in [specification#420](https://github.com/liverty-music/specification/pull/420): two HTTP handlers (`/pre-access-token`, `/auto-verify-email`) served on a new internal-only listener on port **9090**, authenticated via JWT body verification with per-endpoint `aud` pinning.

Paired with [cloud-provisioning#199](https://github.com/liverty-music/cloud-provisioning/pull/199) which provisions the Zitadel infra shells; the cluster-side wiring (expose port 9090 on the backend Deployment, create `server-webhook-svc` Service) ships next.

## What's in scope

**Handlers (`internal/adapter/webhook/`):**
- `PreAccessTokenHandler` — invoked by Zitadel on every access-token issuance. Extracts `user.human.email` from the webhook JWT payload and returns `{"append_claims":[{"key":"email","value":<email>}]}` so the backend's existing `JWTValidator` (which requires `email`) can verify the resulting end-user access token. Machine users (no `user.human`) get an empty `append_claims`.
- `AutoVerifyEmailHandler` — invoked on the intercepted `AddHumanUser` gRPC request during Self-Registration. Returns a JSON merge patch that forces `email.is_verified = true` so the Hosted Login OTP step is skipped for passkey-only users.
- Both handlers: POST-only, reject empty bodies (400), reject unauthenticated or wrong-audience JWTs (401).

**Validator (`internal/infrastructure/auth/webhook_validator.go`):**
- `WebhookValidator` constructed via `(*JWTValidator).NewWebhookValidator(aud)`. Shares the existing `jwk.Cache` and accepted-issuer set but pins `aud` to a webhook-specific value. End-user access tokens (with the OIDC audience) are rejected even though signature + issuer + expiry all pass.

**Listener (`internal/infrastructure/server/webhook.go`):**
- `WebhookServer` — dedicated `net/http` server on `:9090`. No `authn.Middleware` (body-JWT verification replaces header-Bearer auth). Registered in the Drain shutdown phase alongside the Connect server.

**Wiring:**
- `WebhookSettings` in `pkg/config` (port, timeouts, two audience values). `Validate()` rejects a port matching the Connect-RPC port.
- `internal/di/provider.go` instantiates both handlers + the webhook server.
- `cmd/api/main.go` starts both servers concurrently.

## Audience values (must match Zitadel Target config)

- `/pre-access-token` → `urn:liverty-music:webhook:pre-access-token`
- `/auto-verify-email` → `urn:liverty-music:webhook:auto-verify-email`

Overridable via `WEBHOOK_PRE_ACCESS_TOKEN_AUDIENCE` / `WEBHOOK_AUTO_VERIFY_EMAIL_AUDIENCE` env vars.

## Test plan

- [x] `go test ./internal/adapter/webhook/...` — handler unit tests (human email, machine user, wrong aud, wrong issuer, empty body, wrong method).
- [x] `go test ./internal/infrastructure/auth/...` — unchanged JWTValidator tests still pass.
- [x] `go test ./pkg/config/...` — config Load + Validate with WebhookSettings.
- [x] `make lint` — golangci-lint clean.
- [x] `go build ./...` — clean build.
- [ ] CI (post-push) — Go CI + lint.
- [ ] Post-merge end-to-end: Zitadel Target configured with the correct audience hits `http://server-webhook-svc.backend.svc.cluster.local/pre-access-token`, receives 200, and the end-user access token carries `email`.

## Out of scope (deferred to cutover / cleanup PRs)

- `OIDC_ISSUER_URL` flip to `auth.dev.liverty-music.app` (cutover PR).
- Atlas migration to truncate user-scoped tables (cutover PR).
- Cluster manifests exposing port 9090 + `server-webhook-svc` Service (cloud-provisioning follow-up PR).
- Playwright `.auth/` storage state regeneration (cutover PR).
