### PR TITLE
feat(analytics): AnalyticsClient interface + PostHog adapter (Batch 1+2a)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-	github.com/goccy/go-json v0.10.4 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -135,6 +135,7 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -177,6 +178,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/posthog/posthog-go v1.13.1 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.4 h1:JSwxQzIqKfmFX1swYPpUThQZp/Ka4wzJdK0LWVytLPM=
 github.com/goccy/go-json v0.10.4/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
@@ -294,6 +296,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db h1:IZUYC/xb3giYwBLMnr8d0TGTzPKFGNTCGgGLoyeX330=
 github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db/go.mod h1:xTEYN9KCHxuYHs+NmrmzFcnvHMzLLNiGFafCb1n3Mfg=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
@@ -467,6 +471,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posthog/posthog-go v1.13.1 h1:7OtfgOEM9fC2n4Hbs4e5mK1uaLuNguoYWFEI4kEnTUY=
+github.com/posthog/posthog-go v1.13.1/go.mod h1:xsVOW9YImilUcazwPNEq4PJDqEZf2KeCS758zXjwkPg=
 github.com/prometheus/client_golang v1.23.0 h1:ust4zpdl9r4trLY/gSjlm07PuiBq2ynaXXlptpfy8Uc=
 github.com/prometheus/client_golang v1.23.0/go.mod h1:i/o0R9ByOnHX0McrTMTyhYvKE4haaf2mW08I+jGAjEE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -537,6 +543,7 @@ github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0h
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/urfave/cli v1.22.16 h1:MH0k6uJxdwdeWQTwhSO42Pwr4YLrNLwBtg1MRgTqPdQ=
+github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=

--- a/internal/infrastructure/analytics/posthog/export_test.go
+++ b/internal/infrastructure/analytics/posthog/export_test.go
@@ -7,3 +7,8 @@ var NewWithEnqueuer = newWithEnqueuer
 // Enqueuer re-exports the unexported enqueuer interface so tests can
 // declare a fake that satisfies it.
 type Enqueuer = enqueuer
+
+// TracePropertyKey re-exports the unexported tracePropertyKey constant
+// so tests can assert that injected trace_id properties land under the
+// expected key without duplicating the literal.
+const TracePropertyKey = tracePropertyKey

--- a/internal/infrastructure/analytics/posthog/export_test.go
+++ b/internal/infrastructure/analytics/posthog/export_test.go
@@ -1,0 +1,9 @@
+package posthog
+
+// NewWithEnqueuer exposes the unexported newWithEnqueuer constructor to
+// tests in the posthog_test package so they can inject a fake enqueuer.
+var NewWithEnqueuer = newWithEnqueuer
+
+// Enqueuer re-exports the unexported enqueuer interface so tests can
+// declare a fake that satisfies it.
+type Enqueuer = enqueuer

--- a/internal/infrastructure/analytics/posthog/posthog_client.go
+++ b/internal/infrastructure/analytics/posthog/posthog_client.go
@@ -7,10 +7,16 @@ package posthog
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
+	"sync"
 
+	"github.com/google/uuid"
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/pannpers/go-apperr/apperr/codes"
+	"github.com/pannpers/go-logging/logging"
 	posthogsdk "github.com/posthog/posthog-go"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/liverty-music/backend/internal/usecase"
 )
