### PR TITLE
feat(config): accept ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH with fallback (PR 2/11 of rename-zitadel-machine-keys)

### DIFF
--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -134,10 +134,12 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	artistNameResolutionUC := usecase.NewArtistNameResolutionUseCase(artistRepo, musicbrainzClient, logger)
 	artistImageSyncUC := usecase.NewArtistImageSyncUseCase(artistRepo, fanarttvClient, logoFetcher, logger)
 
-	// Infrastructure - Zitadel API client (optional, nil in local dev)
+	// Infrastructure - Zitadel API client (optional, nil in local dev).
+	// ResolveZitadelMachineKeyPath prefers the new env var with fallback
+	// to the legacy one during the rename-zitadel-machine-keys migration.
 	var emailVerifier usecase.EmailVerifier
-	if cfg.ZitadelMachineKeyPath != "" {
-		ev, err := infrazitadel.NewEmailVerifier(ctx, cfg.ZitadelDomain, cfg.ZitadelMachineKeyPath, logger)
+	if zitadelKeyPath := cfg.ResolveZitadelMachineKeyPath(); zitadelKeyPath != "" {
+		ev, err := infrazitadel.NewEmailVerifier(ctx, cfg.ZitadelDomain, zitadelKeyPath, logger)
 		if err != nil {
 			return nil, fmt.Errorf("create zitadel email verifier: %w", err)
 		}

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -169,10 +169,12 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		return nil, fmt.Errorf("create messaging publisher: %w", err)
 	}
 
-	// Infrastructure - Zitadel API client (optional, nil in local dev)
+	// Infrastructure - Zitadel API client (optional, nil in local dev).
+	// ResolveZitadelMachineKeyPath prefers the new env var with fallback
+	// to the legacy one during the rename-zitadel-machine-keys migration.
 	var emailVerifier usecase.EmailVerifier
-	if cfg.ZitadelMachineKeyPath != "" {
-		ev, err := infrazitadel.NewEmailVerifier(ctx, cfg.JWT.Issuer, cfg.ZitadelMachineKeyPath, logger)
+	if zitadelKeyPath := cfg.ResolveZitadelMachineKeyPath(); zitadelKeyPath != "" {
+		ev, err := infrazitadel.NewEmailVerifier(ctx, cfg.JWT.Issuer, zitadelKeyPath, logger)
 		if err != nil {
 			return nil, fmt.Errorf("create zitadel email verifier: %w", err)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,10 +92,42 @@ type ServerConfig struct {
 	// ZitadelMachineKeyPath is the file path to the Zitadel machine user's
 	// private key JSON. When empty, the Zitadel API client is disabled
 	// (email verification features are unavailable).
+	//
+	// Deprecated: prefer ZitadelMachineKeyForBackendAppPath. This field
+	// is kept as a fallback during the GSM secret rename transition
+	// (openspec change rename-zitadel-machine-keys). Removed in PR 5
+	// of the migration after a 7-day soak.
 	ZitadelMachineKeyPath string `envconfig:"ZITADEL_MACHINE_KEY_PATH"`
+
+	// ZitadelMachineKeyForBackendAppPath is the file path to the
+	// `backend-app` Zitadel MachineUser's private key JSON, mounted
+	// from GSM secret `zitadel-machine-key-for-backend-app`. When both
+	// this and ZitadelMachineKeyPath are empty, the Zitadel API client
+	// is disabled. When both are set, the new path wins.
+	ZitadelMachineKeyForBackendAppPath string `envconfig:"ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH"`
 
 	// LastFM API Key
 	LastFMAPIKey string `envconfig:"LASTFM_API_KEY"`
+}
+
+// resolveZitadelMachineKeyPath picks the new path if set, otherwise
+// falls back to the legacy one. Empty result means "no client".
+//
+// The fallback exists only during the rename-zitadel-machine-keys
+// migration and is removed in PR 5 of the migration.
+func resolveZitadelMachineKeyPath(newPath, oldPath string) string {
+	if newPath != "" {
+		return newPath
+	}
+	return oldPath
+}
+
+// ResolveZitadelMachineKeyPath returns the file path to use for the
+// Zitadel API client, preferring ZitadelMachineKeyForBackendAppPath
+// and falling back to ZitadelMachineKeyPath. Returns the empty string
+// if neither is set, which the caller treats as "disable the client".
+func (c *ServerConfig) ResolveZitadelMachineKeyPath() string {
+	return resolveZitadelMachineKeyPath(c.ZitadelMachineKeyForBackendAppPath, c.ZitadelMachineKeyPath)
 }
 
 // JobConfig is the configuration for batch job workloads (e.g., concert-discovery CronJob).
@@ -132,10 +164,30 @@ type ConsumerConfig struct {
 	// ZitadelMachineKeyPath is the file path to the Zitadel machine user's
 	// private key JSON. When empty, the email verification consumer skips
 	// processing with a warning.
+	//
+	// Deprecated: prefer ZitadelMachineKeyForBackendAppPath. This field
+	// is kept as a fallback during the GSM secret rename transition
+	// (openspec change rename-zitadel-machine-keys). Removed in PR 5
+	// of the migration after a 7-day soak.
 	ZitadelMachineKeyPath string `envconfig:"ZITADEL_MACHINE_KEY_PATH"`
+
+	// ZitadelMachineKeyForBackendAppPath is the file path to the
+	// `backend-app` Zitadel MachineUser's private key JSON, mounted
+	// from GSM secret `zitadel-machine-key-for-backend-app`. When both
+	// this and ZitadelMachineKeyPath are empty, the email verification
+	// consumer is disabled. When both are set, the new path wins.
+	ZitadelMachineKeyForBackendAppPath string `envconfig:"ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH"`
 
 	// FanartTV API Key for artist image resolution
 	FanartTVAPIKey string `envconfig:"FANARTTV_API_KEY"`
+}
+
+// ResolveZitadelMachineKeyPath returns the file path to use for the
+// Zitadel API client, preferring ZitadelMachineKeyForBackendAppPath
+// and falling back to ZitadelMachineKeyPath. Returns the empty string
+// if neither is set, which the caller treats as "disable the client".
+func (c *ConsumerConfig) ResolveZitadelMachineKeyPath() string {
+	return resolveZitadelMachineKeyPath(c.ZitadelMachineKeyForBackendAppPath, c.ZitadelMachineKeyPath)
 }
 
 // ServerSettings represents HTTP server settings (port, host, timeouts, CORS).

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -400,3 +400,68 @@ func TestConsumerConfig_Validate(t *testing.T) {
 		assert.Error(t, cfg.Validate())
 	})
 }
+
+// TestResolveZitadelMachineKeyPath covers the fallback used by the
+// DI wiring during the rename-zitadel-machine-keys migration:
+//   - prefer the new env var (ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH)
+//   - fall back to the legacy one (ZITADEL_MACHINE_KEY_PATH)
+//   - return "" when neither is set (treated as "client disabled")
+//
+// The same logic is shared by ServerConfig and ConsumerConfig via a
+// package-private helper, so both methods are exercised.
+func TestResolveZitadelMachineKeyPath(t *testing.T) {
+	const (
+		newPath = "/secrets/zitadel/zitadel-machine-key-for-backend-app.json"
+		oldPath = "/secrets/zitadel/zitadel-machine-key.json"
+	)
+
+	tests := []struct {
+		name string
+		new  string
+		old  string
+		want string
+	}{
+		{
+			name: "new set, old empty: uses new",
+			new:  newPath,
+			old:  "",
+			want: newPath,
+		},
+		{
+			name: "new empty, old set: falls back to old",
+			new:  "",
+			old:  oldPath,
+			want: oldPath,
+		},
+		{
+			name: "both set: new wins",
+			new:  newPath,
+			old:  oldPath,
+			want: newPath,
+		},
+		{
+			name: "neither set: empty (caller disables client)",
+			new:  "",
+			old:  "",
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &ServerConfig{
+				ZitadelMachineKeyForBackendAppPath: tc.new,
+				ZitadelMachineKeyPath:              tc.old,
+			}
+			assert.Equal(t, tc.want, server.ResolveZitadelMachineKeyPath(),
+				"ServerConfig should resolve identically")
+
+			consumer := &ConsumerConfig{
+				ZitadelMachineKeyForBackendAppPath: tc.new,
+				ZitadelMachineKeyPath:              tc.old,
+			}
+			assert.Equal(t, tc.want, consumer.ResolveZitadelMachineKeyPath(),
+				"ConsumerConfig should resolve identically")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Step 2 of the **backend-app key rename arc** in openspec change `rename-zitadel-machine-keys`. Backend now reads the Zitadel MachineUser private key path from a new env var with explicit fallback to the legacy one:

- `ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH` (new, preferred)
- `ZITADEL_MACHINE_KEY_PATH` (legacy fallback)

Both `ServerConfig` and `ConsumerConfig` grow a new `ZitadelMachineKeyForBackendAppPath` field plus a `ResolveZitadelMachineKeyPath()` method that picks new over legacy. DI wiring (`internal/di/provider.go` + `internal/di/consumer.go`) reads through the method, simplifying the call sites.

## Why this is code-only

No env var is set yet in any environment. Once this PR ships:

- `ResolveZitadelMachineKeyPath()` returns `cfg.ZitadelMachineKeyPath` for every existing pod (only legacy is set in current configmaps).
- Behavior is byte-identical to the pre-PR code — same env var read, same file mounted, same `infrazitadel.NewEmailVerifier` call.

PR 3 of the migration (cloud-provisioning) sets the new env var via configmap and mounts the new file path. From that point forward, `ResolveZitadelMachineKeyPath()` returns the new path. PR 5 removes the legacy field after a 7-day soak.

## Migration context

```
PR 1 (merged) ──► PR 2 (this PR) ──► PR 3 ──► PR 4 ──► [7-day soak] ──► PR 5 ──► PR 6
 GSM new secret    backend reads     k8s     drop     soak               drop     destroy
                   new w/ fallback   cutover old GSM                     legacy   old GSM
                                              writer                     field    resource
                   ↑ here
```

Depends on:
- PR 1 (cp#240, merged) — the new GSM secret it provisions is what PR 3 mounts.
- Parallel-safe with PRs 7, 8 (Pulumi URN rename arc) and PRs 10, 11, 12 (pulumi-admin arc).

## Test plan

- [ ] `make lint` — passes locally (verified, 0 issues).
- [ ] `make check` — runs at pre-commit via the PreToolUse hook (verified — commit ec259bd succeeded).
- [ ] `go test ./pkg/config/...` — all 4 new `TestResolveZitadelMachineKeyPath` cases pass (verified).
- [ ] Both `ServerConfig` and `ConsumerConfig` go through the same helper, so the method tests exercise both wirings.
- [ ] After merge, ArgoCD syncs the backend Deployments; pods restart and continue serving identically (no env var change yet).
- [ ] Smoke test in dev: backend → Zitadel API call (e.g., `ResendEmailVerification`) still works because `ResolveZitadelMachineKeyPath()` returns the legacy path until PR 3 lands.

## Implementation note

The legacy fields keep their `envconfig:"ZITADEL_MACHINE_KEY_PATH"` tag — `envconfig` allows multiple fields to share the same env var name (we don't have a collision since they live on different config types). The `Deprecated:` Go doc tag flags the field for the next code-cleanup PR (PR 5) and surfaces in IDE tooling.
