### PR TITLE
ci(deploy): guarantee a dev image for every main commit (build-or-inherit)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,19 +155,27 @@ jobs:
       #   * any build-relevant file changed -> build (produces fresh images)
       #   * none changed                     -> inherit the parent tip's digest
       #     so this commit still gets a :<sha> image (byte-identical to parent).
-      # Unknown parent (zero `before` SHA on branch creation / force-push, or
-      # an unresolvable parent commit) -> build: the conservative choice that
-      # always produces a fresh image rather than risk a wrong inherit.
+      # Force-push and branch-creation are NOT inheritable and route to build:
+      #   * force-push: `github.event.before` is the previous, now-orphaned tip
+      #     (a real non-zero SHA, flagged by `github.event.forced == true`) that
+      #     is not necessarily an ancestor of the new tip — inheriting its
+      #     digest would pin :<sha> to non-equivalent bytes.
+      #   * branch creation: `github.event.before` is the zero SHA
+      #     (`github.event.created == true`) — no ancestor image exists.
+      # An otherwise-unresolvable parent commit also defaults to build (the
+      # conservative choice that always produces a fresh image).
       - name: Decide build vs inherit (push path)
         if: github.event_name == 'push'
         id: decide
         env:
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
+          FORCED: ${{ github.event.forced }}
+          CREATED: ${{ github.event.created }}
         run: |
           set -uo pipefail