@@ -19,10 +25,17 @@ import (
 // caller passes an empty apiHost to New.
 const DefaultAPIHost = "https://eu.i.posthog.com"
 
+// tracePropertyKey is the property name under which the active OpenTelemetry
+// trace ID is recorded on every emitted event. It matches the catalogue's
+// BaseProps.trace_id contract and lets PostHog event payloads correlate to
+// Cloud Trace spans during incident investigation.
+const tracePropertyKey = "trace_id"
+
 // enqueuer is the minimal subset of the posthog SDK Client that this
 // adapter depends on. Declaring it here lets tests inject a fake without
-// having to implement the dozen feature-flag methods on the full
-// posthog.Client interface.
+// implementing the dozen feature-flag methods on the full posthog.Client
+// interface. Both methods are exposed on the SDK's Client interface, so
+// the real posthog SDK client satisfies enqueuer implicitly.
 type enqueuer interface {
 	Enqueue(posthogsdk.Message) error
 	Close() error
@@ -31,82 +44,177 @@ type enqueuer interface {
 // AnalyticsClient is the PostHog-backed implementation of
 // usecase.AnalyticsClient. Construction is via New for production code
 // and via newWithEnqueuer (exposed through export_test.go) for tests.
+//
+// AnalyticsClient also exposes a Close() error method (io.Closer
+// compatible) so the DI layer can register the instance with the
+// shutdown manager. Close is NOT part of usecase.AnalyticsClient; it
+// stays at the infrastructure layer where lifecycle concerns belong.
 type AnalyticsClient struct {
 	client enqueuer
+	logger *logging.Logger
+
+	closeOnce sync.Once
+	closeErr  error
 }
 
-// Compile-time interface compliance check.
+// Compile-time interface compliance check against the usecase contract.
 var _ usecase.AnalyticsClient = (*AnalyticsClient)(nil)
 
 // New constructs an AnalyticsClient backed by a PostHog SDK client
-// configured against the given apiHost and projectAPIKey. If apiHost is
-// empty, DefaultAPIHost (PostHog Cloud EU) is used. The returned client
-// owns a background worker that flushes events asynchronously; call Close
-// at process shutdown to flush in-flight events.
-func New(apiHost, projectAPIKey string) (*AnalyticsClient, error) {
-	if projectAPIKey == "" {
-		return nil, errors.New("posthog: project API key must not be empty")
+// configured against the given apiHost and projectAPIKey.
+//
+// projectAPIKey MUST be non-empty after trimming whitespace; the
+// posthog-go SDK trims the key internally and silently returns a no-op
+// client when the trimmed value is empty (posthog.go:225-229 in v1.13.1).
+// Without an explicit guard here, a misconfigured secret containing only
+// whitespace would pass the constructor and cause every subsequent
+// Enqueue call to be silently discarded in production.
+//
+// If apiHost is empty, DefaultAPIHost (PostHog Cloud EU) is used. logger
+// is required; tests in the gemini/musicbrainz/lastfm adapters
+// demonstrate the project convention of constructing a no-op logger
+// instead of passing nil.
+//
+// The returned client owns a background worker that flushes events
+// asynchronously; call Close at process shutdown to flush in-flight
+// events.
+func New(apiHost, projectAPIKey string, logger *logging.Logger) (*AnalyticsClient, error) {
+	if strings.TrimSpace(projectAPIKey) == "" {
+		return nil, apperr.New(codes.InvalidArgument, "posthog: project API key must not be empty or whitespace-only")
 	}
 	if apiHost == "" {
 		apiHost = DefaultAPIHost
+	}
+	if logger == nil {
+		return nil, apperr.New(codes.InvalidArgument, "posthog: logger must not be nil")
 	}
 
 	sdkClient, err := posthogsdk.NewWithConfig(projectAPIKey, posthogsdk.Config{
 		Endpoint: apiHost,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("create posthog client: %w", err)
+		return nil, apperr.Wrap(err, codes.Internal, "create posthog client")
 	}
-	return newWithEnqueuer(sdkClient), nil
+	return newWithEnqueuer(sdkClient, logger), nil
 }
 
 // newWithEnqueuer wraps an existing enqueuer. Exposed for tests via
 // export_test.go.
-func newWithEnqueuer(client enqueuer) *AnalyticsClient {
-	return &AnalyticsClient{client: client}
+func newWithEnqueuer(client enqueuer, logger *logging.Logger) *AnalyticsClient {
+	return &AnalyticsClient{
+		client: client,
+		logger: logger,
+	}
 }
 
-// Enqueue implements usecase.AnalyticsClient. It hands the event to the
-// PostHog SDK's internal queue without blocking on network I/O. Transient
-// network failures and retries are absorbed by the SDK worker. Errors
-// returned here describe caller-side mistakes (empty distinctID, empty
-// eventName) or the SDK's own queue overflow.
+// Enqueue implements usecase.AnalyticsClient.
+//
+// Validation:
+//   - distinctID must be a valid UUID; the platform `UserId` is a UUID
+//     (see entity/v1/user.proto). This catches the misuse of passing
+//     the Zitadel `sub` claim (also a UUID-like string but issued by a
+//     different namespace) when it differs from a UUID format. Even
+//     when sub happens to be a UUID, this validation enforces format
+//     hygiene at the boundary.
+//   - eventName must be registered in usecase.IsKnownEvent. A typo'd
+//     constant (e.g. AnalyticsEventName("ticket.purcase.completed"))
+//     would otherwise silently fragment dashboards.
+//
+// Context handling:
+//   - ctx is inspected for an active OpenTelemetry span; if found, its
+//     trace ID is injected as the `trace_id` property unless the caller
+//     already supplied one.
+//   - ctx cancellation does NOT abort the SDK send: posthog-go's public
+//     Client interface does not expose a context-aware Enqueue
+//     (EnqueueWithContext is unexported), so the wrapper falls back to
+//     the SDK's synchronous-into-async-queue Enqueue.
+//
+// The supplied properties map is never mutated; trace_id injection,
+// when applied, happens on a defensive copy.
 func (c *AnalyticsClient) Enqueue(
-	_ context.Context,
+	ctx context.Context,
 	distinctID string,
 	eventName usecase.AnalyticsEventName,
 	properties usecase.AnalyticsProperties,
 ) error {
 	if distinctID == "" {
-		return errors.New("posthog: distinctID must not be empty")
+		return apperr.New(codes.InvalidArgument, "posthog: distinctID must not be empty")
+	}
+	if _, err := uuid.Parse(distinctID); err != nil {
+		return apperr.New(codes.InvalidArgument, fmt.Sprintf("posthog: distinctID must be a UUID (got %q)", distinctID))
 	}
 	if eventName == "" {
-		return errors.New("posthog: eventName must not be empty")
+		return apperr.New(codes.InvalidArgument, "posthog: eventName must not be empty")
+	}
+	if !usecase.IsKnownEvent(eventName) {
+		return apperr.New(codes.InvalidArgument, fmt.Sprintf("posthog: unknown eventName %q (not in usecase.IsKnownEvent allowlist)", eventName))
 	}
 
-	props := posthogsdk.NewProperties()
-	for k, v := range properties {
-		props.Set(k, v)
-	}
+	sdkProps := buildSDKProperties(ctx, properties)
 
 	if err := c.client.Enqueue(posthogsdk.Capture{
 		DistinctId: distinctID,
 		Event:      string(eventName),
-		Properties: props,
+		Properties: sdkProps,
 	}); err != nil {
-		return fmt.Errorf("posthog enqueue %s: %w", eventName, err)
+		return apperr.Wrap(err, codes.Internal, fmt.Sprintf("posthog enqueue %s", eventName))
 	}
 	return nil
 }
 
-// Close flushes in-flight events and releases the SDK's background worker.
-// The underlying SDK Close blocks for up to its configured ShutdownTimeout
-// (unlimited by default) until the queue drains. The supplied context is
-// reserved for forwarding to a future CloseWithContext call; the SDK's
-// public Close does not currently accept a context.
-func (c *AnalyticsClient) Close(_ context.Context) error {
-	if err := c.client.Close(); err != nil {
-		return fmt.Errorf("posthog close: %w", err)
+// buildSDKProperties prepares the property bag handed to the SDK.
+//
+// Fast path (no active OTel span, caller already supplied trace_id, or
+// caller passed nil): zero-cost type conversion since
+// usecase.AnalyticsProperties and posthogsdk.Properties are both
+// map[string]any with the same underlying type — no allocation, no
+// rehash.
+//
+// Slow path (active span and no caller-supplied trace_id): allocate
+// a copy with cap len(properties)+1 and inject trace_id. The caller's
+// map is never mutated.
+func buildSDKProperties(ctx context.Context, properties usecase.AnalyticsProperties) posthogsdk.Properties {
+	span := trace.SpanFromContext(ctx)
+	hasSpan := span.SpanContext().IsValid()
+	_, callerSetTrace := properties[tracePropertyKey]
+
+	if !hasSpan || callerSetTrace {
+		// Zero-cost conversion. Nil properties yields nil sdkProps,
+		// which the SDK treats as an empty payload.
+		if properties == nil {
+			return nil
+		}
+		return posthogsdk.Properties(properties)
 	}
-	return nil
+
+	// Defensive copy to inject trace_id without mutating the caller's map.
+	out := make(posthogsdk.Properties, len(properties)+1)
+	for k, v := range properties {
+		out[k] = v
+	}
+	out[tracePropertyKey] = span.SpanContext().TraceID().String()
+	return out
+}
+
+// Close flushes in-flight events and releases the SDK's background worker.
+//
+// Close is idempotent: subsequent calls return the same error result as
+// the first call (typically nil). This satisfies the io.Closer
+// contract and prevents shutdown sequences that invoke Close twice
+// (signal handler + main defer, for instance) from spuriously reporting
+// the SDK's "client was already closed" error.
+//
+// Close signature is intentionally io.Closer-compatible (no context.Context)
+// so the DI layer can register the instance via shutdown.AddExternalPhase
+// alongside the other outbound clients (lastfm, musicbrainz, etc.). If
+// callers need shutdown deadlines, they wrap this call in a
+// context.WithTimeout goroutine; the underlying SDK Close blocks until
+// in-flight events drain.
+func (c *AnalyticsClient) Close() error {
+	c.closeOnce.Do(func() {
+		if err := c.client.Close(); err != nil {
+			c.closeErr = apperr.Wrap(err, codes.Internal, "posthog close")
+		}
+	})
+	return c.closeErr
 }

--- a/internal/infrastructure/analytics/posthog/posthog_client.go
+++ b/internal/infrastructure/analytics/posthog/posthog_client.go
@@ -1,0 +1,112 @@
+// Package posthog provides a usecase.AnalyticsClient implementation backed
+// by the github.com/posthog/posthog-go SDK. It targets PostHog Cloud EU
+// (https://eu.i.posthog.com) by default and posts events asynchronously
+// through the SDK's internal worker so that callers never block on
+// network availability of the analytics destination.
+package posthog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	posthogsdk "github.com/posthog/posthog-go"
+
+	"github.com/liverty-music/backend/internal/usecase"
+)
+
+// DefaultAPIHost is the PostHog Cloud EU ingestion endpoint. Used when the
+// caller passes an empty apiHost to New.
+const DefaultAPIHost = "https://eu.i.posthog.com"
+
+// enqueuer is the minimal subset of the posthog SDK Client that this
+// adapter depends on. Declaring it here lets tests inject a fake without
+// having to implement the dozen feature-flag methods on the full
+// posthog.Client interface.
+type enqueuer interface {
+	Enqueue(posthogsdk.Message) error
+	Close() error
+}
+
+// AnalyticsClient is the PostHog-backed implementation of
+// usecase.AnalyticsClient. Construction is via New for production code
+// and via newWithEnqueuer (exposed through export_test.go) for tests.
+type AnalyticsClient struct {
+	client enqueuer
+}
+
+// Compile-time interface compliance check.
+var _ usecase.AnalyticsClient = (*AnalyticsClient)(nil)
+
+// New constructs an AnalyticsClient backed by a PostHog SDK client
+// configured against the given apiHost and projectAPIKey. If apiHost is
+// empty, DefaultAPIHost (PostHog Cloud EU) is used. The returned client
+// owns a background worker that flushes events asynchronously; call Close
+// at process shutdown to flush in-flight events.
+func New(apiHost, projectAPIKey string) (*AnalyticsClient, error) {
+	if projectAPIKey == "" {
+		return nil, errors.New("posthog: project API key must not be empty")
+	}
+	if apiHost == "" {
+		apiHost = DefaultAPIHost
+	}
+
+	sdkClient, err := posthogsdk.NewWithConfig(projectAPIKey, posthogsdk.Config{
+		Endpoint: apiHost,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create posthog client: %w", err)
+	}
+	return newWithEnqueuer(sdkClient), nil
+}
+
+// newWithEnqueuer wraps an existing enqueuer. Exposed for tests via
+// export_test.go.
+func newWithEnqueuer(client enqueuer) *AnalyticsClient {
+	return &AnalyticsClient{client: client}
+}
+
+// Enqueue implements usecase.AnalyticsClient. It hands the event to the
+// PostHog SDK's internal queue without blocking on network I/O. Transient
+// network failures and retries are absorbed by the SDK worker. Errors
+// returned here describe caller-side mistakes (empty distinctID, empty
+// eventName) or the SDK's own queue overflow.
+func (c *AnalyticsClient) Enqueue(
+	_ context.Context,
+	distinctID string,
+	eventName usecase.AnalyticsEventName,
+	properties usecase.AnalyticsProperties,
+) error {
+	if distinctID == "" {
+		return errors.New("posthog: distinctID must not be empty")
+	}
+	if eventName == "" {
+		return errors.New("posthog: eventName must not be empty")
+	}
+
+	props := posthogsdk.NewProperties()
+	for k, v := range properties {
+		props.Set(k, v)
+	}
+
+	if err := c.client.Enqueue(posthogsdk.Capture{
+		DistinctId: distinctID,
+		Event:      string(eventName),
+		Properties: props,
+	}); err != nil {
+		return fmt.Errorf("posthog enqueue %s: %w", eventName, err)
+	}
+	return nil
+}
+
+// Close flushes in-flight events and releases the SDK's background worker.
+// The underlying SDK Close blocks for up to its configured ShutdownTimeout
+// (unlimited by default) until the queue drains. The supplied context is
+// reserved for forwarding to a future CloseWithContext call; the SDK's
+// public Close does not currently accept a context.
+func (c *AnalyticsClient) Close(_ context.Context) error {
+	if err := c.client.Close(); err != nil {
+		return fmt.Errorf("posthog close: %w", err)
+	}
+	return nil
+}

--- a/internal/infrastructure/analytics/posthog/posthog_client_test.go
+++ b/internal/infrastructure/analytics/posthog/posthog_client_test.go
@@ -1,0 +1,200 @@
+package posthog_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	posthogsdk "github.com/posthog/posthog-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liverty-music/backend/internal/infrastructure/analytics/posthog"
+	"github.com/liverty-music/backend/internal/usecase"
+)
+
+// fakeEnqueuer captures every Enqueue call into a slice and reports whether
+// Close has been invoked. It implements posthog.Enqueuer.
+type fakeEnqueuer struct {
+	mu         sync.Mutex
+	captured   []posthogsdk.Capture
+	enqueueErr error
+	closeErr   error
+	closed     bool
+}
+
+func (f *fakeEnqueuer) Enqueue(msg posthogsdk.Message) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.enqueueErr != nil {
+		return f.enqueueErr
+	}
+	if c, ok := msg.(posthogsdk.Capture); ok {
+		f.captured = append(f.captured, c)
+	}
+	return nil
+}
+
+func (f *fakeEnqueuer) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return f.closeErr
+}
+
+func (f *fakeEnqueuer) Captured() []posthogsdk.Capture {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]posthogsdk.Capture, len(f.captured))
+	copy(out, f.captured)
+	return out
+}
+
+func (f *fakeEnqueuer) IsClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+
+// TestNew validates the production constructor's input-handling surface
+// without sending any real network traffic.
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects empty project API key", func(t *testing.T) {
+		t.Parallel()
+		client, err := posthog.New("https://eu.i.posthog.com", "")
+		assert.Nil(t, client)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project API key")
+	})
+
+	t.Run("succeeds with explicit apiHost and key", func(t *testing.T) {
+		t.Parallel()
+		client, err := posthog.New("https://eu.i.posthog.com", "phc_test")
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		// Close immediately to release the SDK worker goroutine.
+		assert.NoError(t, client.Close(context.Background()))
+	})
+
+	t.Run("defaults apiHost when empty", func(t *testing.T) {
+		t.Parallel()
+		client, err := posthog.New("", "phc_test")
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.NoError(t, client.Close(context.Background()))
+	})
+}
+
+// TestAnalyticsClient_Enqueue covers the happy path and the validation
+// branches of Enqueue using an injected fake enqueuer.
+func TestAnalyticsClient_Enqueue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("forwards a valid event to the SDK", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake)
+
+		err := client.Enqueue(
+			context.Background(),
+			"user-1",
+			usecase.EventTicketPurchaseCompleted,
+			usecase.AnalyticsProperties{
+				"ticket_id":    "ticket-42",
+				"concert_id":   "concert-7",
+				"price_bucket": "3000-4999",
+			},
+		)
+		require.NoError(t, err)
+
+		captured := fake.Captured()
+		require.Len(t, captured, 1)
+		assert.Equal(t, "user-1", captured[0].DistinctId)
+		assert.Equal(t, string(usecase.EventTicketPurchaseCompleted), captured[0].Event)
+		assert.Equal(t, "ticket-42", captured[0].Properties["ticket_id"])
+		assert.Equal(t, "concert-7", captured[0].Properties["concert_id"])
+		assert.Equal(t, "3000-4999", captured[0].Properties["price_bucket"])
+	})
+
+	t.Run("rejects empty distinctID without contacting the SDK", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake)
+
+		err := client.Enqueue(context.Background(), "", usecase.EventUserCreated, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "distinctID")
+		assert.Empty(t, fake.Captured())
+	})
+
+	t.Run("rejects empty eventName without contacting the SDK", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake)
+
+		err := client.Enqueue(context.Background(), "user-1", "", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "eventName")
+		assert.Empty(t, fake.Captured())
+	})
+
+	t.Run("accepts nil properties and forwards an empty property bag", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake)
+
+		err := client.Enqueue(context.Background(), "user-2", usecase.EventUserCreated, nil)
+		require.NoError(t, err)
+
+		captured := fake.Captured()
+		require.Len(t, captured, 1)
+		assert.Equal(t, "user-2", captured[0].DistinctId)
+		assert.NotNil(t, captured[0].Properties)
+	})
+
+	t.Run("wraps SDK errors with the event name for diagnostics", func(t *testing.T) {
+		t.Parallel()
+		sdkErr := errors.New("queue full")
+		fake := &fakeEnqueuer{enqueueErr: sdkErr}
+		client := posthog.NewWithEnqueuer(fake)
+
+		err := client.Enqueue(
+			context.Background(),
+			"user-1",
+			usecase.EventArtistFollowCompleted,
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), string(usecase.EventArtistFollowCompleted))
+		assert.ErrorIs(t, err, sdkErr)
+	})
+}
+
+// TestAnalyticsClient_Close exercises the Close path including SDK error
+// propagation.
+func TestAnalyticsClient_Close(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closes the underlying enqueuer", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake)
+
+		require.NoError(t, client.Close(context.Background()))
+		assert.True(t, fake.IsClosed())
+	})
+
+	t.Run("propagates the SDK close error wrapped", func(t *testing.T) {
+		t.Parallel()
+		sdkErr := errors.New("shutdown timeout")
+		fake := &fakeEnqueuer{closeErr: sdkErr}
+		client := posthog.NewWithEnqueuer(fake)
+
+		err := client.Close(context.Background())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sdkErr)
+	})
+}

