### PR TITLE
ci(workflows): drop unused checks: write permission

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,14 +6,12 @@ on:
 
 # Permissions are inherited by the reusable workflow's job and intersected
 # with its own workflow-level declarations. Set them here in the caller so
-# the called job has everything it needs (sticky/inline comment, Claude
-# action OIDC, Check Run publish).
+# the called job has everything it needs (inline comments, Claude action OIDC).
 permissions:
   contents: read
   pull-requests: write
   issues: read
   id-token: write
-  checks: write
 
 jobs:
   review:


### PR DESCRIPTION
## Summary

Drop the now-unused `checks: write` permission from `.github/workflows/claude-code-review.yml`. Least-privilege tidy.

## Context

After [`honor-thread-resolution-in-claude-review-check`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-05-29-honor-thread-resolution-in-claude-review-check) (Option B, archived 2026-05-29) reverted the reusable Claude review workflow to the official [`anthropics/claude-code-action` `pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) shape, the reusable no longer creates a GitHub Check Run. The `checks: write` permission inherited from this caller is therefore unused.

Removal has no functional impact:
- The reusable workflow does not declare `checks: write` itself.
- The caller-level permissions only ever *loosen* what the called job receives — never tighten.
- No step in the reusable consumes `checks: write`.

Companion PRs land the same one-line drop in the other three caller repos.

## Test plan

- [ ] CI passes (no behavior change expected; this is permission housekeeping)
- [ ] Claude review workflow still posts inline comments as before

Refs: liverty-music/specification#525