-          if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
-            echo "Parent commit unavailable (BEFORE=${BEFORE}); defaulting to build."
+          if [ "${FORCED}" = "true" ] || [ "${CREATED}" = "true" ] || [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "Force-push / branch-creation / unresolvable parent (forced=${FORCED} created=${CREATED} before=${BEFORE}) -> build."
             echo "mode=build" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -253,6 +261,10 @@ jobs:
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
         run: |
+          # NOTE: -e is intentionally NOT set here — the resolve() calls below
+          # are expected to return non-zero on a missing tag (that drives the
+          # :main fallback), and `digest=$(resolve ...)` would abort under -e.
+          # -e is enabled explicitly just before the crane copy sequence.
           set -uo pipefail
           resolve() { gcloud artifacts docker images describe "$1" --format='value(image_summary.digest)' 2>/dev/null; }
           # The parent push tip (event.before) has a :<sha> image by induction.
@@ -266,6 +278,8 @@ jobs:
             exit 1
           fi
           echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."
+          # Abort immediately if any of the three retags fails.
+          set -e
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:${SHA}"
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:main"
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:latest"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,19 @@
 name: Deploy Backend
 
 # Dual trigger:
-#  - push to main      -> dev build, dev AR (liverty-music-dev/backend)
-#                         4× docker/build-push-action across the strategy
-#                         matrix (server, consumer, concert-discovery,
-#                         artist-image-sync). Each builds and pushes
-#                         :latest, :main, :<sha> for its image.
+#  - push to main      -> dev AR (liverty-music-dev/backend). Every push to
+#                         main runs this workflow (no paths: trigger gate).
+#                         A per-run "build vs inherit" decision over the
+#                         pushed range (event.before..sha) picks one of:
+#                           * build:   4× docker/build-push-action across the
+#                                      strategy matrix (server, consumer,
+#                                      concert-discovery, artist-image-sync),
+#                                      pushing :latest, :main, :<sha>.
+#                           * inherit: no rebuild — crane-copy the parent push
+#                                      tip's dev digest onto :<sha> (and
+#                                      re-point :main, :latest). Used when the
+#                                      push changed no build-relevant file
+#                                      (CI config / docs only).
 #  - release published -> retag dev AR digest into prod AR
 #                         (liverty-music-prod/backend). 4× `crane copy`
 #                         across the matrix — no rebuild. Each matrix
@@ -21,19 +29,17 @@ name: Deploy Backend
 # rebuild per release event (4× ~90 s sequential build-push) down to
 # ~30 s of parallel digest-resolve + crane copy.
 #
-# The `paths:` filter only applies to `push` events. Release events fire on
-# any published Release regardless of file diff — the deploy step is always
-# desired for a Release cut.
+# Per OpenSpec change `guarantee-dev-image-per-main-commit`, the `paths:`
+# trigger gate was removed so EVERY main commit gets a resolvable dev
+# `:<sha>` image (by build or by parent-digest inheritance). This makes
+# "any main commit is releasable" a true invariant: a release cut on main
+# HEAD always resolves a dev image, regardless of what the HEAD commit
+# touched. The former glob set now drives the in-workflow build-vs-inherit
+# decision instead of gating the trigger.
 on:
   push:
     branches:
       - main
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Dockerfile'
-      - '.github/workflows/deploy.yml'
   release:
     types: [published]
 
@@ -67,8 +73,7 @@ jobs:
       id-token: write
     strategy:
       # fail-fast: false so that one matrix entry's failure (e.g. transient
-      # AR error during digest-resolve, or a single-image dev build that
-      # was filtered out by paths) does NOT cancel the other 3. Partial
+      # AR error during digest-resolve) does NOT cancel the other 3. Partial
       # success is the expected steady state on release events: per the
       # retag runbook, the operator can `gh run rerun --job <job-id>` the
       # single failing matrix entry. The 3 successful entries' prod AR
@@ -95,6 +100,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so the push-path "build vs inherit" decision can
+          # diff the pushed range (event.before..sha), and so the release
+          # path's ancestry verification has main's history available.
+          fetch-depth: 0
 
       # Defensive guard layer 2 (runtime verification): for release events,
       # confirm the checked-out commit (`github.sha`, == the tag's commit)
@@ -113,7 +123,7 @@ jobs:
         run: |
           git fetch origin main --depth=100
           if ! git merge-base --is-ancestor HEAD origin/main; then
-            echo "::error::Release tag at $(git rev-parse HEAD) is not reachable from origin/main ($(git rev-parse origin/main)). Refusing to push prod images. Cut releases on main HEAD only."
+            echo "::error::Release tag at $(git rev-parse HEAD) is not reachable from origin/main ($(git rev-parse origin/main)). Refusing to push prod images. Cut releases on a commit reachable from main — main HEAD is always valid, since every main commit has a resolvable dev image (guarantee-dev-image-per-main-commit)."
             exit 1
           fi
 
@@ -127,26 +137,55 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      # `Configure Docker` runs on BOTH paths:
-      #   * push path:    docker/build-push-action's pusher needs it.
-      #   * release path: `crane` reads its auth from ~/.docker/config.json's
-      #                   credential helpers (the gcloud helper for *.pkg.dev).
-      #                   Without this step crane falls back to anonymous and
-      #                   fails on the prod-AR write.
-      # Backend's existing step is already unconditional, so no gating
-      # change is needed here (unlike the frontend rollout which had to
-      # drop a `push`-only `if:` gate during implementation).
+      # `Configure Docker` runs on ALL paths:
+      #   * push/build path:   docker/build-push-action's pusher needs it.
+      #   * push/inherit path: `crane` reads its auth from ~/.docker/config.json's
+      #                        credential helpers (the dev AR copy is dev->dev).
+      #   * release path:      `crane` likewise reads ~/.docker/config.json for
+      #                        the cross-project prod-AR write.
       - name: Configure Docker
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
 
-      # IMAGE_URI is only consumed by `Set Image Tags (dev path)` and the
-      # `Build and Push Docker Image` step, both push-only. Gate the
-      # assignment to push too so the release path doesn't carry a dead
-      # env var that future readers might assume is wired into the retag
-      # flow. (The retag steps below construct DEV_AR_IMAGE /
-      # PROD_AR_IMAGE from literal AR paths, not IMAGE_URI.)
-      - name: Set Image URI
+      # =====================================================================
+      # Push path: decide build vs inherit
+      # =====================================================================
+      # The `paths:` trigger gate was removed (guarantee-dev-image-per-main-commit)
+      # so every push to main runs this workflow. Replicate the former glob set
+      # as an in-workflow decision over the pushed range event.before..sha:
+      #   * any build-relevant file changed -> build (produces fresh images)
+      #   * none changed                     -> inherit the parent tip's digest
+      #     so this commit still gets a :<sha> image (byte-identical to parent).
+      # Unknown parent (zero `before` SHA on branch creation / force-push, or
+      # an unresolvable parent commit) -> build: the conservative choice that
+      # always produces a fresh image rather than risk a wrong inherit.
+      - name: Decide build vs inherit (push path)
         if: github.event_name == 'push'
+        id: decide
+        env:
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "Parent commit unavailable (BEFORE=${BEFORE}); defaulting to build."
+            echo "mode=build" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "${BEFORE}" "${SHA}")
+          echo "Changed files in ${BEFORE}..${SHA}:"
+          echo "${changed}"
+          # Build glob set (kept in lock-step with the prior `on.push.paths`):
+          # any *.go, go.mod, go.sum, root Dockerfile, or this workflow file.
+          if echo "${changed}" | grep -qE '\.go$|^go\.mod$|^go\.sum$|^Dockerfile$|^\.github/workflows/deploy\.yml$'; then
+            echo "Build-relevant change detected -> build."
+            echo "mode=build" >> "$GITHUB_OUTPUT"
+          else
+            echo "No build-relevant change -> inherit parent digest."
+            echo "mode=inherit" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set Image URI
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'build'
         run: echo "IMAGE_URI=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ matrix.image.name }}" >> $GITHUB_ENV
 
       # Dev tag set: :latest (consumed by ArgoCD Image Updater for dev
