### PR TITLE
feat(analytics): publishers for ARTIST.followed/unfollowed + USER.preferred_language_updated

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -110,6 +110,153 @@ func (c *AnalyticsConsumer) HandleUserCreated(msg *message.Message) error {
 	return nil
 }
 
+// HandleUserPreferredLanguageUpdated forwards the
+// USER.preferred_language_updated NATS subject as the catalogue event
+// usecase.EventAccountPreferredLanguageUpdated. Properties: from_locale,
+// to_locale (per specification/docs/analytics/event-catalog.md).
+func (c *AnalyticsConsumer) HandleUserPreferredLanguageUpdated(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.UserPreferredLanguageUpdatedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse USER.preferred_language_updated event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse USER.preferred_language_updated event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventAccountPreferredLanguageUpdated)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "USER.preferred_language_updated event missing user_id, skipping forward")
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"from_locale": data.FromLocale,
+		"to_locale":   data.ToLocale,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventAccountPreferredLanguageUpdated, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventAccountPreferredLanguageUpdated)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
+// HandleArtistFollowed forwards the ARTIST.followed NATS subject as the
+// catalogue event usecase.EventArtistFollowCompleted. Properties:
+// artist_id (per specification/docs/analytics/event-catalog.md; the
+// optional `source` property is FE-only and is therefore omitted here).
+func (c *AnalyticsConsumer) HandleArtistFollowed(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.ArtistFollowedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse ARTIST.followed event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse ARTIST.followed event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventArtistFollowCompleted)),
+			slog.String("user_id", data.UserID),
+			slog.String("artist_id", data.ArtistID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "ARTIST.followed event missing user_id, skipping forward",
+			slog.String("artist_id", data.ArtistID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"artist_id": data.ArtistID,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventArtistFollowCompleted, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventArtistFollowCompleted)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
+// HandleArtistUnfollowed forwards the ARTIST.unfollowed NATS subject as
+// the catalogue event usecase.EventArtistUnfollowCompleted. Properties:
+// artist_id.
+func (c *AnalyticsConsumer) HandleArtistUnfollowed(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.ArtistUnfollowedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse ARTIST.unfollowed event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse ARTIST.unfollowed event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventArtistUnfollowCompleted)),
+			slog.String("user_id", data.UserID),
+			slog.String("artist_id", data.ArtistID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "ARTIST.unfollowed event missing user_id, skipping forward",
+			slog.String("artist_id", data.ArtistID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"artist_id": data.ArtistID,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventArtistUnfollowCompleted, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventArtistUnfollowCompleted)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
 // recordLag emits analytics_consumer_lag_seconds derived from the
 // CloudEvent's `ce_time` metadata. Missing or unparseable timestamps
 // are silently skipped — the metric is best-effort and downstream

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -19,10 +19,9 @@ import (
 )
 
 // makeAnalyticsMsg builds a watermill message with a JSON-encoded
-// UserCreatedData payload (the only subject the consumer subscribes to
-// in this batch). The ce_time metadata is set 1 second in the past so
+// payload. The ce_time metadata is set 1 second in the past so
 // recordLag exercises a deterministic non-zero sample.
-func makeAnalyticsMsg(t *testing.T, data entity.UserCreatedData) *message.Message {
+func makeAnalyticsMsg(t *testing.T, data any) *message.Message {
 	t.Helper()
 	payload, err := json.Marshal(data)
 	require.NoError(t, err)
@@ -136,6 +135,343 @@ func TestAnalyticsConsumer_HandleUserCreated(t *testing.T) {
 
 			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
 			err := handler.HandleUserCreated(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestAnalyticsConsumer_HandleUserPreferredLanguageUpdated covers
+// USER.preferred_language_updated → account.preferred_language.updated
+// routing. Properties from_locale and to_locale travel verbatim.
+func TestAnalyticsConsumer_HandleUserPreferredLanguageUpdated(t *testing.T) {
+	t.Parallel()
+
+	const validUserID = "11111111-2222-3333-4444-555555555555"
+
+	type args struct {
+		data entity.UserPreferredLanguageUpdatedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards with both locales when client + UserID present",
+			args: args{data: entity.UserPreferredLanguageUpdatedData{
+				UserID:     validUserID,
+				FromLocale: "ja",
+				ToLocale:   "en",
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "forwards with empty from_locale when prior was unset",
+			args: args{data: entity.UserPreferredLanguageUpdatedData{
+				UserID:     validUserID,
+				FromLocale: "",
+				ToLocale:   "ja",
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.UserPreferredLanguageUpdatedData{
+				UserID:   validUserID,
+				ToLocale: "ja",
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.UserPreferredLanguageUpdatedData{
+				UserID:   "",
+				ToLocale: "ja",
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.UserPreferredLanguageUpdatedData{
+				UserID:   validUserID,
+				ToLocale: "ja",
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventAccountPreferredLanguageUpdated,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["from_locale"] == tt.args.data.FromLocale &&
+									props["to_locale"] == tt.args.data.ToLocale
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleUserPreferredLanguageUpdated(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestAnalyticsConsumer_HandleArtistFollowed covers ARTIST.followed →
+// artist.follow.completed routing. The catalogue's optional `source`
+// property is FE-only and not present on the backend payload.
+func TestAnalyticsConsumer_HandleArtistFollowed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validUserID   = "11111111-2222-3333-4444-555555555555"
+		validArtistID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
+
+	type args struct {
+		data entity.ArtistFollowedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards artist.follow.completed with artist_id property",
+			args: args{data: entity.ArtistFollowedData{
+				UserID:   validUserID,
+				ArtistID: validArtistID,
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.ArtistFollowedData{
+				UserID:   validUserID,
+				ArtistID: validArtistID,
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.ArtistFollowedData{
+				UserID:   "",
+				ArtistID: validArtistID,
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.ArtistFollowedData{
+				UserID:   validUserID,
+				ArtistID: validArtistID,
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventArtistFollowCompleted,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["artist_id"] == tt.args.data.ArtistID
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleArtistFollowed(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestAnalyticsConsumer_HandleArtistUnfollowed mirrors the followed
+// test for the negative engagement case (artist.unfollow.completed).
+func TestAnalyticsConsumer_HandleArtistUnfollowed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validUserID   = "11111111-2222-3333-4444-555555555555"
+		validArtistID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
+
+	type args struct {
+		data entity.ArtistUnfollowedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards artist.unfollow.completed with artist_id property",
+			args: args{data: entity.ArtistUnfollowedData{
+				UserID:   validUserID,
+				ArtistID: validArtistID,
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.ArtistUnfollowedData{
+				UserID:   validUserID,
+				ArtistID: validArtistID,
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.ArtistUnfollowedData{
+				UserID:   "",
+				ArtistID: validArtistID,
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.ArtistUnfollowedData{
+				UserID:   validUserID,
+				ArtistID: validArtistID,
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventArtistUnfollowCompleted,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["artist_id"] == tt.args.data.ArtistID
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleArtistUnfollowed(makeAnalyticsMsg(t, tt.args.data))
 
 			if tt.want.err != nil {
 				assert.ErrorIs(t, err, tt.want.err)

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -215,6 +215,27 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	)
 
 	router.AddConsumerHandler(
+		"forward-user-preferred-language-updated-to-analytics",
+		entity.SubjectUserPreferredLanguageUpdated,
+		subscriber,
+		analyticsConsumer.HandleUserPreferredLanguageUpdated,
+	)
+
+	router.AddConsumerHandler(
+		"forward-artist-followed-to-analytics",
+		entity.SubjectArtistFollowed,
+		subscriber,
+		analyticsConsumer.HandleArtistFollowed,
+	)
+
+	router.AddConsumerHandler(
+		"forward-artist-unfollowed-to-analytics",
+		entity.SubjectArtistUnfollowed,
+		subscriber,
+		analyticsConsumer.HandleArtistUnfollowed,
+	)
+
+	router.AddConsumerHandler(
 		"log-poison-queue",
 		messaging.PoisonQueueSubject,
 		subscriber,

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -191,7 +191,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	centroidResolver := geo.NewCentroidResolver()
 	concertUC := usecase.NewConcertUseCase(artistRepo, concertRepo, venueRepo, searchLogRepo, geminiSearcher, centroidResolver, eventPublisher, businessMetrics, logger)
 	artistUC := usecase.NewArtistUseCase(artistRepo, lastfmClient, musicbrainzClient, eventPublisher, artistCache, logger)
-	followUC := usecase.NewFollowUseCase(followRepo, artistRepo, musicbrainzClient, concertUC, searchLogRepo, businessMetrics, logger)
+	followUC := usecase.NewFollowUseCase(followRepo, artistRepo, musicbrainzClient, concertUC, searchLogRepo, eventPublisher, businessMetrics, logger)
 	ticketJourneyUC := usecase.NewTicketJourneyUseCase(ticketJourneyRepo, logger)
 	var ticketEmailUC usecase.TicketEmailUseCase
 	if emailParser != nil {

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -1,11 +1,20 @@
 package entity
 
 // Event subject constants for domain events published via messaging.
+//
+// Subjects follow the UPPERCASE two-segment convention enforced by the
+// pre-existing JetStream stream config (CONCERT.*, ARTIST.*, USER.*,
+// VENUE.*, POISON.*). The analytics-consumer maps each subject to a
+// lowercase catalogue event name (see specification/docs/analytics/
+// event-catalog.md) at the Handle method that subscribes to it.
 const (
-	SubjectConcertDiscovered = "CONCERT.discovered"
-	SubjectConcertCreated    = "CONCERT.created"
-	SubjectArtistCreated     = "ARTIST.created"
-	SubjectUserCreated       = "USER.created"
+	SubjectConcertDiscovered            = "CONCERT.discovered"
+	SubjectConcertCreated               = "CONCERT.created"
+	SubjectArtistCreated                = "ARTIST.created"
+	SubjectArtistFollowed               = "ARTIST.followed"
+	SubjectArtistUnfollowed             = "ARTIST.unfollowed"
+	SubjectUserCreated                  = "USER.created"
+	SubjectUserPreferredLanguageUpdated = "USER.preferred_language_updated"
 )
 
 // ConcertDiscoveredData is the payload for concert.discovered.v1 events.
@@ -43,4 +52,44 @@ type ArtistCreatedData struct {
 	ArtistName string `json:"artist_name"`
 	// MBID is the MusicBrainz identifier for canonical identity.
 	MBID string `json:"mbid"`
+}
+
+// UserPreferredLanguageUpdatedData is the payload for USER.preferred_language_updated.
+// Mapped to the catalogue event account.preferred_language.updated by the
+// analytics-consumer. Published by UserUseCase.UpdatePreferredLanguage after
+// the repository confirms the change.
+type UserPreferredLanguageUpdatedData struct {
+	// UserID is the platform-internal user identifier (UUID). Used as the
+	// PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// FromLocale is the ISO 639-1 language code before the change. Empty
+	// when the user had no preferred language set previously (legacy rows
+	// pending backfill — see entity.User.PreferredLanguage docstring).
+	FromLocale string `json:"from_locale"`
+	// ToLocale is the ISO 639-1 language code after the change.
+	ToLocale string `json:"to_locale"`
+}
+
+// ArtistFollowedData is the payload for ARTIST.followed.
+// Mapped to the catalogue event artist.follow.completed by the
+// analytics-consumer. Published by FollowUseCase.Follow after the
+// repository persists the relationship.
+type ArtistFollowedData struct {
+	// UserID is the platform-internal user identifier of the follower.
+	// Used as the PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// ArtistID is the internal UUID of the followed artist.
+	ArtistID string `json:"artist_id"`
+}
+
+// ArtistUnfollowedData is the payload for ARTIST.unfollowed.
+// Mapped to the catalogue event artist.unfollow.completed by the
+// analytics-consumer. Published by FollowUseCase.Unfollow after the
+// repository removes the relationship.
+type ArtistUnfollowedData struct {
+	// UserID is the platform-internal user identifier of the user who
+	// stopped following. Used as the PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// ArtistID is the internal UUID of the unfollowed artist.
+	ArtistID string `json:"artist_id"`
 }

--- a/internal/infrastructure/analytics/posthog/posthog_client.go
+++ b/internal/infrastructure/analytics/posthog/posthog_client.go
@@ -8,6 +8,7 @@ package posthog
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 
@@ -189,9 +190,7 @@ func buildSDKProperties(ctx context.Context, properties usecase.AnalyticsPropert
 
 	// Defensive copy to inject trace_id without mutating the caller's map.
 	out := make(posthogsdk.Properties, len(properties)+1)
-	for k, v := range properties {
-		out[k] = v
-	}
+	maps.Copy(out, properties)
 	out[tracePropertyKey] = span.SpanContext().TraceID().String()
 	return out
 }

--- a/internal/usecase/follow_uc.go
+++ b/internal/usecase/follow_uc.go
@@ -51,6 +51,7 @@ type followUseCase struct {
 	siteResolver  entity.OfficialSiteResolver
 	concertUC     ConcertUseCase
 	searchLogRepo entity.SearchLogRepository
+	publisher     EventPublisher
 	metrics       FollowMetrics
 	logger        *logging.Logger
 }
@@ -65,6 +66,7 @@ func NewFollowUseCase(
 	siteResolver entity.OfficialSiteResolver,
 	concertUC ConcertUseCase,
 	searchLogRepo entity.SearchLogRepository,
+	publisher EventPublisher,
 	metrics FollowMetrics,
 	logger *logging.Logger,
 ) FollowUseCase {
@@ -74,6 +76,7 @@ func NewFollowUseCase(
 		siteResolver:  siteResolver,
 		concertUC:     concertUC,
 		searchLogRepo: searchLogRepo,
+		publisher:     publisher,
 		metrics:       metrics,
 		logger:        logger,
 	}
@@ -82,6 +85,11 @@ func NewFollowUseCase(
 // Follow establishes a follow relationship between a user and an artist.
 // After the follow is persisted, it asynchronously resolves and stores the
 // artist's official site URL if one is not already recorded.
+//
+// The first-call path publishes ARTIST.followed for the analytics-consumer
+// to forward as the catalogue event artist.follow.completed. The idempotent
+// "already following" path returns early WITHOUT republishing — duplicate
+// analytics events would inflate the follow funnel.
 func (uc *followUseCase) Follow(ctx context.Context, userID string, artistID string) error {
 	err := uc.followRepo.Follow(ctx, userID, artistID)
 	if err != nil {
@@ -94,6 +102,17 @@ func (uc *followUseCase) Follow(ctx context.Context, userID string, artistID str
 
 	uc.logger.Info(ctx, "User followed artist", slog.String("user_id", userID), slog.String("artist_id", artistID))
 	uc.metrics.RecordFollow(ctx, "follow")
+
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectArtistFollowed, entity.ArtistFollowedData{
+		UserID:   userID,
+		ArtistID: artistID,
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish ARTIST.followed event", err,
+			slog.String("user_id", userID),
+			slog.String("artist_id", artistID),
+		)
+		// Non-fatal: the follow relationship is already persisted.
+	}
 
 	bgCtx := context.WithoutCancel(ctx)
 	go uc.resolveAndPersistOfficialSite(bgCtx, artistID)
@@ -180,6 +199,18 @@ func (uc *followUseCase) Unfollow(ctx context.Context, userID, artistID string) 
 
 	uc.logger.Info(ctx, "Artist unfollowed", slog.String("user_id", userID), slog.String("artist_id", artistID))
 	uc.metrics.RecordFollow(ctx, "unfollow")
+
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectArtistUnfollowed, entity.ArtistUnfollowedData{
+		UserID:   userID,
+		ArtistID: artistID,
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish ARTIST.unfollowed event", err,
+			slog.String("user_id", userID),
+			slog.String("artist_id", artistID),
+		)
+		// Non-fatal: the unfollow is already persisted.
+	}
+
 	return nil
 }
 

--- a/internal/usecase/follow_uc_test.go
+++ b/internal/usecase/follow_uc_test.go
@@ -10,6 +10,7 @@ import (
 	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // followTestDeps holds all dependencies for FollowUseCase tests.
@@ -19,6 +20,7 @@ type followTestDeps struct {
 	siteResolver  *mocks.MockOfficialSiteResolver
 	concertUC     *ucmocks.MockConcertUseCase
 	searchLogRepo *mocks.MockSearchLogRepository
+	publisher     *ucmocks.MockEventPublisher
 	uc            usecase.FollowUseCase
 }
 
@@ -30,6 +32,7 @@ func newFollowTestDeps(t *testing.T) *followTestDeps {
 		siteResolver:  mocks.NewMockOfficialSiteResolver(t),
 		concertUC:     ucmocks.NewMockConcertUseCase(t),
 		searchLogRepo: mocks.NewMockSearchLogRepository(t),
+		publisher:     ucmocks.NewMockEventPublisher(t),
 	}
 	d.uc = usecase.NewFollowUseCase(
 		d.followRepo,
@@ -37,6 +40,7 @@ func newFollowTestDeps(t *testing.T) *followTestDeps {
 		d.siteResolver,
 		d.concertUC,
 		d.searchLogRepo,
+		d.publisher,
 		noopMetrics{},
 		newTestLogger(t),
 	)
@@ -111,4 +115,130 @@ func TestFollowUseCase_SetHype(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+// TestFollowUseCase_Follow_PublishesAnalyticsEvent verifies that a
+// successful Follow publishes ARTIST.followed via the injected
+// EventPublisher. The background goroutines (resolveAndPersistOfficialSite,
+// triggerFirstFollowSearch) run with context.WithoutCancel and touch
+// the artist + searchLog + concert mocks; their EXPECT()s are declared
+// .Maybe() so the test exits deterministically without waiting on
+// background work that this test isn't asserting.
+func TestFollowUseCase_Follow_PublishesAnalyticsEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("publishes ARTIST.followed on first follow", func(t *testing.T) {
+		t.Parallel()
+		d := newFollowTestDeps(t)
+
+		d.followRepo.EXPECT().
+			Follow(ctx, "user-1", "artist-1").
+			Return(nil).Once()
+		d.publisher.EXPECT().
+			PublishEvent(ctx, entity.SubjectArtistFollowed, entity.ArtistFollowedData{
+				UserID:   "user-1",
+				ArtistID: "artist-1",
+			}).
+			Return(nil).Once()
+
+		// Background goroutine deps — .Maybe() because the goroutines run
+		// asynchronously and may or may not have entered their first mock
+		// call by the time the test returns.
+		d.artistRepo.EXPECT().GetOfficialSite(mock.Anything, "artist-1").
+			Return(nil, apperr.ErrNotFound).Maybe()
+		d.artistRepo.EXPECT().Get(mock.Anything, "artist-1").
+			Return(&entity.Artist{ID: "artist-1"}, nil).Maybe()
+		d.searchLogRepo.EXPECT().GetByArtistID(mock.Anything, "artist-1").
+			Return(nil, apperr.ErrNotFound).Maybe()
+		d.concertUC.EXPECT().SearchNewConcerts(mock.Anything, "artist-1").
+			Return(nil, nil).Maybe()
+
+		err := d.uc.Follow(ctx, "user-1", "artist-1")
+		assert.NoError(t, err)
+	})
+
+	t.Run("does not publish on already-following idempotent path", func(t *testing.T) {
+		t.Parallel()
+		d := newFollowTestDeps(t)
+
+		d.followRepo.EXPECT().
+			Follow(ctx, "user-1", "artist-1").
+			Return(apperr.ErrAlreadyExists).Once()
+		// publisher MUST NOT be called — no EXPECT() registered.
+
+		err := d.uc.Follow(ctx, "user-1", "artist-1")
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns Internal on repository failure without publishing", func(t *testing.T) {
+		t.Parallel()
+		d := newFollowTestDeps(t)
+
+		d.followRepo.EXPECT().
+			Follow(ctx, "user-1", "artist-1").
+			Return(apperr.ErrInternal).Once()
+		// publisher MUST NOT be called.
+
+		err := d.uc.Follow(ctx, "user-1", "artist-1")
+		assert.ErrorIs(t, err, apperr.ErrInternal)
+	})
+}
+
+// TestFollowUseCase_Unfollow_PublishesAnalyticsEvent verifies that a
+// successful Unfollow publishes ARTIST.unfollowed. No goroutines in the
+// Unfollow path, so the test is straightforward.
+func TestFollowUseCase_Unfollow_PublishesAnalyticsEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("publishes ARTIST.unfollowed on success", func(t *testing.T) {
+		t.Parallel()
+		d := newFollowTestDeps(t)
+
+		d.followRepo.EXPECT().
+			Unfollow(ctx, "user-1", "artist-1").
+			Return(nil).Once()
+		d.publisher.EXPECT().
+			PublishEvent(ctx, entity.SubjectArtistUnfollowed, entity.ArtistUnfollowedData{
+				UserID:   "user-1",
+				ArtistID: "artist-1",
+			}).
+			Return(nil).Once()
+
+		err := d.uc.Unfollow(ctx, "user-1", "artist-1")
+		assert.NoError(t, err)
+	})
+
+	t.Run("does not publish when repository fails", func(t *testing.T) {
+		t.Parallel()
+		d := newFollowTestDeps(t)
+
+		d.followRepo.EXPECT().
+			Unfollow(ctx, "user-1", "artist-1").
+			Return(apperr.ErrInternal).Once()
+		// publisher MUST NOT be called.
+
+		err := d.uc.Unfollow(ctx, "user-1", "artist-1")
+		assert.ErrorIs(t, err, apperr.ErrInternal)
+	})
+
+	t.Run("tolerates publisher failure (non-fatal)", func(t *testing.T) {
+		t.Parallel()
+		d := newFollowTestDeps(t)
+
+		d.followRepo.EXPECT().
+			Unfollow(ctx, "user-1", "artist-1").
+			Return(nil).Once()
+		d.publisher.EXPECT().
+			PublishEvent(ctx, entity.SubjectArtistUnfollowed, mock.Anything).
+			Return(apperr.ErrInternal).Once()
+
+		err := d.uc.Unfollow(ctx, "user-1", "artist-1")
+		// Unfollow contract: succeeds despite publish failure because
+		// the relationship is already persisted.
+		assert.NoError(t, err)
+	})
 }

--- a/internal/usecase/user_uc.go
+++ b/internal/usecase/user_uc.go
@@ -208,6 +208,11 @@ func (uc *userUseCase) GetByExternalID(ctx context.Context, externalID string) (
 // the repository — mirrors UpdateHome's `home.Validate()` posture so that
 // non-RPC callers (integration tests, future internal handlers, scripts)
 // don't bypass the wire-layer protovalidate constraint.
+//
+// Captures the prior PreferredLanguage value via a pre-update Get so the
+// USER.preferred_language_updated event can carry both from_locale and
+// to_locale. The extra read is acceptable: this operation is rare and the
+// event's analytical value depends on the locale-transition pair.
 func (uc *userUseCase) UpdatePreferredLanguage(ctx context.Context, id, lang string) (*entity.User, error) {
 	if id == "" {
 		return nil, apperr.New(codes.InvalidArgument, "user id is required")
@@ -216,6 +221,13 @@ func (uc *userUseCase) UpdatePreferredLanguage(ctx context.Context, id, lang str
 		return nil, apperr.New(codes.InvalidArgument,
 			"preferred_language must match ISO 639-1 (^[a-z]{2}$)",
 			slog.String("preferred_language", lang),
+		)
+	}
+
+	prior, err := uc.userRepo.Get(ctx, id)
+	if err != nil {
+		return nil, apperr.Wrap(err, codes.NotFound, "failed to load user for preferred-language update",
+			slog.String("user_id", id),
 		)
 	}
 
@@ -228,6 +240,17 @@ func (uc *userUseCase) UpdatePreferredLanguage(ctx context.Context, id, lang str
 		slog.String("user_id", id),
 		slog.String("preferred_language", lang),
 	)
+
+	if err := uc.publishEvent(ctx, entity.SubjectUserPreferredLanguageUpdated, entity.UserPreferredLanguageUpdatedData{
+		UserID:     user.ID,
+		FromLocale: prior.PreferredLanguage,
+		ToLocale:   user.PreferredLanguage,
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish USER.preferred_language_updated event", err,
+			slog.String("user_id", user.ID),
+		)
+		// Non-fatal: the language change is already persisted.
+	}
 
 	return user, nil
 }

--- a/internal/usecase/user_uc_test.go
+++ b/internal/usecase/user_uc_test.go
@@ -549,12 +549,18 @@ func TestUserUseCase_UpdatePreferredLanguage(t *testing.T) {
 		t.Parallel()
 		d := newUserTestDeps(t)
 
+		priorUser := &entity.User{
+			ID:                "user-lang-1",
+			Email:             "lang@example.com",
+			PreferredLanguage: "ja",
+		}
 		updatedUser := &entity.User{
 			ID:                "user-lang-1",
 			Email:             "lang@example.com",
 			PreferredLanguage: "en",
 		}
 
+		d.repo.EXPECT().Get(ctx, "user-lang-1").Return(priorUser, nil).Once()
 		d.repo.EXPECT().UpdatePreferredLanguage(ctx, "user-lang-1", "en").
 			Return(updatedUser, nil).Once()
 
@@ -565,10 +571,27 @@ func TestUserUseCase_UpdatePreferredLanguage(t *testing.T) {
 		assert.Equal(t, "en", result.PreferredLanguage)
 	})
 
-	t.Run("not found — repository returns NotFound", func(t *testing.T) {
+	t.Run("not found — pre-fetch Get returns NotFound", func(t *testing.T) {
 		t.Parallel()
 		d := newUserTestDeps(t)
 
+		d.repo.EXPECT().Get(ctx, "ghost-id").
+			Return(nil, apperr.New(codes.NotFound, "user not found")).Once()
+		// UpdatePreferredLanguage MUST NOT be called when the pre-fetch fails.
+
+		result, err := d.uc.UpdatePreferredLanguage(ctx, "ghost-id", "ja")
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, apperr.ErrNotFound)
+	})
+
+	t.Run("not found — repository returns NotFound at update", func(t *testing.T) {
+		t.Parallel()
+		d := newUserTestDeps(t)
+
+		priorUser := &entity.User{ID: "ghost-id", PreferredLanguage: "en"}
+		d.repo.EXPECT().Get(ctx, "ghost-id").Return(priorUser, nil).Once()
 		d.repo.EXPECT().UpdatePreferredLanguage(ctx, "ghost-id", "ja").
 			Return(nil, apperr.New(codes.NotFound, "user not found")).Once()
 


### PR DESCRIPTION
## Summary

Third backend batch for the [introduce-analytics-tool](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool) change. Adds three new NATS subjects on the pre-existing `USER` and `ARTIST` streams plus the corresponding `analytics-consumer` Handle methods forwarding them to PostHog Cloud EU.

| NATS subject (new) | Catalogue event | Emission point |
| --- | --- | --- |
| `USER.preferred_language_updated` | `account.preferred_language.updated` | `user_uc.UpdatePreferredLanguage` |
| `ARTIST.followed` | `artist.follow.completed` | `follow_uc.Follow` |
| `ARTIST.unfollowed` | `artist.unfollow.completed` | `follow_uc.Unfollow` |

After this PR lands, **4 of the catalogue's 17 backend events** are wired end-to-end (the prior `user.created` from [#316](https://github.com/liverty-music/backend/pull/316) plus the three above).

## Scope decisions

The catalogue lists 17 backend-emitted events. Of those:

- **4 are wired in this PR + #316** — they live on usecases that exist on `main` and on NATS streams (`USER.*`, `ARTIST.*`) that JetStream already provisions.
- **3 require infra additions and stay deferred** (`entry.zk_proof.verified`, `entry.zk_proof.rejected`, `push.subscription.completed`) — their NATS streams (`ENTRY.*`, `PUSH.*`) don't exist in [streams.go](internal/infrastructure/messaging/streams.go) yet. Adding them is a small cloud-provisioning + streams.go change in a follow-up.
- **10 lack a backing usecase entirely** (`account.signup.completed`, `account.login`, `concert.recommendation.served`, the four `ticket.lottery.*`/`ticket.purchase.*` events, `push.notification.delivered`) — these need feature work (lottery service, recommendation engine, purchase flow) before they can be published. They belong with the features that emit them, not in this analytics-wiring PR.
- **1 is plumbing-blocked** (`user.deleted`) — its `account_age_days_bucket` property requires `entity.User.CreateTime` to exist, and the entity doesn't carry that field today. Defer to a small entity + repository plumbing change.

## Behavioural details

- **Pre-update Get in `UpdatePreferredLanguage`**: published event carries both `from_locale` and `to_locale`, so the extra read is the price of analytical value (the locale-transition pair is what the dashboard cares about). Operation is rare; cost is acceptable.
- **Idempotent Follow path does NOT republish**: when `followRepo.Follow` returns `AlreadyExists` we early-return without firing `ARTIST.followed`. Duplicate analytics events would inflate the follow funnel.
- **Publish failures are non-fatal**: every publish call site logs the error and continues. The persistence is already committed by the time we reach the publish call.

## Tests

Per the [go-tester](https://github.com/anthropics/claude-code) pattern used by the existing `analytics_consumer_test.go`:

- `TestAnalyticsConsumer_HandleUserPreferredLanguageUpdated` — 5 subtests covering forward (with both locales / with empty from_locale), nil-client, empty UserID, and SDK error wrap.
- `TestAnalyticsConsumer_HandleArtistFollowed` — 4 subtests (forward, nil-client, empty UserID, SDK error).
- `TestAnalyticsConsumer_HandleArtistUnfollowed` — same 4 subtests for the negative-engagement mirror.
- `TestUserUseCase_UpdatePreferredLanguage` — extended to verify the pre-update `Get` call ordering; new subtest covers the pre-fetch failure path returning NotFound before the update attempts.
- `TestFollowUseCase_Follow_PublishesAnalyticsEvent` — 3 subtests: publishes on first follow (with `.Maybe()` on the background-goroutine deps so the test exits deterministically), does NOT publish on idempotent already-following, does NOT publish on repository error.
- `TestFollowUseCase_Unfollow_PublishesAnalyticsEvent` — 3 subtests: publishes on success, does not publish on repository error, tolerates publisher failure (verifies the non-fatal contract).

## Drive-by

- `posthog_client.go` manual map copy loop → `maps.Copy` (the `go fix` modernizer in `make check` flagged it; un-related to this batch but blocks the pre-commit hook).

## Test plan

- [x] `make check` passes locally (lint + schema-lint + modernize + integration tests including database/rdb)
- [ ] CI green
- [ ] Manual verification on dev once deployment is back online: trigger `UpdatePreferredLanguage` and an `ArtistService.Follow`/`Unfollow` pair via the gRPC API, observe corresponding events in the PostHog Cloud EU dev project

## Follow-up tracking (NOT in this PR)

- `user.deleted` publisher (needs `entity.User.CreateTime` plumbing).
- `ENTRY.zk_proof_verified` / `ENTRY.zk_proof_rejected` (needs `ENTRY` stream in `streams.go` + cloud-provisioning).
- `PUSH.subscription_completed` (needs `PUSH` stream in `streams.go` + cloud-provisioning).
- The remaining 10 catalogue events ship with the features that emit them.

Refs: liverty-music/specification#532