### PR TITLE
feat(ci): retag dev AR digest into prod AR on release instead of rebuild

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -247,11 +247,16 @@ jobs:
           # consume retry budget.
           stderr_file=$(mktemp)
           for attempt in $(seq 1 6); do
+            # rc MUST be reset per iteration: bash leaves rc untouched on
+            # a successful command (no `|| rc=$?` trigger), so a stale rc
+            # from a prior failed attempt would persist and disqualify a
+            # successful resolve in attempt 2..6. Explicit reset before
+            # the call, and only the failure branch writes rc.
+            rc=0
             digest=$(gcloud artifacts docker images describe \
               "${DEV_AR_IMAGE}:${GITHUB_SHA}" \
               --format='value(image_summary.digest)' \
               2>"$stderr_file") || rc=$?
-            rc=${rc:-0}
             if [ "$rc" -eq 0 ] && [ -n "$digest" ]; then
               echo "Resolved digest on attempt ${attempt}/6: $digest"
               echo "digest=$digest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,7 +139,14 @@ jobs:
       - name: Configure Docker
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
 
+      # IMAGE_URI is only consumed by `Set Image Tags (dev path)` and the
+      # `Build and Push Docker Image` step, both push-only. Gate the
+      # assignment to push too so the release path doesn't carry a dead
+      # env var that future readers might assume is wired into the retag
+      # flow. (The retag steps below construct DEV_AR_IMAGE /
+      # PROD_AR_IMAGE from literal AR paths, not IMAGE_URI.)
       - name: Set Image URI
+        if: github.event_name == 'push'
         run: echo "IMAGE_URI=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ matrix.image.name }}" >> $GITHUB_ENV
 
       # Dev tag set: :latest (consumed by ArgoCD Image Updater for dev
@@ -209,7 +216,11 @@ jobs:
       # release path is already covered without any gating change).
       - name: Install crane
         if: github.event_name == 'release'
-        uses: imjasonh/setup-crane@v0.4
+        # SHA-pinned for the prod-write path: this action runs with prod
+        # AR credentials, so a hijacked mutable tag would execute code
+        # with prod-write authority. SHA of v0.4 verified against
+        # https://github.com/imjasonh/setup-crane refs/tags/v0.4.
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
       - name: Resolve dev AR digest for ${{ matrix.image.name }}:${{ github.sha }}
         if: github.event_name == 'release'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,25 @@
 name: Deploy Backend
 
-# Dual trigger per OpenSpec change `prepare-prod-service-in`:
+# Dual trigger:
 #  - push to main      -> dev build, dev AR (liverty-music-dev/backend)
-#  - release published -> prod build, prod AR (liverty-music-prod/backend)
+#                         4× docker/build-push-action across the strategy
+#                         matrix (server, consumer, concert-discovery,
+#                         artist-image-sync). Each builds and pushes
+#                         :latest, :main, :<sha> for its image.
+#  - release published -> retag dev AR digest into prod AR
+#                         (liverty-music-prod/backend). 4× `crane copy`
+#                         across the matrix — no rebuild. Each matrix
+#                         entry resolves its own dev AR digest for
+#                         github.sha and promotes that exact digest to
+#                         prod AR under :<release-tag> and :<sha>.
+#
+# Per OpenSpec change `backend-symmetric-retag` (extending the
+# frontend `promote-prod-image-via-retag` archive to the backend's
+# 4-image matrix), the release path stops invoking `docker build`. The
+# prod image deployed is byte-identical to the dev image already
+# exercised under the same `:<sha>` tag. This trims ~6 min of redundant
+# rebuild per release event (4× ~90 s sequential build-push) down to
+# ~30 s of parallel digest-resolve + crane copy.
 #
 # The `paths:` filter only applies to `push` events. Release events fire on
 # any published Release regardless of file diff — the deploy step is always
@@ -49,6 +66,15 @@ jobs:
       contents: read
       id-token: write
     strategy:
+      # fail-fast: false so that one matrix entry's failure (e.g. transient
+      # AR error during digest-resolve, or a single-image dev build that
+      # was filtered out by paths) does NOT cancel the other 3. Partial
+      # success is the expected steady state on release events: per the
+      # retag runbook, the operator can `gh run rerun --job <job-id>` the
+      # single failing matrix entry. The 3 successful entries' prod AR
+      # writes are idempotent because `crane copy` to an existing
+      # immutable tag at the same digest is a no-op.
+      fail-fast: false
       matrix:
         image:
           - name: server
