### PR TITLE
fix(usecase): skip concerts with empty venue name instead of poisoning the batch

### DIFF
--- a/internal/usecase/concert_creation_uc.go
+++ b/internal/usecase/concert_creation_uc.go
@@ -63,6 +63,23 @@ func (uc *concertCreationUseCase) CreateFromDiscovered(ctx context.Context, data
 	newVenues := make(map[string]*entity.Venue) // track newly created venues by cache key
 
 	for _, sc := range data.Concerts {
+		if sc.ListedVenueName == "" {
+			// Gemini occasionally returns a concert entry with no `listed_venue_name`
+			// (e.g. announced-but-venue-TBA tour dates). Posting an empty `text_query`
+			// to Google Places returns 400 INVALID_ARGUMENT, which previously bubbled
+			// up and poisoned the whole batch — sibling concerts with valid venues
+			// were silently lost. Skip just this entry instead.
+			uc.logger.Warn(ctx, "skipping concert: empty venue name from Gemini",
+				slog.String("artist_id", data.ArtistID),
+				slog.String("title", sc.Title),
+				slog.Any("admin_area", sc.AdminArea),
+				slog.String("local_date", sc.LocalDate.Format("2006-01-02")),
+				slog.Any("start_time", sc.StartTime),
+				slog.Any("open_time", sc.OpenTime),
+				slog.String("source_url", sc.SourceURL),
+			)
+			continue
+		}
 		venueID, venue, skip, err := uc.resolveVenue(ctx, sc.ListedVenueName, sc.AdminArea, newVenues)
 		if err != nil {
 			return fmt.Errorf("resolve venue %q: %w", sc.ListedVenueName, err)

--- a/internal/usecase/concert_creation_uc.go
+++ b/internal/usecase/concert_creation_uc.go
@@ -64,18 +64,14 @@ func (uc *concertCreationUseCase) CreateFromDiscovered(ctx context.Context, data
 
 	for _, sc := range data.Concerts {
 		if sc.ListedVenueName == "" {
-			// Gemini occasionally returns a concert entry with no `listed_venue_name`
-			// (e.g. announced-but-venue-TBA tour dates). Posting an empty `text_query`
-			// to Google Places returns 400 INVALID_ARGUMENT, which previously bubbled
-			// up and poisoned the whole batch — sibling concerts with valid venues
-			// were silently lost. Skip just this entry instead.
+			// Skip TBA-venue entries; an empty text_query returns 400 from Places and would poison the batch.
 			uc.logger.Warn(ctx, "skipping concert: empty venue name from Gemini",
 				slog.String("artist_id", data.ArtistID),
 				slog.String("title", sc.Title),
 				slog.Any("admin_area", sc.AdminArea),
 				slog.String("local_date", sc.LocalDate.Format("2006-01-02")),
-				slog.Any("start_time", sc.StartTime),
-				slog.Any("open_time", sc.OpenTime),
+				slog.Time("start_time", sc.StartTime),
+				slog.Time("open_time", sc.OpenTime),
 				slog.String("source_url", sc.SourceURL),
 			)
 			continue

--- a/internal/usecase/concert_creation_uc_test.go
+++ b/internal/usecase/concert_creation_uc_test.go
@@ -307,12 +307,6 @@ func TestConcertCreationUseCase_CreateFromDiscovered(t *testing.T) {
 		ps.places["Known Venue"] = &entity.VenuePlace{ExternalID: "place-known", Name: "Known Venue"}
 		uc := usecase.NewConcertCreationUseCase(venueRepo, concertRepo, ps, messaging.NewEventPublisher(pub), newTestLogger(t))
 
-		// Gemini occasionally returns a concert entry with no listed_venue_name
-		// (announced-but-venue-TBA tour dates). Before this fix, the empty string
-		// would be sent to Google Places, which returns 400 INVALID_ARGUMENT,
-		// crashing the whole batch via the watermill retry → poison-queue path.
-		// Now the empty-name entry SHALL be skipped silently and sibling concerts
-		// SHALL persist normally.
 		data := entity.ConcertDiscoveredData{
 			ArtistID:   "artist-empty-venue",
 			ArtistName: "Edge Case Artist",

--- a/internal/usecase/concert_creation_uc_test.go
+++ b/internal/usecase/concert_creation_uc_test.go
@@ -298,6 +298,49 @@ func TestConcertCreationUseCase_CreateFromDiscovered(t *testing.T) {
 		assert.Equal(t, "Concert at Known", concertRepo.created[0].Title)
 	})
 
+	t.Run("skips concert with empty venue name without poisoning the batch", func(t *testing.T) {
+		t.Parallel()
+		venueRepo := newFakeVenueRepo()
+		concertRepo := &fakeConcertRepo{}
+		pub := newGoChannelPub(t)
+		ps := newStubPlaceSearcher()
+		ps.places["Known Venue"] = &entity.VenuePlace{ExternalID: "place-known", Name: "Known Venue"}
+		uc := usecase.NewConcertCreationUseCase(venueRepo, concertRepo, ps, messaging.NewEventPublisher(pub), newTestLogger(t))
+
+		// Gemini occasionally returns a concert entry with no listed_venue_name
+		// (announced-but-venue-TBA tour dates). Before this fix, the empty string
+		// would be sent to Google Places, which returns 400 INVALID_ARGUMENT,
+		// crashing the whole batch via the watermill retry → poison-queue path.
+		// Now the empty-name entry SHALL be skipped silently and sibling concerts
+		// SHALL persist normally.
+		data := entity.ConcertDiscoveredData{
+			ArtistID:   "artist-empty-venue",
+			ArtistName: "Edge Case Artist",
+			Concerts: entity.ScrapedConcerts{
+				{
+					Title:           "Valid Show",
+					ListedVenueName: "Known Venue",
+					LocalDate:       localDate,
+					SourceURL:       "https://example.com/valid",
+				},
+				{
+					Title:           "TBA Show",
+					ListedVenueName: "",
+					LocalDate:       localDate,
+					SourceURL:       "https://example.com/tba",
+				},
+			},
+		}
+
+		err := uc.CreateFromDiscovered(context.Background(), data)
+		require.NoError(t, err)
+
+		// Only the valid-venue concert persists; the empty-name entry is skipped.
+		assert.Len(t, venueRepo.created, 1)
+		require.Len(t, concertRepo.created, 1)
+		assert.Equal(t, "Valid Show", concertRepo.created[0].Title)
+	})
+
 	t.Run("skips all concerts when all venues are not found", func(t *testing.T) {
 		t.Parallel()
 		venueRepo := newFakeVenueRepo()


### PR DESCRIPTION
## Summary

Fixes a prod bug where a single Gemini-returned concert with `listed_venue_name=""` poisons the entire `CONCERT.discovered` batch. All sibling concerts in the batch — many with perfectly valid venues — are silently lost after three retries to the poison queue.

Discovered as a side effect of liverty-music/specification#482 §18.5 push-notification e2e work.

## Root cause

1. Gemini occasionally returns a concert entry with no `listed_venue_name` (typically announced-but-venue-TBA tour dates the artist site lists without a confirmed hall).
2. `resolveVenue` passes the empty string straight to Google Places `searchText`, which returns:
   ```
   400 INVALID_ARGUMENT: Empty text_query.
   ```
3. `resolveVenue` propagates the error (non-NotFound code path), `CreateFromDiscovered`'s loop bails with `fmt.Errorf(\"resolve venue %q: %w\", \"\", err)`, the watermill consumer retries 3× with the same input (deterministic failure), then poison-queues the entire event.
4. All sibling concerts in the same batch never persist.

## Observed live in prod (2026-05-18T09:28:44Z)

Operator first-followed UVERworld with hype=away as part of §18.5 verification. Gemini returned 9 candidates; one had an empty venue. All 9 were lost:

```
09:28:44.20  ERROR google maps search failed: 400 \"Empty text_query.\"
09:28:44.20  ERROR Error occurred, retrying retry_no=1 max_retries=3
09:28:44.97  ERROR same as above, retry_no=2
09:28:45.71  ERROR same, retry_no=3
09:28:46.45  ERROR same, attempt 4 (last)
09:28:46.46  ERROR message routed to poison queue
```

UVERworld currently has zero rows in prod `app.concerts` despite an active 2026 tour.

## Fix

`internal/usecase/concert_creation_uc.go` — in the `CreateFromDiscovered` loop, check `sc.ListedVenueName == \"\"` before calling `resolveVenue`. Emit a WARN with the same field set used by the existing \"venue not found in Google Places\" skip path (minus the empty `listed_venue_name`, plus a distinct message so the two cases are filterable separately).

### Why caller-side, not inside `resolveVenue`

- Keeps `resolveVenue`'s `skip=true` semantics narrow (\"Places said the venue does not exist\") so its WARN log stays accurate.
- The empty-name guard is a data-quality concern with the *upstream* scraper, not a property of the venue-resolution algorithm — the caller is the natural layer to enforce it.

## Verification

- [x] `make lint` clean (gofmt + golangci-lint 0 issues).
- [x] New unit test `TestConcertCreationUseCase_CreateFromDiscovered/skips_concert_with_empty_venue_name_without_poisoning_the_batch` asserts the empty-name entry is skipped and a sibling valid-venue entry persists normally.
- [x] All existing sibling tests in the suite (`creates_venues_and_concerts_from_Places_API_results`, `skips_concerts_when_Places_API_returns_NotFound`, `reuses_existing_venue_by_place_id`, `deduplicates_venues_within_batch_by_place_id`, `skips_all_concerts_when_all_venues_are_not_found`, `EventPublishing`) continue to pass.

## Post-merge expectation

After backend `v1.0.x` release with this fix:
1. Next concert-discovery cronjob run for UVERworld (or any followed artist) handles empty-venue Gemini entries gracefully.
2. Manual re-trigger for UVERworld will populate the missing 8 valid concerts. (The TBA-venue entry stays skipped; no functional loss.)

## Related

- liverty-music/specification#482 — `prepare-prod-service-in` §18.5 follow-up (this PR's parent context)
- Companion KEDA scaling fix landed earlier: liverty-music/cloud-provisioning#280

## Test plan

- [ ] CI green (lint + unit + DB integration tests via docker compose)
- [ ] `Claude review` Check Run green