### PR TITLE
ci(deploy): require release.target_commitish == main for prod path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,16 +26,18 @@ concurrency:
 
 jobs:
   build-and-push:
-    # Defensive guard: only fire on the two supported events AND require
-    # both to originate from `main`. `target_commitish` is the branch/SHA
-    # the Release was created against (set by `--target` on
-    # `gh release create`); without this check a Release published from a
-    # feature branch tag would push to prod AR. Mirrors the fix applied
-    # in liverty-music/frontend#356 (review id 3248455636).
+    # Defensive guard layer 1 (event filter): only fire on the two supported
+    # events. The `target_commitish == 'main'` check is intentionally
+    # absent — it's release-creation metadata, not a verified assertion
+    # about the tag's underlying commit (see PR #297 review threads
+    # 3248512589 / 3248513873). A user could push a tag to a non-main
+    # commit and create the release with `--target main`, passing this
+    # check while building the non-main commit. The authoritative check
+    # is the runtime `Verify release commit on main` step below, which
+    # compares `github.sha` against `origin/main` history.
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'release' && github.event.action == 'published' &&
-       github.event.release.target_commitish == 'main')
+      (github.event_name == 'release' && github.event.action == 'published')
     runs-on: ubuntu-latest
     environment:
       # release -> prod; push to main -> dev. The `prod` environment binds
@@ -67,6 +69,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # Defensive guard layer 2 (runtime verification): for release events,
+      # confirm the checked-out commit (`github.sha`, == the tag's commit)
+      # is actually reachable from `origin/main`. Closes the gap where:
+      #   * a tag points at a non-main commit, AND
+      #   * the release was created with `--target main` (so
+      #     `target_commitish` would have falsely passed an event-level
+      #     check), OR
+      #   * the release was created with `--target <sha>` (where the SHA
+      #     happens to be main HEAD but the literal `target_commitish`
+      #     string is the SHA, not `"main"`, breaking a string check).
+      # See PR #297 review threads 3248512589 (false-negative scenario)
+      # and 3248513873 (false-positive scenario).
+      - name: Verify release commit is on main
+        if: github.event_name == 'release'
+        run: |
+          git fetch origin main --depth=100
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Release tag at $(git rev-parse HEAD) is not reachable from origin/main ($(git rev-parse origin/main)). Refusing to push prod images. Cut releases on main HEAD only."
+            exit 1
+          fi
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,11 +26,16 @@ concurrency:
 
 jobs:
   build-and-push:
-    # Defensive guard: only fire on the two supported events. Any other event
-    # type (workflow_dispatch, schedule, etc.) is rejected without running.
+    # Defensive guard: only fire on the two supported events AND require
+    # both to originate from `main`. `target_commitish` is the branch/SHA
+    # the Release was created against (set by `--target` on
+    # `gh release create`); without this check a Release published from a
+    # feature branch tag would push to prod AR. Mirrors the fix applied
+    # in liverty-music/frontend#356 (review id 3248455636).
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'release' && github.event.action == 'published')
+      (github.event_name == 'release' && github.event.action == 'published' &&
+       github.event.release.target_commitish == 'main')
     runs-on: ubuntu-latest
     environment:
       # release -> prod; push to main -> dev. The `prod` environment binds


### PR DESCRIPTION
## Summary

Mirror the fix applied to liverty-music/frontend#356 (claude-bot review id 3248455636). Close the same gap in backend's `deploy.yml`: the `release` branch of the job-level `if:` guard accepted any release-published event without checking which branch the release was cut from.

A Release created against a feature-branch tag (e.g., `gh release create test-tag --target feature-branch`) would have passed the guard and pushed prod images to `liverty-music-prod/backend/{server,consumer,concert-discovery,artist-image-sync}:test-tag` — contradicting the invariant that prod releases come from `main` HEAD only.

## Fix

Add `github.event.release.target_commitish == 'main'` to the release branch of the guard:

```yaml
if: |
  (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
  (github.event_name == 'release' && github.event.action == 'published' &&
   github.event.release.target_commitish == 'main')
```

For the canonical `gh release create vX.Y.Z --target main` flow, `target_commitish` is `'main'` — guard passes. For any other branch / SHA target, guard rejects without entering the prod environment.

## Defense-in-depth alongside cloud-provisioning PR #266

The prod GitHub Environment tag-pattern policy added in cloud-provisioning#266 (merged 2026-05-15 as `057e9bf6`) gates which tag refs may even attempt to deploy to prod (only `v*`). This workflow-level check is the second layer: even if a `v*` tag pointed at a non-main commit (e.g., an operator cut `v1.0.0` against a feature branch tip by mistake), this guard rejects before entering the prod environment.

The two checks are complementary:
- **Env tag policy** (Pulumi-managed, cloud-prov side): "only `v*` tag refs may even enter the prod env"
- **Workflow target_commitish guard** (this PR): "and only if the tag points at main"

## Test plan

- [x] Workflow YAML edited (1 file, 8+/3- diff).
- [ ] CI green.
- [ ] claude-review feedback addressed.
- [ ] Reviewer sign-off.

## Related

- Frontend mirror: liverty-music/frontend#356 (in flight)
- Companion: liverty-music/cloud-provisioning#266 (merged 2026-05-15, prod env tag-pattern policy fix)
- Spec PR: liverty-music/specification#473 (merged 2026-05-15)