@@ -101,6 +127,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      # `Configure Docker` runs on BOTH paths:
+      #   * push path:    docker/build-push-action's pusher needs it.
+      #   * release path: `crane` reads its auth from ~/.docker/config.json's
+      #                   credential helpers (the gcloud helper for *.pkg.dev).
+      #                   Without this step crane falls back to anonymous and
+      #                   fails on the prod-AR write.
+      # Backend's existing step is already unconditional, so no gating
+      # change is needed here (unlike the frontend rollout which had to
+      # drop a `push`-only `if:` gate during implementation).
       - name: Configure Docker
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
 
@@ -110,19 +145,22 @@ jobs:
       # Dev tag set: :latest (consumed by ArgoCD Image Updater for dev
       # auto-rollout) + :sha (immutable digest pointer) + :main (branch ref).
       # Prod is forbidden from using :latest per the `prod-image-pipeline`
-      # spec — release builds use :<tag> + :sha only.
+      # spec — release builds use :<tag> + :sha only, and on the release
+      # path those tags are written by `crane copy` directly (no
+      # IMAGE_TAGS env-var indirection is needed on prod).
       - name: Set Image Tags (dev path)
         if: github.event_name == 'push'
         run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main" >> $GITHUB_ENV
 
-      - name: Set Image Tags (prod path)
-        if: github.event_name == 'release'
-        run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:${{ github.event.release.tag_name }},${{ env.IMAGE_URI }}:${{ github.sha }}" >> $GITHUB_ENV
-
+      # =====================================================================
+      # Dev push path: build + push the 4 images to dev AR
+      # =====================================================================
       - name: Set up Docker Buildx
