### PR TITLE
ci(deploy): add release-tag prod build path + Atlas prod overlay

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,12 @@
 name: Deploy Backend
 
+# Dual trigger per OpenSpec change `prepare-prod-service-in`:
+#  - push to main      -> dev build, dev AR (liverty-music-dev/backend)
+#  - release published -> prod build, prod AR (liverty-music-prod/backend)
+#
+# The `paths:` filter only applies to `push` events. Release events fire on
+# any published Release regardless of file diff — the deploy step is always
+# desired for a Release cut.
 on:
   push:
     branches:
@@ -10,8 +17,8 @@ on:
       - 'go.sum'
       - 'Dockerfile'
       - '.github/workflows/deploy.yml'
-
-
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,9 +26,18 @@ concurrency:
 
 jobs:
   build-and-push:
+    # Defensive guard: only fire on the two supported events. Any other event
+    # type (workflow_dispatch, schedule, etc.) is rejected without running.
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'release' && github.event.action == 'published')
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref == 'refs/heads/main' && 'dev' || 'prod' }}
+      # release -> prod; push to main -> dev. The `prod` environment binds
+      # vars.PROJECT_ID=liverty-music-prod / vars.WORKLOAD_IDENTITY_PROVIDER /
+      # vars.SERVICE_ACCOUNT scoped to the prod project (managed by Pulumi's
+      # GitHubRepositoryComponent — see cloud-provisioning/src/github/).
+      name: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
     permissions:
       contents: read
       id-token: write
@@ -63,6 +79,18 @@ jobs:
       - name: Set Image URI
         run: echo "IMAGE_URI=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ matrix.image.name }}" >> $GITHUB_ENV
 
+      # Dev tag set: :latest (consumed by ArgoCD Image Updater for dev
+      # auto-rollout) + :sha (immutable digest pointer) + :main (branch ref).
+      # Prod is forbidden from using :latest per the `prod-image-pipeline`
+      # spec — release builds use :<tag> + :sha only.
+      - name: Set Image Tags (dev path)
+        if: github.event_name == 'push'
+        run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main" >> $GITHUB_ENV
+
+      - name: Set Image Tags (prod path)
+        if: github.event_name == 'release'
+        run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:${{ github.event.release.tag_name }},${{ env.IMAGE_URI }}:${{ github.sha }}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -72,6 +100,6 @@ jobs:
           context: .
           target: ${{ matrix.image.target }}
           push: true