--- a/internal/infrastructure/analytics/posthog/posthog_client_test.go
+++ b/internal/infrastructure/analytics/posthog/posthog_client_test.go
@@ -149,15 +149,15 @@ func TestAnalyticsClient_Enqueue(t *testing.T) {
 		properties usecase.AnalyticsProperties
 	}
 	tests := []struct {
-		name      string
-		args      args
-		setupErr  error // optional: makes the fake return this on Enqueue
-		wantErr   error
-		check     func(t *testing.T, fake *fakeEnqueuer)
+		name     string
+		args     args
+		setupErr error // optional: makes the fake return this on Enqueue
+		wantErr  error
+		check    func(t *testing.T, fake *fakeEnqueuer)
 	}{
 		{
-			name: "rejects empty distinctID",
-			args: args{distinctID: "", eventName: usecase.EventUserCreated},
+			name:    "rejects empty distinctID",
+			args:    args{distinctID: "", eventName: usecase.EventUserCreated},
 			wantErr: apperr.ErrInvalidArgument,
 			check: func(t *testing.T, fake *fakeEnqueuer) {
 				t.Helper()
@@ -165,8 +165,8 @@ func TestAnalyticsClient_Enqueue(t *testing.T) {
 			},
 		},
 		{
-			name: "rejects non-UUID distinctID (Finding 05 — Zitadel sub mistakenly passed)",
-			args: args{distinctID: "not-a-uuid", eventName: usecase.EventUserCreated},
+			name:    "rejects non-UUID distinctID (Finding 05 — Zitadel sub mistakenly passed)",
+			args:    args{distinctID: "not-a-uuid", eventName: usecase.EventUserCreated},
 			wantErr: apperr.ErrInvalidArgument,
 			check: func(t *testing.T, fake *fakeEnqueuer) {
 				t.Helper()
@@ -174,8 +174,8 @@ func TestAnalyticsClient_Enqueue(t *testing.T) {
 			},
 		},
 		{
-			name: "rejects empty eventName",
-			args: args{distinctID: validUUID, eventName: ""},
+			name:    "rejects empty eventName",
+			args:    args{distinctID: validUUID, eventName: ""},
 			wantErr: apperr.ErrInvalidArgument,
 			check: func(t *testing.T, fake *fakeEnqueuer) {
 				t.Helper()

--- a/internal/infrastructure/analytics/posthog/posthog_client_test.go
+++ b/internal/infrastructure/analytics/posthog/posthog_client_test.go
@@ -6,22 +6,34 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/pannpers/go-logging/logging"
 	posthogsdk "github.com/posthog/posthog-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/liverty-music/backend/internal/infrastructure/analytics/posthog"
 	"github.com/liverty-music/backend/internal/usecase"
 )
 
-// fakeEnqueuer captures every Enqueue call into a slice and reports whether
-// Close has been invoked. It implements posthog.Enqueuer.
+// testLogger returns a no-op logger suitable for unit tests; mirrors the
+// helper used in the musicbrainz/lastfm/fanarttv adapter tests.
+func testLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	l, _ := logging.New()
+	return l
+}
+
+// fakeEnqueuer captures every Enqueue call into a slice and reports
+// whether Close has been invoked. It satisfies posthog.Enqueuer.
 type fakeEnqueuer struct {
 	mu         sync.Mutex
 	captured   []posthogsdk.Capture
 	enqueueErr error
 	closeErr   error
-	closed     bool
+	closeCalls int
 }
 
 func (f *fakeEnqueuer) Enqueue(msg posthogsdk.Message) error {
@@ -39,7 +51,7 @@ func (f *fakeEnqueuer) Enqueue(msg posthogsdk.Message) error {
 func (f *fakeEnqueuer) Close() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.closed = true
+	f.closeCalls++
 	return f.closeErr
 }
 
@@ -51,150 +63,361 @@ func (f *fakeEnqueuer) Captured() []posthogsdk.Capture {
 	return out
 }
 
-func (f *fakeEnqueuer) IsClosed() bool {
+func (f *fakeEnqueuer) CloseCalls() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.closed
+	return f.closeCalls
 }
 
-// TestNew validates the production constructor's input-handling surface
-// without sending any real network traffic.
+// validUUID is reused across happy-path cases as a stand-in for a real
+// platform UserId UUID.
+const validUUID = "11111111-2222-3333-4444-555555555555"
+
+// TestNew validates the production constructor's input-handling surface.
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	t.Run("rejects empty project API key", func(t *testing.T) {
-		t.Parallel()
-		client, err := posthog.New("https://eu.i.posthog.com", "")
-		assert.Nil(t, client)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "project API key")
-	})
+	type args struct {
+		apiHost       string
+		projectAPIKey string
+		nilLogger     bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name:    "rejects empty project API key",
+			args:    args{apiHost: posthog.DefaultAPIHost, projectAPIKey: ""},
+			wantErr: apperr.ErrInvalidArgument,
+		},
+		{
+			name:    "rejects whitespace-only project API key (Finding 03)",
+			args:    args{apiHost: posthog.DefaultAPIHost, projectAPIKey: "   \t\n  "},
+			wantErr: apperr.ErrInvalidArgument,
+		},
+		{
+			name:    "rejects nil logger",
+			args:    args{apiHost: posthog.DefaultAPIHost, projectAPIKey: "phc_test", nilLogger: true},
+			wantErr: apperr.ErrInvalidArgument,
+		},
+		{
+			name:    "succeeds with explicit apiHost and key",
+			args:    args{apiHost: posthog.DefaultAPIHost, projectAPIKey: "phc_test"},
+			wantErr: nil,
+		},
+		{
+			name:    "defaults apiHost when empty",
+			args:    args{apiHost: "", projectAPIKey: "phc_test"},
+			wantErr: nil,
+		},
+	}
 
-	t.Run("succeeds with explicit apiHost and key", func(t *testing.T) {
-		t.Parallel()
-		client, err := posthog.New("https://eu.i.posthog.com", "phc_test")
-		require.NoError(t, err)
-		require.NotNil(t, client)
-		// Close immediately to release the SDK worker goroutine.
-		assert.NoError(t, client.Close(context.Background()))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("defaults apiHost when empty", func(t *testing.T) {
-		t.Parallel()
-		client, err := posthog.New("", "phc_test")
-		require.NoError(t, err)
-		require.NotNil(t, client)
-		assert.NoError(t, client.Close(context.Background()))
-	})
+			var lg *logging.Logger
+			if !tt.args.nilLogger {
+				lg = testLogger(t)
+			}
+
+			client, err := posthog.New(tt.args.apiHost, tt.args.projectAPIKey, lg)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, client)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, client)
+			// Release the SDK worker goroutine.
+			assert.NoError(t, client.Close())
+		})
+	}
 }
 