+        if: github.event_name == 'push'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Docker Image
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -131,3 +169,98 @@ jobs:
           tags: ${{ env.IMAGE_TAGS }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+
+      # =====================================================================
+      # Release path: retag the dev AR digest into prod AR — no rebuild
+      # =====================================================================
+      # Each matrix entry resolves the dev AR digest for its own
+      # `<image>:<sha>` and copies it twice into prod AR under
+      # `:<release-tag>` and `:<sha>`. The 4 matrix entries run in parallel;
+      # total wall-clock is bounded by the slowest single retag (~30 s).
+      #
+      # Source and destination FQDNs are written with the literal `backend`
+      # repository segment rather than `${{ env.REPOSITORY }}`. Although
+      # `REPOSITORY` (== `github.event.repository.name`) happens to equal
+      # `backend` today, the dev-AR source is structurally fixed at
+      # `liverty-music-dev/backend` regardless of the GitHub repo name —
+      # threading it via env would invite a class of bug where renaming
+      # the GitHub repo silently breaks the retag pointer. PROJECT_ID
+      # is still env-driven because it correctly toggles between
+      # `liverty-music-dev` and `liverty-music-prod` via the per-event
+      # `environment:` binding above, and we want that toggle.
+
+      # Install `crane` (go-containerregistry's registry CLI) for the
+      # cross-repository / cross-project digest copy. `gcloud artifacts
+      # docker tags add` is intentionally NOT used here: despite its
+      # name, it only renames tags within a single repository — passing
+      # a source from `liverty-music-dev/backend/<img>` and a destination
+      # in `liverty-music-prod/backend/<img>` fails with `Image ... does
+      # not match image ...`. `crane copy` is the registry-to-registry
+      # primitive; within the same AR region it uses cross-repo blob
+      # mounting so no image bytes actually transfer (manifest re-push
+      # only).
+      #
+      # Note: the action's name is `setup-crane`, and it installs the
+      # `crane` binary — NOT the `gcrane` wrapper (a GCR-specific
+      # convenience build from the same go-containerregistry repo that
+      # the action does not ship). `crane` works identically for AR.
+      # Auth: `crane` reads ~/.docker/config.json populated by the
+      # `Configure Docker` step above (which is unconditional, so the
+      # release path is already covered without any gating change).
+      - name: Install crane
+        if: github.event_name == 'release'
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Resolve dev AR digest for ${{ matrix.image.name }}:${{ github.sha }}
+        if: github.event_name == 'release'
+        id: resolve_digest
+        env:
+          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/backend/${{ matrix.image.name }}
+        run: |
+          # 6 total attempts (initial + 5 retries) × 60s wait between =
+          # ~5-minute total budget. Absorbs the race window where a
+          # release is cut seconds after merge-to-main and the dev push
+          # for THIS matrix entry's image is still in-flight. Per the
+          # spec, this is a SHALL retry, not a MAY — silent failure on
+          # the digest-resolve step is exactly what the retry contract
+          # prevents.
+          for attempt in $(seq 1 6); do
+            digest=$(gcloud artifacts docker images describe \
+              "${DEV_AR_IMAGE}:${GITHUB_SHA}" \
+              --format='value(image_summary.digest)' \
+              2>/dev/null || echo "")
+            if [ -n "$digest" ]; then
+              echo "Resolved digest on attempt ${attempt}/6: $digest"
+              echo "digest=$digest" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$attempt" -lt 6 ]; then
+              echo "Attempt ${attempt}/6: dev AR :sha not yet available; waiting 60s..."
+              sleep 60
+            fi
+          done
+          echo "::error::dev AR tag :${GITHUB_SHA} not found for ${DEV_AR_IMAGE} after 6 attempts (~5 min total wait). Either the dev build for this matrix entry's image failed, or the release was cut on a non-main commit. See docs/runbooks/prod-image-tag-pinning.md retag-failure-recovery in cloud-provisioning."
+          exit 1
+
+      - name: Promote dev AR digest to prod AR (semver tag)
+        if: github.event_name == 'release'
+        env:
+          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/backend/${{ matrix.image.name }}
+          PROD_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/backend/${{ matrix.image.name }}
+          DIGEST: ${{ steps.resolve_digest.outputs.digest }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          crane copy \
+            "${DEV_AR_IMAGE}@${DIGEST}" \
+            "${PROD_AR_IMAGE}:${RELEASE_TAG}"
+
+      - name: Promote dev AR digest to prod AR (commit SHA tag)
+        if: github.event_name == 'release'
+        env:
+          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/backend/${{ matrix.image.name }}
+          PROD_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/backend/${{ matrix.image.name }}
+          DIGEST: ${{ steps.resolve_digest.outputs.digest }}
+        run: |
+          crane copy \
+            "${DEV_AR_IMAGE}@${DIGEST}" \
+            "${PROD_AR_IMAGE}:${GITHUB_SHA}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,25 +235,81 @@ jobs:
           # spec, this is a SHALL retry, not a MAY — silent failure on
           # the digest-resolve step is exactly what the retry contract
           # prevents.
+          #
+          # Error classification: gcloud exits non-zero on any failure
+          # (NOT_FOUND for missing :<sha>, PERMISSION_DENIED for auth
+          # regression, transient 5xx, rate limit, etc.). Treating all
+          # failures uniformly as "retry up to 6×" would mask an IAM
+          # regression as a 5-minute timeout with a misleading
+          # "not found" error. So we capture stderr, classify against
+          # the gcloud / AR error vocabulary, and fail fast on auth and
+          # other non-NOT_FOUND classes. Only NOT_FOUND-shaped responses
+          # consume retry budget.
+          stderr_file=$(mktemp)
           for attempt in $(seq 1 6); do
             digest=$(gcloud artifacts docker images describe \
               "${DEV_AR_IMAGE}:${GITHUB_SHA}" \
               --format='value(image_summary.digest)' \
-              2>/dev/null || echo "")
-            if [ -n "$digest" ]; then
+              2>"$stderr_file") || rc=$?
+            rc=${rc:-0}
+            if [ "$rc" -eq 0 ] && [ -n "$digest" ]; then
               echo "Resolved digest on attempt ${attempt}/6: $digest"
               echo "digest=$digest" >> "$GITHUB_OUTPUT"
+              rm -f "$stderr_file"
               exit 0
             fi
+            stderr_body=$(cat "$stderr_file")
+            # PERMISSION_DENIED / 403 / forbidden — IAM regression or
+            # WIF token misconfig. Retrying for 5 minutes won't help;
+            # surface immediately.
+            if echo "$stderr_body" | grep -qE 'PERMISSION_DENIED|Permission .* denied|HTTPError 403|403 Forbidden|UNAUTHENTICATED|401'; then
+              echo "::error::Auth failure resolving dev AR digest for ${DEV_AR_IMAGE}:${GITHUB_SHA} on attempt ${attempt}/6. The prod CI service account likely lost the cross-project AR reader grant on dev backend AR (resource: prod-ci-backend-ar-reader in cloud-provisioning Pulumi state). Recovery: see docs/runbooks/prod-image-tag-pinning.md retag-failure-recovery in cloud-provisioning."
+              echo "::error::gcloud stderr: ${stderr_body}"
+              rm -f "$stderr_file"
+              exit 1
+            fi
+            # NOT_FOUND-shaped: the dev :<sha> tag hasn't landed yet
+            # (typical) or the release was cut on a non-main commit
+            # whose dev build never ran (corner case). Retry within
+            # the 5-minute budget.
+            if echo "$stderr_body" | grep -qE 'NOT_FOUND|not found|does not exist|tag .* doesn'\''t exist'; then
+              if [ "$attempt" -lt 6 ]; then
+                echo "Attempt ${attempt}/6: dev AR :sha not yet available; waiting 60s..."
+                sleep 60
+                continue
+              fi
+            fi
+            # Empty digest with rc==0 OR any other non-zero (transient
+            # 5xx, rate limit, network blip) — retry. Echo the stderr
+            # so the run log shows what we saw rather than hiding it.
             if [ "$attempt" -lt 6 ]; then
-              echo "Attempt ${attempt}/6: dev AR :sha not yet available; waiting 60s..."
+              if [ -n "$stderr_body" ]; then
+                echo "Attempt ${attempt}/6: gcloud rc=$rc stderr=${stderr_body}; waiting 60s before retry..."
+              else
+                echo "Attempt ${attempt}/6: gcloud returned empty digest with rc=$rc; waiting 60s before retry..."
+              fi
               sleep 60
             fi
           done
-          echo "::error::dev AR tag :${GITHUB_SHA} not found for ${DEV_AR_IMAGE} after 6 attempts (~5 min total wait). Either the dev build for this matrix entry's image failed, or the release was cut on a non-main commit. See docs/runbooks/prod-image-tag-pinning.md retag-failure-recovery in cloud-provisioning."
+          final_stderr=$(cat "$stderr_file" 2>/dev/null || echo "(no stderr captured)")
+          rm -f "$stderr_file"
+          echo "::error::dev AR tag :${GITHUB_SHA} not resolved for ${DEV_AR_IMAGE} after 6 attempts (~5 min total wait). Either the dev build for this matrix entry's image failed, or the release was cut on a non-main commit. Last gcloud stderr: ${final_stderr}. See docs/runbooks/prod-image-tag-pinning.md retag-failure-recovery in cloud-provisioning."
           exit 1
 
-      - name: Promote dev AR digest to prod AR (semver tag)
+      # The two `crane copy` calls are bundled into a single step so the
+      # workflow's release path presents one "Promote dev AR digest to
+      # prod AR" unit rather than two separate steps that could each
+      # surface in a partial-success state. Note that this does not
+      # change atomicity at the registry layer — `crane copy` is two
+      # sequential AR API calls regardless of whether they live in one
+      # YAML step or two. If the SHA tag write fails after the semver
+      # tag write succeeds, prod AR has only the semver tag; recovery
+      # is `gh run rerun --job <job-id>` and the second copy completes
+      # (the semver-tag copy is a no-op at the same digest under AR's
+      # immutability policy). The runbook
+      # docs/runbooks/prod-image-tag-pinning.md "Retag failure recovery"
+      # in cloud-provisioning documents this re-run path explicitly.
+      - name: Promote dev AR digest to prod AR (semver + sha tags)
         if: github.event_name == 'release'
         env:
           DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/backend/${{ matrix.image.name }}
@@ -261,17 +317,6 @@ jobs:
           DIGEST: ${{ steps.resolve_digest.outputs.digest }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          crane copy \
-            "${DEV_AR_IMAGE}@${DIGEST}" \
-            "${PROD_AR_IMAGE}:${RELEASE_TAG}"
-
-      - name: Promote dev AR digest to prod AR (commit SHA tag)
-        if: github.event_name == 'release'
-        env:
-          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/backend/${{ matrix.image.name }}
-          PROD_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/backend/${{ matrix.image.name }}
-          DIGEST: ${{ steps.resolve_digest.outputs.digest }}
-        run: |
-          crane copy \
-            "${DEV_AR_IMAGE}@${DIGEST}" \
-            "${PROD_AR_IMAGE}:${GITHUB_SHA}"
+          set -euo pipefail
+          crane copy "${DEV_AR_IMAGE}@${DIGEST}" "${PROD_AR_IMAGE}:${RELEASE_TAG}"
+          crane copy "${DEV_AR_IMAGE}@${DIGEST}" "${PROD_AR_IMAGE}:${GITHUB_SHA}"


### PR DESCRIPTION
## Summary

Replace the `deploy.yml` release path's 4× `docker/build-push-action` matrix with a digest-resolve + `crane copy` flow across the existing strategy matrix (`server`, `consumer`, `concert-discovery`, `artist-image-sync`). Each matrix entry resolves its own dev AR digest for `github.sha` (6-attempt × 60s retry budget) and promotes that exact digest to prod AR under `:<release-tag>` and `:<sha>`. The dev push path is unchanged.

- `strategy.fail-fast: false` so one matrix entry's failure does NOT cancel the other 3 (partial-success recovery via `gh run rerun --job <job-id>` is documented in the cloud-provisioning retag runbook).
- `Install crane` (`imjasonh/setup-crane@v0.4`) gated `if: github.event_name == 'release'`. Comment block notes the action installs `crane` (not `gcrane`) and reads auth from `~/.docker/config.json` populated by the existing unconditional `Configure Docker` step.
- `Set up Docker Buildx` and `docker/build-push-action` gated `if: github.event_name == 'push'`.
- Dead `Set Image Tags (prod path)` step removed (the release path now passes destination tags directly to `crane copy`).
- Source FQDNs use the literal `liverty-music-dev/backend` repo segment rather than `${{ env.REPOSITORY }}` — `REPOSITORY` happens to equal `backend` today but the dev AR source is structurally fixed regardless of the GitHub repo name; threading it via env would invite a class of bug where renaming the repo silently breaks the retag pointer. `PROJECT_ID` stays env-driven so it correctly toggles between `liverty-music-dev` and `liverty-music-prod` via the per-event `environment:` binding.

## Why

Backend's `deploy.yml` was the missing symmetric half: the frontend retag flow has been live and validated since `frontend@v1.0.2` (archive `2026-05-18-promote-prod-image-via-retag`), but backend still rebuilt 4 images on every release event — ~6 minutes of redundant build per release and reintroducing the dev/prod image-divergence risk that retag was designed to eliminate.

After this PR + the IAM prerequisite (liverty-music/cloud-provisioning#290, merged), prod backend pulls bytes byte-identical to the dev AR bytes already exercised under the same `:<sha>`. Release-event runtime drops from ~6 min (4× sequential build-push, `cache-from type=gha`) to ~30 s (parallel digest-resolve + `crane copy` across the matrix).

OpenSpec change: `backend-symmetric-retag` (specification PR liverty-music/specification#499, merged).

## Test plan

- [ ] CI lint passes (`make lint`).
- [ ] Merge-to-main triggers the **push** event → 4× `docker/build-push-action` runs unchanged → all 4 dev AR `:<sha>` / `:main` / `:latest` tags written (task 3.1). Runtime within ±10% of the prior baseline.
- [ ] Capture the 4 dev AR `:<sha>` digests (task 3.2):
      ```bash
      for img in server consumer concert-discovery artist-image-sync; do
        gcloud artifacts docker images describe \
          asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/$img:<merge-sha> \
          --format='value(image_summary.digest)'
      done
      ```
- [ ] Cut a backend Release (`vN+1`, target = the merge commit) → 4× parallel retag → both `:vN+1` and `:<sha>` written to prod AR (task 4.1–4.2).
- [ ] Byte-identity check: prod AR `:vN+1` digest matches the dev AR `:<sha>` digest captured above for each of the 4 images (task 4.3).
- [ ] Cloud-provisioning kustomize bump (task 4.4): single PR bumping `images[*].newTag` and `app.kubernetes.io/version` for all 4 backend Deployments to `vN+1`. ArgoCD syncs in lock-step.
- [ ] Prod health probe (task 4.6): `curl https://api.liverty-music.app/grpc.health.v1.Health/Check` returns `SERVING`.

## Follows / Blocked by

- **Follows**: liverty-music/cloud-provisioning#290 (merged 2026-05-19; IAM grant `prod-ci-backend-ar-reader` live and verified).
- **Follows**: liverty-music/specification#499 (OpenSpec proposal, merged).
- **Next downstream**: cloud-provisioning prod overlay bump PR after the first release retag completes.

Closes #300