### PR TITLE
fix(zitadel): use Management v1 _resend_verification for ResendEmailVerification

### DIFF
--- a/internal/infrastructure/zitadel/email_verifier.go
+++ b/internal/infrastructure/zitadel/email_verifier.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/middleware"
-	userv2 "github.com/zitadel/zitadel-go/v3/pkg/client/user/v2"
 	zitadelconn "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel"
+	mgmtpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	userpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user/v2"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -26,28 +26,44 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 )
 
-// emailCodeClient is the subset of the Zitadel UserServiceClient that
-// EmailVerifier needs. Extracting this narrow interface allows unit testing
-// without a real gRPC connection.
-type emailCodeClient interface {
+// emailSendClient is the subset of the v2 UserServiceClient used by
+// SendVerification (initial verification email at sign-up time).
+type emailSendClient interface {
 	SendEmailCode(ctx context.Context, in *userpb.SendEmailCodeRequest, opts ...grpc.CallOption) (*userpb.SendEmailCodeResponse, error)
-	ResendEmailCode(ctx context.Context, in *userpb.ResendEmailCodeRequest, opts ...grpc.CallOption) (*userpb.ResendEmailCodeResponse, error)
+}
+
+// emailResendClient is the subset of the v1 ManagementServiceClient used by
+// ResendVerification (post-sign-up "Resend verification email" button).
+//
+// v1 Management ResendHumanEmailVerification is used instead of v2
+// ResendEmailCode because v2 only resends an EXISTING code: if SMTP was
+// inactive at sign-up time (the §13.16 cutover incident path), no code was
+// ever generated and v2 fails with `Code is empty (EMAIL-5w5ilin4yt)`.
+// v1 generates a fresh code AND sends the email, which matches the
+// user-intent of the Settings-page "Resend verification email" button.
+// See `cutover-warning-fixes` design doc D1 for the full rationale.
+type emailResendClient interface {
+	ResendHumanEmailVerification(ctx context.Context, in *mgmtpb.ResendHumanEmailVerificationRequest, opts ...grpc.CallOption) (*mgmtpb.ResendHumanEmailVerificationResponse, error)
 }
 
 // Compile-time interface compliance check.
 var _ usecase.EmailVerifier = (*EmailVerifier)(nil)
 
-// EmailVerifier calls the Zitadel User Service v2 API to send and resend
-// email verification codes.
+// EmailVerifier calls Zitadel APIs to send and resend email verification
+// codes. SendVerification uses the v2 User Service; ResendVerification uses
+// the v1 Management Service (see emailResendClient docstring).
 type EmailVerifier struct {
-	client emailCodeClient
-	logger *logging.Logger
+	sendClient   emailSendClient
+	resendClient emailResendClient
+	logger       *logging.Logger
 }
 
 // NewEmailVerifier creates a new EmailVerifier that authenticates to the
-// Zitadel API using a machine user's private key JWT.
+// Zitadel API using a machine user's private key JWT. A single underlying
+// gRPC connection is shared between the v2 User Service and v1 Management
+// Service stubs, so there is exactly one auth/refresh goroutine per process.
 //
-// issuerURL is the OIDC issuer URL (e.g., "https://dev-svijfm.us1.zitadel.cloud").
+// issuerURL is the OIDC issuer URL (e.g., "https://auth.dev.liverty-music.app").
 // keyPath is the file path to the machine key JSON.
 // opts are additional zitadel connection options (e.g., WithInsecure for testing).
 func NewEmailVerifier(ctx context.Context, issuerURL, keyPath string, logger *logging.Logger, opts ...zitadelconn.Option) (*EmailVerifier, error) {
@@ -66,7 +82,7 @@ func NewEmailVerifier(ctx context.Context, issuerURL, keyPath string, logger *lo
 	}
 	connOpts = append(connOpts, opts...)
 
-	userClient, err := userv2.NewClient(
+	conn, err := zitadelconn.NewConnection(
 		ctx,
 		issuerURL,
 		apiEndpoint,
@@ -74,18 +90,19 @@ func NewEmailVerifier(ctx context.Context, issuerURL, keyPath string, logger *lo
 		connOpts...,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("create zitadel user client: %w", err)
+		return nil, fmt.Errorf("create zitadel connection: %w", err)
 	}
 
 	return &EmailVerifier{
-		client: userClient,
-		logger: logger,
+		sendClient:   userpb.NewUserServiceClient(conn.ClientConn),
+		resendClient: mgmtpb.NewManagementServiceClient(conn.ClientConn),
+		logger:       logger,
 	}, nil
 }
 
 // SendVerification triggers a verification email for the given Zitadel user.
 func (v *EmailVerifier) SendVerification(ctx context.Context, externalID string) error {
-	_, err := v.client.SendEmailCode(ctx, &userpb.SendEmailCodeRequest{
+	_, err := v.sendClient.SendEmailCode(ctx, &userpb.SendEmailCodeRequest{
 		UserId: externalID,
 	})
 	if err != nil {
@@ -98,13 +115,16 @@ func (v *EmailVerifier) SendVerification(ctx context.Context, externalID string)
 }
 
 // ResendVerification resends a verification email for the given Zitadel user.
+// Always succeeds for users whose email is unverified, including the case
+// where SMTP was inactive at sign-up time and no prior code exists — the v1
+// Management endpoint generates a fresh code and sends the email.
 // Returns FailedPrecondition if the email is already verified.
 func (v *EmailVerifier) ResendVerification(ctx context.Context, externalID string) error {
-	_, err := v.client.ResendEmailCode(ctx, &userpb.ResendEmailCodeRequest{
+	_, err := v.resendClient.ResendHumanEmailVerification(ctx, &mgmtpb.ResendHumanEmailVerificationRequest{
 		UserId: externalID,
 	})
 	if err != nil {
-		v.logger.Error(ctx, "failed to resend email code", err,
+		v.logger.Error(ctx, "failed to resend email verification", err,
 			slog.String("external_id", externalID),
 		)
 		if st, ok := status.FromError(err); ok && st.Code() == grpccodes.FailedPrecondition {

--- a/internal/infrastructure/zitadel/email_verifier_test.go
+++ b/internal/infrastructure/zitadel/email_verifier_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	zitadelconn "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel"
+	mgmtpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	userpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user/v2"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
@@ -20,15 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// stubUserServiceServer implements only the two email code methods under test.
-// All other UserServiceServer methods return Unimplemented via the embedded type.
+// stubUserServiceServer implements only the v2 UserService method used by
+// SendVerification. All other methods return Unimplemented via the embedded
+// type.
 type stubUserServiceServer struct {
 	userpb.UnimplementedUserServiceServer
-	sendErr   error
-	resendErr error
+	sendErr error
 
-	lastSendUserID   string
-	lastResendUserID string
+	lastSendUserID string
 }
 
 func (s *stubUserServiceServer) SendEmailCode(_ context.Context, in *userpb.SendEmailCodeRequest) (*userpb.SendEmailCodeResponse, error) {
@@ -39,23 +39,41 @@ func (s *stubUserServiceServer) SendEmailCode(_ context.Context, in *userpb.Send
 	return &userpb.SendEmailCodeResponse{}, nil
 }
 
-func (s *stubUserServiceServer) ResendEmailCode(_ context.Context, in *userpb.ResendEmailCodeRequest) (*userpb.ResendEmailCodeResponse, error) {
+// stubManagementServiceServer implements only the v1 Management method used
+// by ResendVerification. The post-cutover ResendVerification path uses v1
+// Management `ResendHumanEmailVerification` rather than v2
+// `ResendEmailCode` — see emailResendClient docstring in email_verifier.go.
+type stubManagementServiceServer struct {
+	mgmtpb.UnimplementedManagementServiceServer
+	resendErr error
+
+	lastResendUserID string
+}
+
+func (s *stubManagementServiceServer) ResendHumanEmailVerification(_ context.Context, in *mgmtpb.ResendHumanEmailVerificationRequest) (*mgmtpb.ResendHumanEmailVerificationResponse, error) {
 	s.lastResendUserID = in.UserId
 	if s.resendErr != nil {
 		return nil, s.resendErr
 	}
-	return &userpb.ResendEmailCodeResponse{}, nil
+	return &mgmtpb.ResendHumanEmailVerificationResponse{}, nil
 }
 
-// startUserServiceServer starts a real gRPC server on a random local port and
-// returns the "host:port" address, mirroring the pattern used in the Zitadel SDK
-// own tests (pkg/client/zitadel/client_test.go).
-func startUserServiceServer(t *testing.T, srv *stubUserServiceServer) string {
+// startZitadelStubServer starts a real gRPC server on a random local port
+// with both v2 UserService and v1 ManagementService registered, mirroring
+// the real Zitadel API surface. The same listener handles both because the
+// EmailVerifier shares one underlying connection between its two service
+// stubs.
+func startZitadelStubServer(t *testing.T, userSrv *stubUserServiceServer, mgmtSrv *stubManagementServiceServer) string {
 	t.Helper()
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	s := grpc.NewServer()
-	userpb.RegisterUserServiceServer(s, srv)
+	if userSrv != nil {
+		userpb.RegisterUserServiceServer(s, userSrv)
+	}
+	if mgmtSrv != nil {
+		mgmtpb.RegisterManagementServiceServer(s, mgmtSrv)
+	}
 	go func() { _ = s.Serve(lis) }()
 	t.Cleanup(s.GracefulStop)
 	return lis.Addr().String()
@@ -129,7 +147,7 @@ func TestEmailVerifier_SendVerification(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			stub := &stubUserServiceServer{sendErr: tt.sendErr}
-			addr := startUserServiceServer(t, stub)
+			addr := startZitadelStubServer(t, stub, nil)
 			v, logBuf := newTestVerifier(t, addr)
 
 			err := v.SendVerification(context.Background(), tt.args.externalID)
@@ -165,7 +183,7 @@ func TestEmailVerifier_ResendVerification(t *testing.T) {
 		resendErr error
 		wantErr   error
 		wantInLog string
-		check     func(t *testing.T, stub *stubUserServiceServer)
+		check     func(t *testing.T, stub *stubManagementServiceServer)
 	}{
 		{
 			name:      "success emits INFO log",
@@ -173,9 +191,24 @@ func TestEmailVerifier_ResendVerification(t *testing.T) {
 			resendErr: nil,
 			wantErr:   nil,
 			wantInLog: "email verification resent",
-			check: func(t *testing.T, stub *stubUserServiceServer) {
+			check: func(t *testing.T, stub *stubManagementServiceServer) {
 				t.Helper()
 				assert.Equal(t, "user-123", stub.lastResendUserID)
+			},
+		},
+		{
+			// §13.16 incident path: user signed up while SMTP was inactive,
+			// so no verification code was ever generated. The v2 endpoint
+			// fails this case with `Code is empty (EMAIL-5w5ilin4yt)`; the
+			// v1 Management endpoint generates a fresh code and succeeds.
+			name:      "succeeds when no prior verification code exists (post-SMTP-inactive sign-up)",
+			args:      args{externalID: "user-no-prior-code"},
+			resendErr: nil,
+			wantErr:   nil,
+			wantInLog: "email verification resent",
+			check: func(t *testing.T, stub *stubManagementServiceServer) {
+				t.Helper()
+				assert.Equal(t, "user-no-prior-code", stub.lastResendUserID)
 			},
 		},
 		{
@@ -183,36 +216,36 @@ func TestEmailVerifier_ResendVerification(t *testing.T) {
 			args:      args{externalID: "verified-user"},
 			resendErr: grpcstatus.Error(grpccodes.FailedPrecondition, "email already verified"),
 			wantErr:   apperr.ErrFailedPrecondition,
-			wantInLog: "failed to resend email code",
+			wantInLog: "failed to resend email verification",
 		},
 		{
 			name:      "gRPC unavailable emits ERROR log and wraps as internal",
 			args:      args{externalID: "user-456"},
 			resendErr: grpcstatus.Error(grpccodes.Unavailable, "connection refused"),
 			wantErr:   apperr.ErrInternal,
-			wantInLog: "failed to resend email code",
+			wantInLog: "failed to resend email verification",
 		},
 		{
 			name:      "gRPC internal emits ERROR log and wraps as internal",
 			args:      args{externalID: "user-789"},
 			resendErr: grpcstatus.Error(grpccodes.Internal, "something went wrong"),
 			wantErr:   apperr.ErrInternal,
-			wantInLog: "failed to resend email code",
+			wantInLog: "failed to resend email verification",
 		},
 		{
 			name:      "gRPC permission denied emits ERROR log and wraps as internal",
 			args:      args{externalID: "no-perms"},
 			resendErr: grpcstatus.Error(grpccodes.PermissionDenied, "insufficient permissions"),
 			wantErr:   apperr.ErrInternal,
-			wantInLog: "failed to resend email code",
+			wantInLog: "failed to resend email verification",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			stub := &stubUserServiceServer{resendErr: tt.resendErr}
-			addr := startUserServiceServer(t, stub)
+			stub := &stubManagementServiceServer{resendErr: tt.resendErr}
+			addr := startZitadelStubServer(t, nil, stub)
 			v, logBuf := newTestVerifier(t, addr)
 
 			err := v.ResendVerification(context.Background(), tt.args.externalID)


### PR DESCRIPTION
## Summary

Fixes the user-visible "Failed to send verification email" bug that surfaces on the frontend Settings page for users who signed up during the SMTP-inactive cutover window. Switches the backend's `ResendEmailVerification` RPC from Zitadel's User v2 `ResendEmailCode` to Management v1 `ResendHumanEmailVerification`.

This is **PR-A2 of the openspec change [`cutover-warning-fixes`](../specification/openspec/changes/cutover-warning-fixes)**.

## Why the v2 endpoint was wrong

User v2 `ResendEmailCode` only resends an **existing** code. If SMTP was inactive at the moment a user signed up (the §13.16 incident path during the cutover), no code was ever generated and the v2 endpoint fails with:

```
Code is empty (EMAIL-5w5ilin4yt)
```

The frontend then surfaces this as a generic "Failed to send verification email" error, even though the user is doing exactly what the button label says they should.

Management v1 `ResendHumanEmailVerification` generates a fresh code **and** sends the email in one call. That matches user intent. The trade-off — relying on a v1 endpoint when v2 exists — is documented in `design.md` D1: v1 Management is Zitadel's most-used and most-stable surface, with no announced deprecation horizon at v4.

## What changes

- **`internal/infrastructure/zitadel/email_verifier.go`**: `EmailVerifier` now holds two narrow client interfaces — `emailSendClient` (v2 `SendEmailCode`) and `emailResendClient` (v1 `ResendHumanEmailVerification`). Both stubs are constructed from a single `*zitadel.Connection` so there's one auth/refresh goroutine per process. `NewEmailVerifier` shifts from the wrapped `userv2.NewClient` to the lower-level `zitadelconn.NewConnection` to enable the shared connection.
- **`SendVerification` is unchanged behaviorally** — still uses v2 `SendEmailCode`. Initial sign-up sends are not affected by the v2 "code is empty" trap because the code is generated by the same call.
- **`internal/infrastructure/zitadel/email_verifier_test.go`**: stub gRPC server now registers both `UserServiceServer` and `ManagementServiceServer` on a single in-process listener, matching the real Zitadel API surface. Adds a new test case (`succeeds when no prior verification code exists`) that pins down the §13.16 incident path.

## Public surface

The Connect-RPC contract `liverty_music.rpc.user.v1.UserService/ResendEmailVerification` is unchanged. Callers, return types, error mappings (`FailedPrecondition` for already-verified), and the per-user rate limit are all preserved. Frontend code does not need to change.

## Test plan

- [x] `make lint` (gofmt + golangci-lint) — green.
- [x] `make lint-schema` — green.
- [x] `make modernize` — green.
- [x] `make test` — `internal/infrastructure/zitadel` and `internal/adapter/rpc` packages pass; full backend test suite green against local Postgres.
- [x] `make check` — full pre-commit pipeline green.
- [ ] CI green on this branch.
- [ ] Post-deploy verification in dev: log in as a user who signed up during the SMTP-inactive window (see `troubleshooting/2026-04-30-cutover` notes) and confirm the Settings page "Resend verification email" button completes successfully and an email arrives.

## Dependency note

This PR is independent of PR-A1 (#290) at the file level — the two PRs touch disjoint files and can land in either order. They are sequenced PR-A1 → PR-A2 in `tasks.md` purely by blast radius (subtraction-only first), not by code dependency.