-          tags: ${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main
+          tags: ${{ env.IMAGE_TAGS }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}

--- a/k8s/atlas/overlays/prod/kustomization.yaml
+++ b/k8s/atlas/overlays/prod/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod Atlas migration overlay. Per OpenSpec change `prepare-prod-service-in`
+# §4, this directory's presence is the precondition for ArgoCD's
+# `backend-migrations` Application (declared in
+# cloud-provisioning/k8s/argocd-apps/prod/backend-migrations.yaml) to sync —
+# without it the app reports `Status=Unknown (ComparisonError)`.
+#
+# Divergence from dev (mirroring dev's deployed config exactly except for
+# host):
+#   - `spec.credentials.host` → prod Cloud SQL PSC DNS
+#     (`298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog`)
+#   - No `devURL` / `devDB` patch: those are dev-only schema-diffing knobs
+#     used by `atlas migrate diff`. Prod runs `atlas migrate apply` only —
+#     no devDB pod is needed.
+#
+# Migration source: the same `configMapGenerator` from `../../base` is
+# reused unchanged. Both envs apply identical forward migrations from the
+# same `migrations/` directory; no fork.
+#
+# Authenticated user: `postgres` (inherited from base). Atlas Operator
+# requires superuser privileges to GRANT/REVOKE on the `app` schema; the
+# `postgres-admin-password` is delivered via the ESO-synced
+# `atlas-db-credentials` Secret in the `atlas-operator` namespace (provisioned
+# by Pulumi in `liverty-music-prod`).
+#
+# First-apply safety: per task §4.5 (operator-attended), run
+# `atlas migrate diff` against the prod DB before merging this overlay to
+# confirm zero destructive operations. The prod `liverty-music` database
+# is freshly bootstrapped (no pre-existing `app.*` tables) so the full
+# forward migration set is expected.
+
+resources:
+- ../../base
+
+patches:
+- target:
+    group: db.atlasgo.io
+    version: v1alpha1
+    kind: AtlasMigration
+    name: backend-migration
+  patch: |
+    - op: replace
+      path: /spec/credentials/host
+      value: "298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog"


### PR DESCRIPTION
## Summary

Implements specification PR liverty-music/specification#473 (`prepare-prod-service-in`) tasks **§3** + **§4**:

1. **§3** Backend prod build pipeline: extend `.github/workflows/deploy.yml` with a release-tag-triggered prod path. Push-to-main keeps building dev images (`liverty-music-dev/backend/*:latest,:sha,:main`); a published GitHub Release fires the prod path (`liverty-music-prod/backend/*:<tag>,:sha`).
2. **§4** Backend Atlas migration prod overlay: add `k8s/atlas/overlays/prod/kustomization.yaml`. Closes the precondition gap for the `backend-migrations` ArgoCD Application (declared in `cloud-provisioning/k8s/argocd-apps/prod/backend-migrations.yaml`) which has been reporting `Status=Unknown (ComparisonError)` because the path didn't exist.

## What changes

### `.github/workflows/deploy.yml`
- Dual trigger: `push: branches:[main]` (dev) + `release: types:[published]` (prod). Paths filter applies only to push events.
- Job-level `environment:` selector: `release` → `prod`, push → `dev`. Picks up Pulumi-managed GitHub Environment vars (`vars.PROJECT_ID=liverty-music-prod`, `vars.WORKLOAD_IDENTITY_PROVIDER=projects/108947861615/.../github-provider`, `vars.SERVICE_ACCOUNT=github-actions@liverty-music-prod.iam`).
- Defensive `if:` guard at job level — only fires on the two supported event combinations.
- Image tag set is event-conditional via two mutually-exclusive `Set Image Tags` steps:
  - dev: `:latest,:<sha>,:main` (preserved — ArgoCD Image Updater for dev relies on `:latest`).
  - prod: `:<release-tag>,:<sha>` (no `:latest` per the `prod-image-pipeline` spec).

### `k8s/atlas/overlays/prod/kustomization.yaml` (new)
- Imports `../../base` (same `configMapGenerator` for migration SQL files; no fork from dev).
- Patches `spec.credentials.host` to the prod Cloud SQL PSC DNS `298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog`.
- Does NOT patch `devURL` / `devDB` — those are dev-only schema-diff knobs used by `atlas migrate diff`. Prod runs `migrate apply` only.
- Authenticated user: `postgres` (inherited from base), matching dev's deployed pattern. Atlas Operator requires superuser privileges to GRANT/REVOKE on the `app` schema; the `postgres-admin-password` is delivered via the ESO-synced `atlas-db-credentials` Secret in the prod `atlas-operator` namespace (provisioned by Pulumi in `liverty-music-prod`).

## Verification

- [x] `make lint` passes (gofmt + golangci-lint, 0 issues — non-Go changes only).
- [x] `kubectl kustomize k8s/atlas/overlays/prod` renders 0-exit. Rendered `AtlasMigration` has:
  ```yaml
  spec:
    credentials:
      database: liverty-music
      host: 298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog
      parameters:
        search_path: app
        sslmode: require
      port: 5432
      scheme: postgres
      user: postgres
  ```
  Plus the migration ConfigMap (53 SQL files inherited from base, no fork).
- [x] No `devURL` / `devDB` in rendered output.

## Sequencing

Per the specification's design D7 migration plan:
- This PR is item C (backend) — can run in parallel with item B (cloud-provisioning ApplicationOidc, separate PR).
- After this PR merges: **§5** operator action — cut a backend Release tag (e.g., `v1.0.0`) on `main` to trigger the prod path. The four images (`server`, `consumer`, `concert-discovery`, `artist-image-sync`) push to `liverty-music-prod/backend/`.
- The prod overlay's first apply against prod Cloud SQL should be operator-monitored. The prod `liverty-music` database is freshly bootstrapped on 2026-05-12 with no pre-existing `app.*` tables, so a full forward apply is expected (no destructive operations).

## Out of scope

- Cutting the actual `v1.0.0` Release tag — operator-attended (§5).
- The `atlas migrate diff` dry-run against prod Cloud SQL (§4.5) — operator-attended.
- The prod kustomize overlay image-pinning to prod AR (specification §9) — separate cloud-provisioning PR, blocked on this PR's Release tag cut producing the SHA the overlay pins.

## Related

- Spec PR: liverty-music/specification#473 (merged 2026-05-15)
- Companion PR (cloud-provisioning, in parallel): coming separately for §1 (`webFrontendClientId` + `productOrgId` stack outputs)

## Test plan

- [ ] CI green
- [ ] claude-review feedback addressed
- [ ] Reviewer sign-off
