### PR TITLE
fix(webhook): drop iss check from WebhookValidator

### DIFF
--- a/internal/adapter/webhook/pre_access_token_handler_test.go
+++ b/internal/adapter/webhook/pre_access_token_handler_test.go
@@ -181,24 +181,6 @@ func TestPreAccessTokenHandler_WrongAudience_Returns401(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
-func TestPreAccessTokenHandler_WrongIssuer_Returns401(t *testing.T) {
-	fixture := newJWKSFixture(t)
-	handler := webhook.NewPreAccessTokenHandler(
-		fixture.newValidator(t, testPreAccessAud),
-		newLogger(t),
-	)
-
-	body := fixture.signWebhookJWT(t, "https://evil.example.com", testPreAccessAud, map[string]any{
-		"user": map[string]any{"human": map[string]any{"email": "x@x"}},
-	})
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/pre-access-token", bytes.NewBufferString(body))
-	handler.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusUnauthorized, rec.Code)
-}
-
 func TestPreAccessTokenHandler_EmptyBody_Returns400(t *testing.T) {
 	fixture := newJWKSFixture(t)
 	handler := webhook.NewPreAccessTokenHandler(

--- a/internal/infrastructure/auth/webhook_validator.go
+++ b/internal/infrastructure/auth/webhook_validator.go
@@ -11,41 +11,52 @@ import (
 
 // WebhookValidator validates Zitadel Actions v2 webhook JWT bodies.
 //
-// Webhook JWTs are signed by the same Zitadel JWKS that signs end-user access
-// tokens, so signature + issuer + expiry checks alone cannot distinguish a
-// user-facing access token from a webhook payload. `expectedAudience` is the
-// decisive check — each webhook Target is registered with a distinct `aud`
-// value (e.g. `urn:liverty-music:webhook:pre-access-token`), and the
-// validator rejects any JWT whose audience list does not include that value.
+// Webhook JWTs are signed by the same Zitadel JWKS that signs end-user
+// access tokens, so signature verification alone proves the JWT
+// originated from our Zitadel instance (only Zitadel holds the private
+// key). The decisive boundary that distinguishes a webhook payload from
+// a user-facing access token is `expectedAudience` — each webhook
+// Target is registered with a distinct `aud` value (e.g.
+// `urn:liverty-music:webhook:pre-access-token`), and the validator
+// rejects any JWT whose audience list does not include that value.
+//
+// `iss` is intentionally NOT enforced. Empirically, Zitadel v4 webhook
+// JWTs do not include an `iss` claim (or include it as an empty
+// string), and the upstream community Go webhook implementation
+// (xianyu-one/zitadel-mapping) also relies on signature + custom
+// validation without checking `iss`. Adding an issuer check here is
+// redundant once signature verification has succeeded — there is no
+// other Zitadel instance that could have signed a token verifiable
+// against our JWKS.
 //
 // The JWKS cache is shared with the end-user JWTValidator rather than
 // duplicated, so there is exactly one refresh goroutine per instance.
 type WebhookValidator struct {
 	jwks             *jwk.Cache
 	jwksURL          string
-	acceptedIssuers  []string
 	expectedAudience string
 }
 
 // NewWebhookValidator returns a validator that shares the receiver's JWKS
-// cache and accepted-issuer set but pins `expectedAudience` (the `aud` claim)
-// to distinguish webhook JWTs from end-user access tokens.
+// cache but pins `expectedAudience` (the `aud` claim) to distinguish
+// webhook JWTs from end-user access tokens.
 func (v *JWTValidator) NewWebhookValidator(expectedAudience string) *WebhookValidator {
 	return &WebhookValidator{
 		jwks:             v.jwks,
 		jwksURL:          v.jwksURL,
-		acceptedIssuers:  slices.Clone(v.acceptedIssuers),
 		expectedAudience: expectedAudience,
 	}
 }
 
-// ValidateWebhookToken verifies the JWT string and returns the parsed token
-// (claims included). Unlike end-user access-token validation, `sub`, `email`,
-// and `name` claims are not required — webhook payload user data is extracted
-// from application-specific private claims by the caller.
+// ValidateWebhookToken verifies the JWT string and returns the parsed
+// token (claims included). Unlike end-user access-token validation,
+// `sub`, `email`, `name`, and `iss` claims are not required — webhook
+// payload user data is extracted from application-specific private
+// claims by the caller.
 //
-// The validator enforces: signature (via JWKS), issuer in accepted set,
-// expiry not past, audience matches `expectedAudience`.
+// The validator enforces: signature (via JWKS), expiry not past, and
+// audience matches `expectedAudience`. See the type-level doc comment
+// for why `iss` is intentionally not enforced.
 func (v *WebhookValidator) ValidateWebhookToken(
 	ctx context.Context,
 	tokenString string,
@@ -62,10 +73,6 @@ func (v *WebhookValidator) ValidateWebhookToken(
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate webhook token: %w", err)
-	}
-
-	if !slices.Contains(v.acceptedIssuers, token.Issuer()) {
-		return nil, fmt.Errorf("webhook token issuer %q is not in the accepted issuers list", token.Issuer())
 	}
 
 	if !slices.Contains(token.Audience(), v.expectedAudience) {


### PR DESCRIPTION
## Summary

Drop the `iss` claim check from `WebhookValidator`. The Zitadel v4 Actions v2 webhook `PAYLOAD_TYPE_JWT` JWTs do not include an `iss` claim, so the previous validator rejected every webhook call:

```
auto-verify-email: webhook JWT validation failed
error: webhook token issuer "" is not in the accepted issuers list
```

This was blocking the self-hosted Zitadel cutover — every sign-up attempt (`AddHumanUser`) triggered the `auto-verify-email` Execution with `interruptOnError: true`, which the validator aborted.

## Why this is safe

1. **Signature verification proves origin**: webhook JWTs are signed by our Zitadel instance's JWKS (the same set that signs end-user access tokens). Once `jwt.Parse(... WithKeySet(keySet) ...)` succeeds, no other party could have minted that token.
2. **`aud` remains the security boundary**: each webhook Target is registered with a distinct `aud` value (e.g. `urn:liverty-music:webhook:pre-access-token`), and the validator continues to reject any JWT whose audience does not match. This is what distinguishes a webhook payload from a user-facing access token.
3. **Reference implementation parity**: the community Go webhook reference ([xianyu-one/zitadel-mapping](https://github.com/xianyu-one/zitadel-mapping/blob/main/main.go)) also relies on signature + custom checks, without an `iss` enforcement.

## Changes

- `internal/infrastructure/auth/webhook_validator.go`:
  - Remove `acceptedIssuers` field from `WebhookValidator` struct
  - Drop the iss check from `ValidateWebhookToken`
  - Doc-comment the rationale (struct-level + method-level)
- `internal/adapter/webhook/pre_access_token_handler_test.go`:
  - Remove `TestPreAccessTokenHandler_WrongIssuer_Returns401` — its premise (wrong iss = 401) no longer holds. `WrongAudience` test remains and continues to enforce the audience boundary.

## Test plan

- [x] `go test ./internal/adapter/webhook/... ./internal/infrastructure/auth/...` passes
- [x] `make lint` clean
- [ ] After merge: backend image rebuilds + ArgoCD sync rolls out new pod
- [ ] After rollout: sign-up flow at `https://dev.liverty-music.app` completes (new user created, email auto-verified, JWT issued with email claim)

## Risk

- **Reduced defense-in-depth**: with `iss` not enforced, a JWT signed by our Zitadel instance for a different purpose could in theory be replayed at our webhook endpoint. But:
  - Distinct `aud` values per Target prevent replay across our own webhooks
  - End-user access tokens have `aud` = OIDC client ID, never the webhook URN, so they cannot be replayed at the webhook
  - The signature key is private to Zitadel; an external attacker cannot forge a JWT regardless of `iss` or `aud`
- **Forward compatibility**: if Zitadel adds an `iss` claim to webhook JWTs in a future version, our validator will silently accept it. We can re-introduce the check if and when an authoritative `iss` value gets documented upstream.