@@ -156,18 +195,18 @@ jobs:
       # path those tags are written by `crane copy` directly (no
       # IMAGE_TAGS env-var indirection is needed on prod).
       - name: Set Image Tags (dev path)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'build'
         run: echo "IMAGE_TAGS=${{ env.IMAGE_URI }}:latest,${{ env.IMAGE_URI }}:${{ github.sha }},${{ env.IMAGE_URI }}:main" >> $GITHUB_ENV
 
       # =====================================================================
-      # Dev push path: build + push the 4 images to dev AR
+      # Dev build path: build + push the 4 images to dev AR
       # =====================================================================
       - name: Set up Docker Buildx
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'build'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Docker Image
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'build'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -176,6 +215,60 @@ jobs:
           tags: ${{ env.IMAGE_TAGS }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+
+      # Install `crane` (go-containerregistry's registry CLI) for the
+      # cross-repository / cross-project digest copy. Needed on BOTH the
+      # push/inherit path (dev->dev retag) and the release path (dev->prod
+      # retag). `gcloud artifacts docker tags add` is intentionally NOT used:
+      # despite its name, it only renames tags within a single repository —
+      # passing a source from `liverty-music-dev/backend/<img>` and a
+      # destination in `liverty-music-prod/backend/<img>` fails with
+      # `Image ... does not match image ...`. `crane copy` is the
+      # registry-to-registry primitive; within the same AR region it uses
+      # cross-repo blob mounting so no image bytes actually transfer
+      # (manifest re-push only).
+      #
+      # Note: the action's name is `setup-crane`, and it installs the
+      # `crane` binary — NOT the `gcrane` wrapper. `crane` works for AR.
+      # Auth: `crane` reads ~/.docker/config.json populated by the
+      # `Configure Docker` step above (unconditional).
+      - name: Install crane
+        if: github.event_name == 'release' || (github.event_name == 'push' && steps.decide.outputs.mode == 'inherit')
+        # SHA-pinned: on the release path this action runs with prod AR
+        # credentials, so a hijacked mutable tag would execute code with
+        # prod-write authority. SHA of v0.4 verified against
+        # https://github.com/imjasonh/setup-crane refs/tags/v0.4.
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      # =====================================================================
+      # Push/inherit path: this commit changed nothing build-relevant, so its
+      # image is byte-identical to the parent push tip's. Copy the parent's
+      # digest onto :<sha> (and re-point :main, :latest) — no rebuild. This
+      # keeps the "every main commit has a resolvable dev :<sha>" invariant.
+      # =====================================================================
+      - name: Inherit parent dev AR digest (push path, no rebuild)
+        if: github.event_name == 'push' && steps.decide.outputs.mode == 'inherit'
+        env:
+          DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/backend/${{ matrix.image.name }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          resolve() { gcloud artifacts docker images describe "$1" --format='value(image_summary.digest)' 2>/dev/null; }
+          # The parent push tip (event.before) has a :<sha> image by induction.
+          digest=$(resolve "${DEV_AR_IMAGE}:${BEFORE}")
+          if [ -z "${digest}" ]; then
+            echo "Parent :${BEFORE} not resolvable; falling back to the :main tag digest."
+            digest=$(resolve "${DEV_AR_IMAGE}:main")
+          fi
+          if [ -z "${digest}" ]; then
+            echo "::error::Cannot resolve a parent dev image for ${DEV_AR_IMAGE} (tried :${BEFORE} and :main). The inherit chain is broken. Seed it by pushing a build-relevant change (any **.go / go.mod / Dockerfile) to main, which forces a fresh build. Not writing :${SHA} to avoid pinning a wrong digest."
+            exit 1
+          fi
+          echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."
+          crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:${SHA}"
+          crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:main"
+          crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:latest"
 
       # =====================================================================
       # Release path: retag the dev AR digest into prod AR — no rebuild
@@ -195,33 +288,6 @@ jobs:
       # is still env-driven because it correctly toggles between
       # `liverty-music-dev` and `liverty-music-prod` via the per-event
       # `environment:` binding above, and we want that toggle.
-
-      # Install `crane` (go-containerregistry's registry CLI) for the
-      # cross-repository / cross-project digest copy. `gcloud artifacts
-      # docker tags add` is intentionally NOT used here: despite its
-      # name, it only renames tags within a single repository — passing
-      # a source from `liverty-music-dev/backend/<img>` and a destination
-      # in `liverty-music-prod/backend/<img>` fails with `Image ... does
-      # not match image ...`. `crane copy` is the registry-to-registry
-      # primitive; within the same AR region it uses cross-repo blob
-      # mounting so no image bytes actually transfer (manifest re-push
-      # only).
-      #
-      # Note: the action's name is `setup-crane`, and it installs the
-      # `crane` binary — NOT the `gcrane` wrapper (a GCR-specific
-      # convenience build from the same go-containerregistry repo that
-      # the action does not ship). `crane` works identically for AR.
-      # Auth: `crane` reads ~/.docker/config.json populated by the
-      # `Configure Docker` step above (which is unconditional, so the
-      # release path is already covered without any gating change).
-      - name: Install crane
-        if: github.event_name == 'release'
-        # SHA-pinned for the prod-write path: this action runs with prod
-        # AR credentials, so a hijacked mutable tag would execute code
-        # with prod-write authority. SHA of v0.4 verified against
-        # https://github.com/imjasonh/setup-crane refs/tags/v0.4.
-        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
-
       - name: Resolve dev AR digest for ${{ matrix.image.name }}:${{ github.sha }}
         if: github.event_name == 'release'
         id: resolve_digest
@@ -229,12 +295,13 @@ jobs:
           DEV_AR_IMAGE: ${{ env.REGION }}-docker.pkg.dev/liverty-music-dev/backend/${{ matrix.image.name }}
         run: |
           # 6 total attempts (initial + 5 retries) × 60s wait between =
-          # ~5-minute total budget. Absorbs the race window where a
-          # release is cut seconds after merge-to-main and the dev push
-          # for THIS matrix entry's image is still in-flight. Per the
-          # spec, this is a SHALL retry, not a MAY — silent failure on
-          # the digest-resolve step is exactly what the retry contract
-          # prevents.
+          # ~5-minute total budget. With the "every main commit has a
+          # resolvable dev image" invariant (guarantee-dev-image-per-main-commit),
+          # a missing :<sha> can only mean the push-path build/inherit job for
+          # this commit is still in-flight (release cut seconds after the push)
+          # or that job failed — NOT a filtered-out or non-main commit. The
+          # retry absorbs the in-flight race; a non-main commit is already
+          # rejected by the `Verify release commit is on main` step above.
           #
           # Error classification: gcloud exits non-zero on any failure
           # (NOT_FOUND for missing :<sha>, PERMISSION_DENIED for auth
@@ -273,10 +340,9 @@ jobs:
               rm -f "$stderr_file"
               exit 1
             fi
-            # NOT_FOUND-shaped: the dev :<sha> tag hasn't landed yet
-            # (typical) or the release was cut on a non-main commit
-            # whose dev build never ran (corner case). Retry within
-            # the 5-minute budget.
+            # NOT_FOUND-shaped: the dev :<sha> tag hasn't landed yet — the
+            # push-path build/inherit job for this commit is still in-flight
+            # (release cut seconds after the push). Retry within the budget.
             if echo "$stderr_body" | grep -qE 'NOT_FOUND|not found|does not exist|tag .* doesn'\''t exist'; then
               if [ "$attempt" -lt 6 ]; then
                 echo "Attempt ${attempt}/6: dev AR :sha not yet available; waiting 60s..."
@@ -298,7 +364,7 @@ jobs:
           done
           final_stderr=$(cat "$stderr_file" 2>/dev/null || echo "(no stderr captured)")
           rm -f "$stderr_file"
-          echo "::error::dev AR tag :${GITHUB_SHA} not resolved for ${DEV_AR_IMAGE} after 6 attempts (~5 min total wait). Either the dev build for this matrix entry's image failed, or the release was cut on a non-main commit. Last gcloud stderr: ${final_stderr}. See docs/runbooks/prod-image-tag-pinning.md retag-failure-recovery in cloud-provisioning."
+          echo "::error::dev AR tag :${GITHUB_SHA} not resolved for ${DEV_AR_IMAGE} after 6 attempts (~5 min total wait). Given the every-main-commit-has-an-image invariant, the push-path build/inherit for this commit is still in-flight or failed — do NOT re-target an earlier commit; re-run the push-path 'Deploy Backend' run for this SHA, then re-run this matrix entry. Last gcloud stderr: ${final_stderr}. See docs/runbooks/prod-image-tag-pinning.md retag-failure-recovery in cloud-provisioning."
           exit 1
 
       # The two `crane copy` calls are bundled into a single step so the

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -298,9 +298,10 @@ jobs:
               sleep 20
             fi
           done
+          final_stderr=$(cat "$stderr_file" 2>/dev/null || echo "(no stderr captured)")
           rm -f "$stderr_file"
           if [ -z "${digest}" ]; then
-            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push for this matrix entry failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any **.go / go.mod / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest. Last gcloud stderr: ${body}"
+            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push for this matrix entry failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any **.go / go.mod / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest. Last gcloud stderr: ${final_stderr}"
             exit 1
           fi
           echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -275,12 +275,13 @@ jobs:
           # Errors are classified like the release-path resolve (auth ->
           # fail fast with auth guidance; transient -> retry; NOT_FOUND ->
           # chain-broken) so an IAM/5xx failure is not misreported as a
-          # missing-tag "seed the chain" instruction. -e is NOT set during
-          # resolve (gcloud's non-zero is handled explicitly) and is enabled
-          # only around the crane copies.
-          set -uo pipefail
+          # missing-tag "seed the chain" instruction. -e is safe to keep on
+          # throughout: every gcloud call is guarded by `|| rc=$?` or sits
+          # inside an `if`, so a non-zero resolve does not abort the step.
+          set -euo pipefail
           stderr_file=$(mktemp)
           digest=""
+          body=""
           for attempt in $(seq 1 3); do
             rc=0
             digest=$(gcloud artifacts docker images describe "${DEV_AR_IMAGE}:${BEFORE}" \
@@ -299,12 +300,12 @@ jobs:
           done
           rm -f "$stderr_file"
           if [ -z "${digest}" ]; then
-            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push for this matrix entry failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any **.go / go.mod / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest."
+            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push for this matrix entry failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any **.go / go.mod / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest. Last gcloud stderr: ${body}"
             exit 1
           fi
           echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."
-          # Abort immediately if any of the three retags fails.
-          set -e
+          # -e (set at the top of this step) aborts immediately if any of the
+          # three retags fails.
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:${SHA}"
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:main"
           crane copy "${DEV_AR_IMAGE}@${digest}" "${DEV_AR_IMAGE}:latest"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -261,20 +261,45 @@ jobs:
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
         run: |
-          # NOTE: -e is intentionally NOT set here — the resolve() calls below
-          # are expected to return non-zero on a missing tag (that drives the
-          # :main fallback), and `digest=$(resolve ...)` would abort under -e.
-          # -e is enabled explicitly just before the crane copy sequence.
+          # Resolve ONLY the parent push tip's digest (event.before). By
+          # induction + the `concurrency` serialization (the parent run
+          # completes before this one starts), :<before> exists in steady
+          # state. There is deliberately NO fallback to :main or any other
+          # tag: the fallback would only ever fire when :<before> is missing
+          # (i.e. the parent run FAILED), and in that gapped state :main can
+          # point at an older commit whose tree differs from this one —
+          # inheriting it would pin non-equivalent bytes onto :<sha> and
+          # silently ship the wrong code to prod. A missing :<before> means
+          # the chain is genuinely broken -> fail loudly.
+          #
+          # Errors are classified like the release-path resolve (auth ->
+          # fail fast with auth guidance; transient -> retry; NOT_FOUND ->
+          # chain-broken) so an IAM/5xx failure is not misreported as a
+          # missing-tag "seed the chain" instruction. -e is NOT set during
+          # resolve (gcloud's non-zero is handled explicitly) and is enabled
+          # only around the crane copies.
           set -uo pipefail
-          resolve() { gcloud artifacts docker images describe "$1" --format='value(image_summary.digest)' 2>/dev/null; }
-          # The parent push tip (event.before) has a :<sha> image by induction.
-          digest=$(resolve "${DEV_AR_IMAGE}:${BEFORE}")
+          stderr_file=$(mktemp)
+          digest=""
+          for attempt in $(seq 1 3); do
+            rc=0
+            digest=$(gcloud artifacts docker images describe "${DEV_AR_IMAGE}:${BEFORE}" \
+              --format='value(image_summary.digest)' 2>"$stderr_file") || rc=$?
+            if [ "$rc" -eq 0 ] && [ -n "$digest" ]; then break; fi
+            body=$(cat "$stderr_file")
+            if echo "$body" | grep -qE 'PERMISSION_DENIED|Permission .* denied|HTTPError 403|403 Forbidden|UNAUTHENTICATED|401'; then
+              echo "::error::Auth failure resolving ${DEV_AR_IMAGE}:${BEFORE} (dev AR read) — NOT a missing-tag/chain problem. Check the dev build service account's AR read access. stderr: ${body}"
+              rm -f "$stderr_file"; exit 1
+            fi
+            digest=""
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3: ${DEV_AR_IMAGE}:${BEFORE} not resolvable yet (${body}); retrying in 20s..."
+              sleep 20
+            fi
+          done
+          rm -f "$stderr_file"
           if [ -z "${digest}" ]; then
-            echo "Parent :${BEFORE} not resolvable; falling back to the :main tag digest."
-            digest=$(resolve "${DEV_AR_IMAGE}:main")
-          fi
-          if [ -z "${digest}" ]; then
-            echo "::error::Cannot resolve a parent dev image for ${DEV_AR_IMAGE} (tried :${BEFORE} and :main). The inherit chain is broken. Seed it by pushing a build-relevant change (any **.go / go.mod / Dockerfile) to main, which forces a fresh build. Not writing :${SHA} to avoid pinning a wrong digest."
+            echo "::error::Cannot resolve parent dev image ${DEV_AR_IMAGE}:${BEFORE} after 3 attempts. The inherit chain is broken — the parent push for this matrix entry failed or never wrote :${BEFORE}. Seed by pushing a build-relevant change (any **.go / go.mod / Dockerfile) to main to force a fresh build, then re-cut the release on the new HEAD. Not writing :${SHA} to avoid pinning a wrong digest."
             exit 1
           fi
           echo "Inheriting digest ${digest} onto :${SHA}, :main, :latest."


### PR DESCRIPTION
## Summary

Per OpenSpec `guarantee-dev-image-per-main-commit` (spec liverty-music/specification#536).

- Drop the `paths:` trigger gate — every push to `main` runs the workflow.
- **Decide build vs inherit** by diffing `event.before..sha` against the build glob set (`**.go`, `go.mod`, `go.sum`, `Dockerfile`, `deploy.yml`).
- **Inherit path** (per matrix image): when no build-relevant file changed, `crane copy` the parent tip's dev digest onto `:<sha>` and re-point `:main`/`:latest` — no rebuild (byte-identical to parent). Parent-resolution fallback (`:main` digest) + fail-loud-no-wrong-pin guard.
- Align the release `Resolve dev AR digest` + `Verify release commit is on main` messages with the invariant (drop "main HEAD only" / "re-target earlier commit"; keep the 6×60s retry). `fetch-depth: 0` for the range diff.

## Why

A release cut on a CI-only `main` HEAD had no dev `:<sha>` image and failed at digest-resolve — the v1.2.0 / efd340a incident. This makes every main commit carry a resolvable dev image, so main HEAD is always releasable.

## Notes

- `deploy.yml` runs on push-to-main / release, **not** on PRs — PR CI doesn't exercise the new logic. First run is the post-merge build, which self-seeds HEAD's image (editing this file matches the build globs).
- Inherit-path verification uses dev AR (up); dev-cluster checks deferred while dev is stopped.

close: #314