### PR TITLE
feat(db): TRUNCATE user-scoped tables for self-hosted Zitadel cutover

### DIFF
--- a/k8s/atlas/base/kustomization.yaml
+++ b/k8s/atlas/base/kustomization.yaml
@@ -65,3 +65,4 @@ configMapGenerator:
   - migrations/20260319120000_create_ticket_emails.sql
   - migrations/20260324120000_consolidate_ticket_email_status.sql
   - migrations/20260406120000_add_venue_listed_name_index.sql
+  - migrations/20260427081142_truncate_users_for_zitadel_migration.sql

--- a/k8s/atlas/base/migrations/20260427081142_truncate_users_for_zitadel_migration.sql
+++ b/k8s/atlas/base/migrations/20260427081142_truncate_users_for_zitadel_migration.sql
@@ -1,0 +1,40 @@
+-- Wipe user-scoped data ahead of cutting the dev OIDC issuer over from
+-- Zitadel Cloud (`dev-svijfm.us1.zitadel.cloud`) to the self-hosted Zitadel
+-- instance (`auth.dev.liverty-music.app`).
+--
+-- The new instance assigns Zitadel-internal `sub` claims that have no
+-- relation to the Cloud tenant's IDs, so any existing `users` row whose
+-- `external_id` points at a Cloud-tenant `sub` would orphan: the same human
+-- logging in via the new instance would be issued a different `sub` and
+-- therefore appear as a different user, while the original row would remain
+-- forever unmapped. Rather than rewrite identifiers (which has no source of
+-- truth that maps Cloud `sub` ↔ self-hosted `sub`), the OpenSpec
+-- `self-hosted-zitadel` change explicitly accepts dropping all dev users
+-- and their dependent rows. See OpenSpec D9 for the full rationale.
+--
+-- TRUNCATE on `users` cascades through every FK with `ON DELETE CASCADE`:
+--
+--     users
+--      ├── followed_artists  (user_id)
+--      ├── tickets           (user_id)
+--      ├── ticket_journeys   (user_id)
+--      ├── ticket_emails     (user_id)
+--      └── push_subscriptions(user_id)
+--
+-- Event-level tables (`merkle_tree`, `nullifiers`) and the `homes` lookup
+-- table are intentionally NOT truncated:
+--
+--   - `merkle_tree` / `nullifiers` are keyed by `event_id`. Surviving rows
+--     are inert lookup data; they don't reference users directly and
+--     remain valid for any future ticket minted against the same event.
+--   - `homes` is a dimension table of geographic regions, referenced by
+--     users via `home_id` (not the other way round). Its rows are
+--     reusable across users; truncating them would force re-resolution
+--     of every region centroid post-cutover for no benefit.
+--
+-- This migration is reversible only as a no-op — an empty table cannot
+-- have its rows restored. Rollback of the broader Zitadel cutover
+-- (revert PR cloud-provisioning#209 + revert frontend GH secrets) leaves
+-- these tables empty; existing dev users do not return.
+
+TRUNCATE TABLE users CASCADE;

--- a/k8s/atlas/base/migrations/atlas.sum
+++ b/k8s/atlas/base/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:P3U7EvBOMU9e+5aycwCWpbEpEG+xV8Kgb4RefxZsDoY=
+h1:TXGfPw6Ol1E/AF9MwMS5E84WS3aEyKFnKJdckAdOOgE=
 20250726000000_bootstrap_app_schema.sql h1:nKAFSMmbY+9pdhajenyx25jK6t5SAHc5x/JpNt9EgFM=
 20250726081442_initial_schema.sql h1:cWOx1AMHpgE784lJBtFmEj1oXRBkeqv56bKw1XV8ThI=
 20250726101741_add_foreign_key_to_posts.sql h1:Yq6yocwX7/UQHaMneA16MoHzImLamXDe7PvGYiGWudw=
@@ -51,3 +51,4 @@ h1:P3U7EvBOMU9e+5aycwCWpbEpEG+xV8Kgb4RefxZsDoY=
 20260319120000_create_ticket_emails.sql h1:6lgvs8T5Gtr+Sjo5kjVZXJ33uwvAkiDRKZdjXMbUttg=
 20260324120000_consolidate_ticket_email_status.sql h1:BL0f7xaE4MXzF6H29RJ25sAkcr2pS3g3edRlv7zEy50=
 20260406120000_add_venue_listed_name_index.sql h1:Ufe7vfOM9zLLK9hixGFJrgCr+u7FNeId7s1I9hv2wNU=
+20260427081142_truncate_users_for_zitadel_migration.sql h1:E4C/6gWXCrFqaXPT/kZ+12+or3iIWrITtLGIRHKj9vI=


### PR DESCRIPTION
## Summary

Adds Atlas migration `20260427081142_truncate_users_for_zitadel_migration` that wipes `users` and its FK-cascading dependents in preparation for cutting the dev OIDC issuer from Zitadel Cloud to the self-hosted instance at `https://auth.dev.liverty-music.app`.

This is **PR A** of the 3-PR cutover sequence (per OpenSpec change `self-hosted-zitadel`):

| PR | Repo | Status |
|---|---|---|
| **A** | **backend** | **This PR** — Atlas TRUNCATE for `users` + dependents |
| B | cloud-provisioning | [#209 (draft)](https://github.com/liverty-music/cloud-provisioning/pull/209) — Pulumi domain swap + ActionsV2 + backend issuer flip |
| C | frontend | (post-cutover) Playwright `.auth/` regen against new issuer |

## Why TRUNCATE rather than re-key

Existing `users` rows reference Cloud-tenant `sub` claims via `users.external_id`. The self-hosted instance assigns its own unrelated `sub` values, with no source of truth that maps Cloud `sub` ↔ self-hosted `sub` for the same human. A row-rewrite migration would have nothing valid to rewrite to.

OpenSpec change `self-hosted-zitadel` ([D9](https://github.com/liverty-music/specification/blob/self-hosted-zitadel/openspec/changes/self-hosted-zitadel/design.md#d9)) explicitly accepts dropping all dev users and their dependent rows: dev has no users outside the team and test fixtures, so the data loss is the intended outcome of the cutover.

## Cascade chain

`TRUNCATE TABLE users CASCADE;` propagates through every `ON DELETE CASCADE` FK:

```
users
 ├── followed_artists   (user_id)
 ├── tickets            (user_id)
 ├── ticket_journeys    (user_id)
 ├── ticket_emails      (user_id)
 └── push_subscriptions (user_id)
```

## Tables NOT truncated (intentional)

| Table | Why kept |
|---|---|
| `merkle_tree` | Event-keyed (FK to `events`, not `users`). Inert ZKP lookup data; remains valid for future tickets at the same event. |
| `nullifiers` | Event-keyed. Used-nullifier set per event; no user reference. |
| `homes` | Dimension table of geographic regions. Users reference `home_id`, not vice versa. Reusable across users. Truncating would force re-resolution of every region centroid post-cutover for no benefit. |

## Reversibility

**None.** Atlas migrations are forward-only in this repo, and TRUNCATE has no reverse-migration analogue (you can't restore truncated rows). The rollback path of the broader cutover (revert [cloud-provisioning#209](https://github.com/liverty-music/cloud-provisioning/pull/209) + revert frontend GH Actions secrets to the Cloud issuer) leaves these tables empty; existing dev users do not return.

This is documented in:
- OpenSpec [D9](https://github.com/liverty-music/specification/blob/self-hosted-zitadel/openspec/changes/self-hosted-zitadel/design.md#d9) (data wipe rationale)
- OpenSpec [D10](https://github.com/liverty-music/specification/blob/self-hosted-zitadel/openspec/changes/self-hosted-zitadel/design.md#d10) (Cloud tenant cooldown for issuer rollback only)
- The migration's inline comment block.

## Test plan

- [x] `atlas migrate hash --dir 'file://k8s/atlas/base/migrations'` — `atlas.sum` regenerated.
- [x] `atlas migrate validate --dir 'file://k8s/atlas/base/migrations'` — clean.
- [x] `make lint` — passes (no Go code changed; gofmt + golangci-lint clean).
- [x] New migration registered in `k8s/atlas/base/kustomization.yaml` under `configMapGenerator.files`.
- [ ] Post-merge: ArgoCD's `backend-migrations` Application syncs → Atlas Operator applies `TRUNCATE TABLE users CASCADE` against dev Cloud SQL → next backend pod restart sees an empty `users` table.

## Merge ordering

This PR can be merged in any order relative to [cloud-provisioning#209](https://github.com/liverty-music/cloud-provisioning/pull/209), but the runbook in #209 schedules them sequentially:

```
1. ArgoCD pause auto-sync on backend / frontend (manual)
2. Pulumi state cleanup (manual, see #209 PR description)
3. Merge THIS PR (backend Atlas TRUNCATE)
4. Merge #209 (cloud-provisioning Pulumi cutover + backend issuer flip)
5. Frontend GH secrets update (manual)
6. ArgoCD resume auto-sync on backend (manual)
7. Merge frontend Playwright .auth/ regen PR
8. Smoke test
```

## Out of scope

- Staging / prod cutover (D10: dev-only).
- `users.external_id` schema changes — column type stays `TEXT`, suitable for both Cloud snowflake and self-hosted snowflake IDs.
