### PR TITLE
refactor(workflows): drop additional_focus from Claude review caller

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,5 +19,3 @@ jobs:
   review:
     uses: liverty-music/.github/.github/workflows/claude-review.yml@main
     secrets: inherit
-    with:
-      additional_focus: "Go conventions, error handling (no silent fails), table-driven tests, pgx usage"


### PR DESCRIPTION
## Summary

Drop `with: additional_focus: ...` from `.github/workflows/claude-code-review.yml`. Companion to the [reusable workflow rewrite](https://github.com/liverty-music/.github/pull/4) which removed the `additional_focus` input entirely.

## Why

The `additional_focus` free-text input was a prompt-injection surface that, combined with five other deviations from `code-review` plugin official patterns, caused nit-level comment overload under the Anthropic model-serving incidents of 2026-05-18 to 2026-05-22. Per-repo review focus (Go conventions, error handling, table-driven tests, pgx usage) is already documented in [`CLAUDE.md`](CLAUDE.md) and is read by the code-review plugin's CLAUDE.md-audit agents — no information loss.

See [`liverty-music/specification#522`](https://github.com/liverty-music/specification/pull/522) for the OpenSpec change proposal and full design rationale.

## Test plan

- [ ] CI passes
- [ ] First post-merge PR's `Claude review` Check Run uses the new mechanical-counting mechanism

## Refs

Refs: liverty-music/specification#521