-// TestAnalyticsClient_Enqueue covers the happy path and the validation
-// branches of Enqueue using an injected fake enqueuer.
+// TestAnalyticsClient_Enqueue covers validation and happy-path branches
+// of Enqueue using an injected fake enqueuer.
 func TestAnalyticsClient_Enqueue(t *testing.T) {
 	t.Parallel()
 
-	t.Run("forwards a valid event to the SDK", func(t *testing.T) {
-		t.Parallel()
-		fake := &fakeEnqueuer{}
-		client := posthog.NewWithEnqueuer(fake)
-
-		err := client.Enqueue(
-			context.Background(),
-			"user-1",
-			usecase.EventTicketPurchaseCompleted,
-			usecase.AnalyticsProperties{
-				"ticket_id":    "ticket-42",
-				"concert_id":   "concert-7",
-				"price_bucket": "3000-4999",
+	type args struct {
+		distinctID string
+		eventName  usecase.AnalyticsEventName
+		properties usecase.AnalyticsProperties
+	}
+	tests := []struct {
+		name      string
+		args      args
+		setupErr  error // optional: makes the fake return this on Enqueue
+		wantErr   error
+		check     func(t *testing.T, fake *fakeEnqueuer)
+	}{
+		{
+			name: "rejects empty distinctID",
+			args: args{distinctID: "", eventName: usecase.EventUserCreated},
+			wantErr: apperr.ErrInvalidArgument,
+			check: func(t *testing.T, fake *fakeEnqueuer) {
+				t.Helper()
+				assert.Empty(t, fake.Captured(), "no event should reach the SDK")
 			},
-		)
+		},
+		{
+			name: "rejects non-UUID distinctID (Finding 05 — Zitadel sub mistakenly passed)",
+			args: args{distinctID: "not-a-uuid", eventName: usecase.EventUserCreated},
+			wantErr: apperr.ErrInvalidArgument,
+			check: func(t *testing.T, fake *fakeEnqueuer) {
+				t.Helper()
+				assert.Empty(t, fake.Captured())
+			},
+		},
+		{
+			name: "rejects empty eventName",
+			args: args{distinctID: validUUID, eventName: ""},
+			wantErr: apperr.ErrInvalidArgument,
+			check: func(t *testing.T, fake *fakeEnqueuer) {
+				t.Helper()
+				assert.Empty(t, fake.Captured())
+			},
+		},
+		{
+			name: "rejects unknown eventName (Finding 06 — typo guard)",
+			args: args{
+				distinctID: validUUID,
+				eventName:  usecase.AnalyticsEventName("ticket.purcase.completed"), // typo
+			},
+			wantErr: apperr.ErrInvalidArgument,
+			check: func(t *testing.T, fake *fakeEnqueuer) {
+				t.Helper()
+				assert.Empty(t, fake.Captured())
+			},
+		},
+		{
+			name: "forwards a known event with properties",
+			args: args{
+				distinctID: validUUID,
+				eventName:  usecase.EventTicketPurchaseCompleted,
+				properties: usecase.AnalyticsProperties{
+					"ticket_id":    "ticket-42",
+					"concert_id":   "concert-7",
+					"price_bucket": "3000-4999",
+				},
+			},
+			wantErr: nil,
+			check: func(t *testing.T, fake *fakeEnqueuer) {
+				t.Helper()
+				captured := fake.Captured()
+				require.Len(t, captured, 1)
+				assert.Equal(t, validUUID, captured[0].DistinctId)
+				assert.Equal(t, string(usecase.EventTicketPurchaseCompleted), captured[0].Event)
+				assert.Equal(t, "ticket-42", captured[0].Properties["ticket_id"])
+				assert.Equal(t, "concert-7", captured[0].Properties["concert_id"])
+				assert.Equal(t, "3000-4999", captured[0].Properties["price_bucket"])
+			},
+		},
+		{
+			name: "accepts nil properties and forwards nil to the SDK (Finding 15 — no empty allocation)",
+			args: args{
+				distinctID: validUUID,
+				eventName:  usecase.EventUserCreated,
+				properties: nil,
+			},
+			wantErr: nil,
+			check: func(t *testing.T, fake *fakeEnqueuer) {
+				t.Helper()
+				captured := fake.Captured()
+				require.Len(t, captured, 1)
+				assert.Equal(t, validUUID, captured[0].DistinctId)
+				assert.Nil(t, captured[0].Properties, "no empty map should be allocated when caller passes nil and no trace context is active")
+			},
+		},
+		{
+			name: "wraps SDK errors with the event name and apperr.ErrInternal",
+			args: args{
+				distinctID: validUUID,
+				eventName:  usecase.EventArtistFollowCompleted,
+				properties: nil,
+			},
+			setupErr: errors.New("queue full"),
+			wantErr:  apperr.ErrInternal,
+			check: func(t *testing.T, fake *fakeEnqueuer) {
+				t.Helper()
+				// no captured because the fake's enqueueErr short-circuits.
+				assert.Empty(t, fake.Captured())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeEnqueuer{enqueueErr: tt.setupErr}
+			client := posthog.NewWithEnqueuer(fake, testLogger(t))
+
+			err := client.Enqueue(
+				context.Background(),
+				tt.args.distinctID,
+				tt.args.eventName,
+				tt.args.properties,
+			)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.check != nil {
+				tt.check(t, fake)
+			}
+		})
+	}
+}
+
+// TestAnalyticsClient_Enqueue_TracePropagation verifies the OTel
+// trace_id injection branch (Finding 10).
+func TestAnalyticsClient_Enqueue_TracePropagation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("injects trace_id from active OTel span", func(t *testing.T) {
+		t.Parallel()
+		provider := trace.NewTracerProvider()
+		tracer := provider.Tracer("test")
+		ctx, span := tracer.Start(context.Background(), "test-op")
+		defer span.End()
+
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake, testLogger(t))
+
+		err := client.Enqueue(ctx, validUUID, usecase.EventUserCreated, usecase.AnalyticsProperties{"foo": "bar"})
 		require.NoError(t, err)
 
 		captured := fake.Captured()
 		require.Len(t, captured, 1)
-		assert.Equal(t, "user-1", captured[0].DistinctId)
-		assert.Equal(t, string(usecase.EventTicketPurchaseCompleted), captured[0].Event)
-		assert.Equal(t, "ticket-42", captured[0].Properties["ticket_id"])
-		assert.Equal(t, "concert-7", captured[0].Properties["concert_id"])
-		assert.Equal(t, "3000-4999", captured[0].Properties["price_bucket"])
+		expected := span.SpanContext().TraceID().String()
+		assert.Equal(t, expected, captured[0].Properties[posthog.TracePropertyKey], "trace_id must match the active span")
+		assert.Equal(t, "bar", captured[0].Properties["foo"], "caller-supplied properties must survive the injection copy")
 	})
 
-	t.Run("rejects empty distinctID without contacting the SDK", func(t *testing.T) {
+	t.Run("does not overwrite caller-supplied trace_id", func(t *testing.T) {
 		t.Parallel()
+		provider := trace.NewTracerProvider()
+		tracer := provider.Tracer("test")
+		ctx, span := tracer.Start(context.Background(), "test-op")
+		defer span.End()
+
 		fake := &fakeEnqueuer{}
-		client := posthog.NewWithEnqueuer(fake)
+		client := posthog.NewWithEnqueuer(fake, testLogger(t))
 
-		err := client.Enqueue(context.Background(), "", usecase.EventUserCreated, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "distinctID")
-		assert.Empty(t, fake.Captured())
-	})
-
-	t.Run("rejects empty eventName without contacting the SDK", func(t *testing.T) {
-		t.Parallel()
-		fake := &fakeEnqueuer{}
-		client := posthog.NewWithEnqueuer(fake)
-
-		err := client.Enqueue(context.Background(), "user-1", "", nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "eventName")
-		assert.Empty(t, fake.Captured())
-	})
-
-	t.Run("accepts nil properties and forwards an empty property bag", func(t *testing.T) {
-		t.Parallel()
-		fake := &fakeEnqueuer{}
-		client := posthog.NewWithEnqueuer(fake)
-
-		err := client.Enqueue(context.Background(), "user-2", usecase.EventUserCreated, nil)
+		err := client.Enqueue(ctx, validUUID, usecase.EventUserCreated, usecase.AnalyticsProperties{
+			posthog.TracePropertyKey: "caller-supplied-trace",
+		})
 		require.NoError(t, err)
 
 		captured := fake.Captured()
 		require.Len(t, captured, 1)
-		assert.Equal(t, "user-2", captured[0].DistinctId)
-		assert.NotNil(t, captured[0].Properties)
+		assert.Equal(t, "caller-supplied-trace", captured[0].Properties[posthog.TracePropertyKey])
 	})
 
-	t.Run("wraps SDK errors with the event name for diagnostics", func(t *testing.T) {
+	t.Run("no trace_id when context has no active span", func(t *testing.T) {
 		t.Parallel()
-		sdkErr := errors.New("queue full")
-		fake := &fakeEnqueuer{enqueueErr: sdkErr}
-		client := posthog.NewWithEnqueuer(fake)
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake, testLogger(t))
 
-		err := client.Enqueue(
-			context.Background(),
-			"user-1",
-			usecase.EventArtistFollowCompleted,
-			nil,
-		)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), string(usecase.EventArtistFollowCompleted))
-		assert.ErrorIs(t, err, sdkErr)
+		err := client.Enqueue(context.Background(), validUUID, usecase.EventUserCreated, usecase.AnalyticsProperties{"foo": "bar"})
+		require.NoError(t, err)
+
+		captured := fake.Captured()
+		require.Len(t, captured, 1)
+		_, has := captured[0].Properties[posthog.TracePropertyKey]
+		assert.False(t, has, "no trace_id should be auto-injected without an active span")
+	})
+
+	t.Run("caller's properties map is not mutated", func(t *testing.T) {
+		t.Parallel()
+		provider := trace.NewTracerProvider()
+		tracer := provider.Tracer("test")
+		ctx, span := tracer.Start(context.Background(), "test-op")
+		defer span.End()
+
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake, testLogger(t))
+
+		callerProps := usecase.AnalyticsProperties{"foo": "bar"}
+		require.NoError(t, client.Enqueue(ctx, validUUID, usecase.EventUserCreated, callerProps))
+
+		_, mutated := callerProps[posthog.TracePropertyKey]
+		assert.False(t, mutated, "caller's map must remain unchanged after trace_id injection")
 	})
 }
 
-// TestAnalyticsClient_Close exercises the Close path including SDK error
-// propagation.
+// TestAnalyticsClient_Close covers the io.Closer-compatible Close path
+// including idempotency (Finding 04).
 func TestAnalyticsClient_Close(t *testing.T) {
 	t.Parallel()
 
 	t.Run("closes the underlying enqueuer", func(t *testing.T) {
 		t.Parallel()
 		fake := &fakeEnqueuer{}
-		client := posthog.NewWithEnqueuer(fake)
+		client := posthog.NewWithEnqueuer(fake, testLogger(t))
 
-		require.NoError(t, client.Close(context.Background()))
-		assert.True(t, fake.IsClosed())
+		require.NoError(t, client.Close())
+		assert.Equal(t, 1, fake.CloseCalls())
 	})
 
-	t.Run("propagates the SDK close error wrapped", func(t *testing.T) {
+	t.Run("propagates the SDK close error wrapped as apperr.ErrInternal", func(t *testing.T) {
 		t.Parallel()
 		sdkErr := errors.New("shutdown timeout")
 		fake := &fakeEnqueuer{closeErr: sdkErr}
-		client := posthog.NewWithEnqueuer(fake)
+		client := posthog.NewWithEnqueuer(fake, testLogger(t))
 
-		err := client.Close(context.Background())
-		require.Error(t, err)
+		err := client.Close()
+		assert.ErrorIs(t, err, apperr.ErrInternal)
 		assert.ErrorIs(t, err, sdkErr)
 	})
+
+	t.Run("is idempotent across repeated calls (Finding 04)", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeEnqueuer{}
+		client := posthog.NewWithEnqueuer(fake, testLogger(t))
+
+		// First call closes successfully.
+		require.NoError(t, client.Close())
+		// Second and third calls return the same result, NOT a wrapped ErrClosed.
+		assert.NoError(t, client.Close())
+		assert.NoError(t, client.Close())
+		// SDK Close is invoked exactly once.
+		assert.Equal(t, 1, fake.CloseCalls(), "sync.Once must gate the underlying SDK call")
+	})
+
+	t.Run("idempotent error path returns the same wrapped error on repeated calls", func(t *testing.T) {
+		t.Parallel()
+		sdkErr := errors.New("shutdown timeout")
+		fake := &fakeEnqueuer{closeErr: sdkErr}
+		client := posthog.NewWithEnqueuer(fake, testLogger(t))
+
+		first := client.Close()
+		second := client.Close()
+		assert.ErrorIs(t, first, apperr.ErrInternal)
+		assert.ErrorIs(t, second, apperr.ErrInternal)
+		assert.Equal(t, first.Error(), second.Error(), "same error on every call")
+		assert.Equal(t, 1, fake.CloseCalls())
+	})
+}
+
+// TestNew_GeneratedKeys exercises uuid.New() round-trips through the
+// adapter to confirm production-shape distinctIDs satisfy the UUID guard.
+func TestEnqueue_AcceptsUUIDGeneratedDistinctID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeEnqueuer{}
+	client := posthog.NewWithEnqueuer(fake, testLogger(t))
+
+	generated := uuid.New().String()
+	require.NoError(t, client.Enqueue(context.Background(), generated, usecase.EventUserCreated, nil))
+
+	captured := fake.Captured()
+	require.Len(t, captured, 1)
+	assert.Equal(t, generated, captured[0].DistinctId)
 }

--- a/internal/usecase/analytics_client.go
+++ b/internal/usecase/analytics_client.go
@@ -1,0 +1,48 @@
+package usecase
+
+import "context"
+
+// AnalyticsProperties carries the per-event payload sent to the analytics
+// destination. Keys MUST be snake_case and MUST NOT include personally
+// identifiable information; see specification/docs/analytics/event-catalog.md
+// for the per-event property contract and the PII three-layer classification.
+type AnalyticsProperties map[string]any
+
+// AnalyticsClient delivers product-analytics events to the configured
+// analytics destination (PostHog Cloud EU in production).
+//
+// Implementations MUST NOT block the caller on network availability of the
+// destination. Enqueue is expected to hand the event off to an internal
+// buffer or queue and return immediately so that Connect-RPC handlers
+// retain their latency contract even when the analytics destination is
+// degraded.
+//
+// Trust-critical events (ticket purchases, ZK proof verification, push
+// delivery, account state changes) flow through AnalyticsClient from the
+// analytics-consumer adapter, which subscribes to existing NATS event
+// subjects. Connect-RPC handlers MUST NOT call AnalyticsClient directly.
+type AnalyticsClient interface {
+	// Enqueue hands an event off for asynchronous delivery to the
+	// analytics destination.
+	//
+	// distinctID is the platform-internal UserId UUID — never the
+	// Zitadel sub claim and never an empty string. Implementations MUST
+	// reject empty distinctID and MUST NOT substitute a fallback identifier
+	// that could correlate to a real user across sessions.
+	//
+	// eventName MUST be one of the AnalyticsEventName constants defined
+	// in analytics_events.go.
+	//
+	// properties is the per-event payload, optional, sanitised per the
+	// PII policy before this call.
+	//
+	// Enqueue returns an error only for caller-side mistakes (empty
+	// distinctID, unknown eventName). Transient destination failures are
+	// retried internally by the implementation and never surfaced here.
+	Enqueue(ctx context.Context, distinctID string, eventName AnalyticsEventName, properties AnalyticsProperties) error
+
+	// Close flushes any in-flight events and releases resources. It is
+	// invoked at process shutdown. Close MUST be safe to call after a
+	// failed initialisation and MUST be idempotent.
+	Close(ctx context.Context) error
+}

--- a/internal/usecase/analytics_client.go
+++ b/internal/usecase/analytics_client.go
@@ -19,30 +19,44 @@ type AnalyticsProperties map[string]any
 //
 // Trust-critical events (ticket purchases, ZK proof verification, push
 // delivery, account state changes) flow through AnalyticsClient from the
-// analytics-consumer adapter, which subscribes to existing NATS event
+// analytics-consumer adapter, which subscribes to existing domain event
 // subjects. Connect-RPC handlers MUST NOT call AnalyticsClient directly.
+//
+// Lifecycle (Close, flush) is intentionally NOT part of this interface.
+// Implementations expose an io.Closer-compatible Close method on the
+// concrete type so the DI layer can register them with the shutdown
+// manager via shutdown.AddExternalPhase, matching the pattern used by
+// other outbound clients (lastfm, musicbrainz, fanarttv, db).
 type AnalyticsClient interface {
 	// Enqueue hands an event off for asynchronous delivery to the
 	// analytics destination.
 	//
 	// distinctID is the platform-internal UserId UUID — never the
 	// Zitadel sub claim and never an empty string. Implementations MUST
-	// reject empty distinctID and MUST NOT substitute a fallback identifier
-	// that could correlate to a real user across sessions.
+	// reject empty distinctID and SHOULD validate UUID format so that
+	// callers cannot accidentally pass an opaque IdP subject identifier.
 	//
 	// eventName MUST be one of the AnalyticsEventName constants defined
-	// in analytics_events.go.
+	// in analytics_events.go. Implementations MUST reject unknown event
+	// names (use IsKnownEvent for membership checks) so a typo at a
+	// call site fails fast instead of silently fragmenting dashboards.
+	//
+	// ctx is read by implementations to extract the active OpenTelemetry
+	// trace ID and inject it into the event payload as the `trace_id`
+	// property, providing a one-click bridge from the analytics event to
+	// the originating request trace during incident investigation. ctx
+	// cancellation is NOT propagated to the underlying SDK because the
+	// posthog-go Client interface does not expose a context-aware Enqueue.
 	//
 	// properties is the per-event payload, optional, sanitised per the
-	// PII policy before this call.
+	// PII policy before this call. Implementations MUST NOT mutate the
+	// supplied map; trace_id injection, when applied, happens on a
+	// defensive copy.
 	//
-	// Enqueue returns an error only for caller-side mistakes (empty
-	// distinctID, unknown eventName). Transient destination failures are
-	// retried internally by the implementation and never surfaced here.
+	// Enqueue returns an apperr-coded error for caller-side mistakes
+	// (codes.InvalidArgument: empty/non-UUID distinctID, empty/unknown
+	// eventName) and for the rare SDK queue-overflow case
+	// (codes.Internal). Transient destination failures are retried
+	// internally by the implementation and never surfaced here.
 	Enqueue(ctx context.Context, distinctID string, eventName AnalyticsEventName, properties AnalyticsProperties) error
-
-	// Close flushes any in-flight events and releases resources. It is
-	// invoked at process shutdown. Close MUST be safe to call after a
-	// failed initialisation and MUST be idempotent.
-	Close(ctx context.Context) error
 }

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -109,3 +109,39 @@ const (
 	// downstream open/dismiss separately.
 	EventPushNotificationDelivered AnalyticsEventName = "push.notification.delivered"
 )
+
+// knownBackendEvents is the allowlist of AnalyticsEventName constants
+// emitted from the backend. AnalyticsClient implementations consult this
+// via IsKnownEvent to reject typos at the call site, satisfying the
+// "unknown eventName" contract on Enqueue.
+//
+// The map is populated lazily-once at package init via the const groups
+// above; every new constant MUST be added here in the same commit.
+var knownBackendEvents = map[AnalyticsEventName]struct{}{
+	EventAccountSignupCompleted:          {},
+	EventAccountLogin:                    {},
+	EventAccountPreferredLanguageUpdated: {},
+	EventUserCreated:                     {},
+	EventUserDeleted:                     {},
+	EventArtistFollowCompleted:           {},
+	EventArtistUnfollowCompleted:         {},
+	EventConcertRecommendationServed:     {},
+	EventTicketLotteryEntryAccepted:      {},
+	EventTicketLotteryEntryRejected:      {},
+	EventTicketLotteryResultAssigned:     {},
+	EventTicketPurchaseCompleted:         {},
+	EventTicketPurchaseFailed:            {},
+	EventEntryZkProofVerified:            {},
+	EventEntryZkProofRejected:            {},
+	EventPushSubscriptionCompleted:       {},
+	EventPushNotificationDelivered:       {},
+}
+
+// IsKnownEvent reports whether name is registered in the backend event
+// catalogue. AnalyticsClient implementations call this on Enqueue to
+// fail fast on typos like AnalyticsEventName("ticket.purcase.completed")
+// that would otherwise silently fragment downstream dashboards.
+func IsKnownEvent(name AnalyticsEventName) bool {
+	_, ok := knownBackendEvents[name]
+	return ok
+}

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -1,0 +1,111 @@
+package usecase
+
+// AnalyticsEventName identifies a product-analytics event recorded against a
+// user's behavioral profile in PostHog.
+//
+// Every event emitted from the backend MUST use a constant defined here.
+// Event names follow the convention domain.action[.outcome] in dot.case;
+// see specification/docs/analytics/event-catalog.md for the catalogue and
+// per-event property contracts.
+//
+// Frontend-only events are NOT listed here; they live in
+// frontend/src/services/analytics-events.ts. Trust-critical events whose
+// accuracy must survive client tampering (ticket purchases, ZK proof
+// verification, push delivery, account state changes) are emitted only
+// from the backend through these constants.
+type AnalyticsEventName string
+
+// Account lifecycle events emitted from the backend.
+const (
+	// EventAccountSignupCompleted is recorded when a new user record has
+	// been persisted after Zitadel returns a successful signup callback.
+	EventAccountSignupCompleted AnalyticsEventName = "account.signup.completed"
+
+	// EventAccountLogin is recorded when an existing user successfully
+	// completes the OIDC authentication callback.
+	EventAccountLogin AnalyticsEventName = "account.login"
+
+	// EventAccountPreferredLanguageUpdated is recorded when a user's
+	// preferred display language is changed via UpdatePreferredLanguage.
+	EventAccountPreferredLanguageUpdated AnalyticsEventName = "account.preferred_language.updated"
+
+	// EventUserCreated is recorded when the backend creates a User record
+	// for the first time, either through self-signup or admin provisioning.
+	EventUserCreated AnalyticsEventName = "user.created"
+
+	// EventUserDeleted is recorded when a User record is permanently
+	// removed from the platform.
+	EventUserDeleted AnalyticsEventName = "user.deleted"
+)
+
+// Artist engagement events emitted from the backend after persistence.
+const (
+	// EventArtistFollowCompleted is recorded after a follow relationship
+	// has been persisted. The frontend emits a paired artist.follow.requested
+	// event at the moment the user submits the action.
+	EventArtistFollowCompleted AnalyticsEventName = "artist.follow.completed"
+
+	// EventArtistUnfollowCompleted is recorded after the corresponding
+	// follow relationship has been removed.
+	EventArtistUnfollowCompleted AnalyticsEventName = "artist.unfollow.completed"
+)
+
+// Concert and recommendation events emitted from the backend.
+const (
+	// EventConcertRecommendationServed is recorded when the backend
+	// computes a recommendation set for a user. This is the truth source
+	// for recommendation impressions; the frontend records click-through
+	// separately via concert.recommendation.clicked.
+	EventConcertRecommendationServed AnalyticsEventName = "concert.recommendation.served"
+)
+
+// Ticket lottery and purchase events emitted from the backend.
+const (
+	// EventTicketLotteryEntryAccepted is recorded after a lottery entry
+	// passes validation and is persisted. Paired with the frontend
+	// ticket.lottery.entry.submitted to measure the intent-to-acceptance gap.
+	EventTicketLotteryEntryAccepted AnalyticsEventName = "ticket.lottery.entry.accepted"
+
+	// EventTicketLotteryEntryRejected is recorded when a lottery entry
+	// fails validation (duplicate, closed window, etc.). Paired with
+	// ticket.lottery.entry.submitted.
+	EventTicketLotteryEntryRejected AnalyticsEventName = "ticket.lottery.entry.rejected"
+
+	// EventTicketLotteryResultAssigned is recorded when the lottery draw
+	// completes and a result (WON or LOST) is recorded against the entry.
+	EventTicketLotteryResultAssigned AnalyticsEventName = "ticket.lottery.result.assigned"
+
+	// EventTicketPurchaseCompleted is the trust-critical event recorded
+	// when a payment provider confirms a successful ticket purchase. The
+	// frontend emits a paired ticket.purchase.initiated at the moment the
+	// user starts the purchase flow.
+	EventTicketPurchaseCompleted AnalyticsEventName = "ticket.purchase.completed"
+
+	// EventTicketPurchaseFailed is recorded when a purchase attempt is
+	// rejected by the payment provider or backend validation.
+	EventTicketPurchaseFailed AnalyticsEventName = "ticket.purchase.failed"
+)
+
+// Entry verification events emitted from the backend, including the
+// zero-knowledge-proof check at venue gates.
+const (
+	// EventEntryZkProofVerified is recorded when a fan's Groth16 proof
+	// passes verification against the published Merkle root for the event.
+	EventEntryZkProofVerified AnalyticsEventName = "entry.zk_proof.verified"
+
+	// EventEntryZkProofRejected is recorded when proof verification fails
+	// for any reason (invalid proof, wrong event, expired commitment).
+	EventEntryZkProofRejected AnalyticsEventName = "entry.zk_proof.rejected"
+)
+
+// Push notification lifecycle events emitted from the backend.
+const (
+	// EventPushSubscriptionCompleted is recorded after a Web Push
+	// subscription has been persisted against the user record.
+	EventPushSubscriptionCompleted AnalyticsEventName = "push.subscription.completed"
+
+	// EventPushNotificationDelivered is recorded when the push provider
+	// accepts a notification for delivery. The frontend records the
+	// downstream open/dismiss separately.
+	EventPushNotificationDelivered AnalyticsEventName = "push.notification.delivered"
+)


### PR DESCRIPTION
## Summary

Batch 1 + 2a for the backend analytics introduction. Two stacked commits:

**Batch 1 — Contract layer (commit 6fe4c45):**
- `internal/usecase/analytics_client.go`: `AnalyticsClient` interface (`Enqueue` + `Close`) with the non-blocking-enqueue contract.
- `internal/usecase/analytics_events.go`: canonical `AnalyticsEventName` constants for all 17 backend-emitted events.

**Batch 2a — PostHog adapter (commit fc8388d):**
- `internal/infrastructure/analytics/posthog/posthog_client.go`: `AnalyticsClient` impl backed by `github.com/posthog/posthog-go` v1.13.1. Defaults to PostHog Cloud EU (`https://eu.i.posthog.com`), rejects empty project keys, translates `AnalyticsProperties` to `posthog.Properties`, hands events to the SDK's async worker.
- An internal `enqueuer` interface narrows the SDK surface to `Enqueue` + `Close`, enabling test injection without implementing posthog.Client's dozen feature-flag methods.
- `export_test.go` exposes the constructor + interface alias to the external `posthog_test` package.
- `posthog_client_test.go`: 8 test cases covering happy path, both validation branches, nil properties, SDK error wrapping, Close success and error propagation, and constructor input handling. All pass.

distinctID is the platform-internal Liverty `UserId` UUID; use of the Zitadel `sub` claim is forbidden by the interface contract.

This is **Batch 1+2a of 5**. Still ahead in subsequent batches:

- **2b**: `analytics-consumer` worker + DI wiring + config struct + entrypoint
- **3**: Frontend `AnalyticsService` runtime + consent UI
- **4**: Feature-flag helpers + integration tests
- **5**: Dashboards, privacy policy, rollout

## Path adjustment from design.md

The OpenSpec design.md originally placed the adapter under `internal/adapter/analytics/posthog/`. After inspecting the repo, that path is inconsistent with the existing pattern where outbound-dependency adapters (`messaging`, `webpush`, `zitadel`, etc.) live under `internal/infrastructure/`. The adapter ships at `internal/infrastructure/analytics/posthog/` and `tasks.md` is updated to reflect the correct path. Also: the repo uses hand-written DI in `internal/di/provider.go`, not Google Wire — `tasks.md` updated accordingly.

## Context

OpenSpec change: [`introduce-analytics-tool`](https://github.com/liverty-music/specification/tree/introduce-analytics-tool/openspec/changes/introduce-analytics-tool) on the specification repo.

Capability requirements covered:

- *Analytics `distinct_id` is the platform-internal `UserId`* (Decision 3 in `design.md`)
- *Event names follow `domain.action[.outcome]` in dot.case* (Decision 4)
- *Event sourcing is partitioned between frontend and backend* — BE half (Decision 5)
- *Backend analytics flow uses NATS and an `analytics-consumer`* — adapter layer prep (Decision 6); the consumer itself ships in Batch 2b
- *AnalyticsClient is non-blocking* (Decision 6) — verified by the SDK's async worker model and the adapter's contract

## Companion PRs

- liverty-music/specification#533 — OpenSpec change + canonical event catalogue + flag policy
- liverty-music/frontend#375 — typed `Events` catalogue
- liverty-music/cloud-provisioning#315 — PostHog secret rotation runbook

## Test plan

- [x] `go test ./internal/infrastructure/analytics/posthog/...` passes (8/8 verified locally)
- [x] `go build ./...` passes
- [ ] `make check` passes
- [ ] Event-name constants match the canonical catalogue at `specification/docs/analytics/event-catalog.md`

Refs: liverty-music/specification#532