### PR TITLE
feat(analytics): publish entry.zk_proof.verified/rejected + ENTRY JetStream

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -305,6 +305,110 @@ func (c *AnalyticsConsumer) HandlePushSubscriptionCompleted(msg *message.Message
 	return nil
 }
 
+// HandleEntryZkProofVerified forwards the ENTRY.zk_proof_verified
+// NATS subject as the catalogue event usecase.EventEntryZkProofVerified.
+// The distinct_id is the nullifier hash hex — anonymous-by-design per
+// ZK guarantee, stable per (ticket, event) pair.
+func (c *AnalyticsConsumer) HandleEntryZkProofVerified(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.EntryZkProofVerifiedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse ENTRY.zk_proof_verified event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse ENTRY.zk_proof_verified event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventEntryZkProofVerified)),
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.NullifierHashHex == "" {
+		c.logger.Warn(ctx, "ENTRY.zk_proof_verified event missing nullifier_hash_hex, skipping forward",
+			slog.String("event_id", data.EventID),
+		)
+		// Reuse the empty-user_id status label: the metric label set is
+		// fixed to keep Prometheus cardinality bounded, and "missing
+		// distinct_id" is the semantic match regardless of the field name.
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"event_id": data.EventID,
+	}
+
+	if err := c.client.Enqueue(ctx, data.NullifierHashHex, usecase.EventEntryZkProofVerified, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventEntryZkProofVerified)),
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
+// HandleEntryZkProofRejected forwards the ENTRY.zk_proof_rejected NATS
+// subject as the catalogue event usecase.EventEntryZkProofRejected.
+// Properties: event_id, reason (one of the entity.EntryRejection*
+// constants).
+func (c *AnalyticsConsumer) HandleEntryZkProofRejected(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.EntryZkProofRejectedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse ENTRY.zk_proof_rejected event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse ENTRY.zk_proof_rejected event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventEntryZkProofRejected)),
+			slog.String("event_id", data.EventID),
+			slog.String("reason", string(data.Reason)),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.NullifierHashHex == "" {
+		c.logger.Warn(ctx, "ENTRY.zk_proof_rejected event missing nullifier_hash_hex, skipping forward",
+			slog.String("event_id", data.EventID),
+			slog.String("reason", string(data.Reason)),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"event_id": data.EventID,
+		"reason":   string(data.Reason),
+	}
+
+	if err := c.client.Enqueue(ctx, data.NullifierHashHex, usecase.EventEntryZkProofRejected, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventEntryZkProofRejected)),
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
 // recordLag emits analytics_consumer_lag_seconds derived from the
 // CloudEvent's `ce_time` metadata. Missing or unparseable timestamps
 // are silently skipped — the metric is best-effort and downstream

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -589,6 +589,230 @@ func TestAnalyticsConsumer_HandlePushSubscriptionCompleted(t *testing.T) {
 	}
 }
 
+// TestAnalyticsConsumer_HandleEntryZkProofVerified covers
+// ENTRY.zk_proof_verified routing. Distinct_id is the nullifier hash
+// hex (anonymous per ZK guarantee); event_id is a property.
+func TestAnalyticsConsumer_HandleEntryZkProofVerified(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validNullifier = "deadbeefcafebabe1234567890abcdef"
+		validEventID   = "550e8400-e29b-41d4-a716-446655440000"
+	)
+
+	type args struct {
+		data entity.EntryZkProofVerifiedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards entry.zk_proof.verified with event_id property",
+			args: args{data: entity.EntryZkProofVerifiedData{
+				NullifierHashHex: validNullifier,
+				EventID:          validEventID,
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.EntryZkProofVerifiedData{
+				NullifierHashHex: validNullifier,
+				EventID:          validEventID,
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when nullifier_hash_hex is empty",
+			args: args{data: entity.EntryZkProofVerifiedData{
+				NullifierHashHex: "",
+				EventID:          validEventID,
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.EntryZkProofVerifiedData{
+				NullifierHashHex: validNullifier,
+				EventID:          validEventID,
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.NullifierHashHex,
+							usecase.EventEntryZkProofVerified,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["event_id"] == tt.args.data.EventID
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleEntryZkProofVerified(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestAnalyticsConsumer_HandleEntryZkProofRejected mirrors the verified
+// test for the rejection case (carries the reason property additionally).
+func TestAnalyticsConsumer_HandleEntryZkProofRejected(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validNullifier = "deadbeefcafebabe1234567890abcdef"
+		validEventID   = "550e8400-e29b-41d4-a716-446655440000"
+	)
+
+	type args struct {
+		data entity.EntryZkProofRejectedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards entry.zk_proof.rejected with event_id + reason",
+			args: args{data: entity.EntryZkProofRejectedData{
+				NullifierHashHex: validNullifier,
+				EventID:          validEventID,
+				Reason:           entity.EntryRejectionMerkleRootMismatch,
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.EntryZkProofRejectedData{
+				NullifierHashHex: validNullifier,
+				EventID:          validEventID,
+				Reason:           entity.EntryRejectionProofInvalid,
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when nullifier_hash_hex is empty",
+			args: args{data: entity.EntryZkProofRejectedData{
+				NullifierHashHex: "",
+				EventID:          validEventID,
+				Reason:           entity.EntryRejectionAlreadyCheckedIn,
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.EntryZkProofRejectedData{
+				NullifierHashHex: validNullifier,
+				EventID:          validEventID,
+				Reason:           entity.EntryRejectionProofInvalid,
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.NullifierHashHex,
+							usecase.EventEntryZkProofRejected,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["event_id"] == tt.args.data.EventID &&
+									props["reason"] == string(tt.args.data.Reason)
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleEntryZkProofRejected(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // TestAnalyticsConsumer_HandleUserCreated_BadPayload covers the
 // CloudEvent decode failure path separately because constructing an
 // invalid JSON payload with the same table shape would obscure the

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -245,6 +245,20 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	)
 
 	router.AddConsumerHandler(
+		"forward-entry-zk-proof-verified-to-analytics",
+		entity.SubjectEntryZkProofVerified,
+		subscriber,
+		analyticsConsumer.HandleEntryZkProofVerified,
+	)
+
+	router.AddConsumerHandler(
+		"forward-entry-zk-proof-rejected-to-analytics",
+		entity.SubjectEntryZkProofRejected,
+		subscriber,
+		analyticsConsumer.HandleEntryZkProofRejected,
+	)
+
+	router.AddConsumerHandler(
 		"log-poison-queue",
 		messaging.PoisonQueueSubject,
 		subscriber,

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -312,7 +312,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		eventEntryRepo := rdb.NewEventEntryRepository(db)
 		merkleBuilder := inframerkle.NewBuilder(usecase.DefaultTreeDepth)
 
-		entryUC := usecase.NewEntryUseCase(verifier, nullifierRepo, merkleTreeRepo, merkleBuilder, eventEntryRepo, ticketRepo, logger)
+		entryUC := usecase.NewEntryUseCase(verifier, nullifierRepo, merkleTreeRepo, merkleBuilder, eventEntryRepo, ticketRepo, eventPublisher, logger)
 		handlers = append(handlers, func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return entryconnect.NewEntryServiceHandler(
 				rpc.NewEntryHandler(entryUC, userRepo, logger),

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -16,6 +16,24 @@ const (
 	SubjectUserCreated                  = "USER.created"
 	SubjectUserPreferredLanguageUpdated = "USER.preferred_language_updated"
 	SubjectPushSubscriptionCompleted    = "PUSH.subscription_completed"
+	SubjectEntryZkProofVerified         = "ENTRY.zk_proof_verified"
+	SubjectEntryZkProofRejected         = "ENTRY.zk_proof_rejected"
+)
+
+// EntryRejectionReason enumerates the legitimate causes for a
+// zk-proof entry rejection. Carried on the entry.zk_proof.rejected
+// analytics event so operations dashboards can break down
+// check-in-failure rate by cause. Parse-error and event-id-mismatch
+// paths return errors instead of rejections and intentionally do NOT
+// fire the analytics event — those are attacks or upstream bugs, not
+// legitimate user attempts.
+type EntryRejectionReason string
+
+// Legitimate entry.zk_proof.rejected reasons.
+const (
+	EntryRejectionMerkleRootMismatch EntryRejectionReason = "merkle_root_mismatch"
+	EntryRejectionAlreadyCheckedIn   EntryRejectionReason = "already_checked_in"
+	EntryRejectionProofInvalid       EntryRejectionReason = "proof_invalid"
 )
 
 // ConcertDiscoveredData is the payload for concert.discovered.v1 events.
@@ -93,6 +111,32 @@ type ArtistUnfollowedData struct {
 	UserID string `json:"user_id"`
 	// ArtistID is the internal UUID of the unfollowed artist.
 	ArtistID string `json:"artist_id"`
+}
+
+// EntryZkProofVerifiedData is the payload for ENTRY.zk_proof_verified.
+// Mapped to the catalogue event entry.zk_proof.verified by the
+// analytics-consumer. Published by EntryUseCase.VerifyEntry after a
+// successful proof verification and nullifier insertion.
+//
+// NullifierHashHex (hex of the on-wire nullifier) serves as the PostHog
+// distinct_id: it is stable per (ticket, event) pair, intentionally
+// non-reversible to a user identity by ZK guarantee, and already on the
+// public-signals wire so forwarding it leaks no new information.
+type EntryZkProofVerifiedData struct {
+	// NullifierHashHex is the hex-encoded nullifier hash. Used as
+	// PostHog distinct_id.
+	NullifierHashHex string `json:"nullifier_hash_hex"`
+	// EventID is the internal UUID of the live event.
+	EventID string `json:"event_id"`
+}
+
+// EntryZkProofRejectedData is the payload for ENTRY.zk_proof_rejected.
+// Mapped to the catalogue event entry.zk_proof.rejected. Reason takes
+// one of the EntryRejection* constants.
+type EntryZkProofRejectedData struct {
+	NullifierHashHex string               `json:"nullifier_hash_hex"`
+	EventID          string               `json:"event_id"`
+	Reason           EntryRejectionReason `json:"reason"`
 }
 
 // PushSubscriptionCompletedData is the payload for PUSH.subscription_completed.

--- a/internal/infrastructure/messaging/streams.go
+++ b/internal/infrastructure/messaging/streams.go
@@ -84,6 +84,16 @@ var streams = []nats.StreamConfig{
 		Duplicates: 2 * time.Minute,
 	},
 	{
+		Name:       "ENTRY",
+		Subjects:   []string{"ENTRY.*"},
+		Retention:  nats.LimitsPolicy,
+		MaxAge:     7 * 24 * time.Hour,
+		Storage:    nats.FileStorage,
+		Discard:    nats.DiscardOld,
+		Replicas:   1,
+		Duplicates: 2 * time.Minute,
+	},
+	{
 		Name:       "POISON",
 		Subjects:   []string{"POISON.*"},
 		Retention:  nats.LimitsPolicy,

--- a/internal/usecase/entry_uc.go
+++ b/internal/usecase/entry_uc.go
@@ -62,6 +62,7 @@ type entryUseCase struct {
 	merkleBuilder entity.MerkleTreeBuilder
 	eventRepo     entity.EventRepository
 	ticketRepo    entity.TicketRepository
+	publisher     EventPublisher
 	logger        *logging.Logger
 }
 
@@ -76,6 +77,7 @@ func NewEntryUseCase(
 	merkleBuilder entity.MerkleTreeBuilder,
 	eventRepo entity.EventRepository,
 	ticketRepo entity.TicketRepository,
+	publisher EventPublisher,
 	logger *logging.Logger,
 ) EntryUseCase {
 	return &entryUseCase{
@@ -85,6 +87,7 @@ func NewEntryUseCase(
 		merkleBuilder: merkleBuilder,
 		eventRepo:     eventRepo,
 		ticketRepo:    ticketRepo,
+		publisher:     publisher,
 		logger:        logger,
 	}
 }
@@ -127,6 +130,7 @@ func (uc *entryUseCase) VerifyEntry(ctx context.Context, params *VerifyEntryPara
 		slog.Bool("match", rootMatch),
 	)
 	if !rootMatch {
+		uc.publishRejected(ctx, params.EventID, nullifierHash, entity.EntryRejectionMerkleRootMismatch)
 		return &VerifyEntryResult{
 			Verified: false,
 			Message:  "merkle root mismatch: proof does not match event membership set",
@@ -149,6 +153,7 @@ func (uc *entryUseCase) VerifyEntry(ctx context.Context, params *VerifyEntryPara
 			slog.String("eventID", params.EventID),
 			slog.String("nullifier", hex.EncodeToString(nullifierHash)),
 		)
+		uc.publishRejected(ctx, params.EventID, nullifierHash, entity.EntryRejectionAlreadyCheckedIn)
 		return &VerifyEntryResult{
 			Verified: false,
 			Message:  "already checked in for this event",
@@ -162,6 +167,7 @@ func (uc *entryUseCase) VerifyEntry(ctx context.Context, params *VerifyEntryPara
 	}
 
 	if !verified {
+		uc.publishRejected(ctx, params.EventID, nullifierHash, entity.EntryRejectionProofInvalid)
 		return &VerifyEntryResult{
 			Verified: false,
 			Message:  "proof verification failed",
@@ -172,6 +178,7 @@ func (uc *entryUseCase) VerifyEntry(ctx context.Context, params *VerifyEntryPara
 	if err := uc.nullifiers.Insert(ctx, params.EventID, nullifierHash); err != nil {
 		if errors.Is(err, apperr.ErrAlreadyExists) {
 			// Concurrent verification succeeded first — treat as duplicate.
+			uc.publishRejected(ctx, params.EventID, nullifierHash, entity.EntryRejectionAlreadyCheckedIn)
 			return &VerifyEntryResult{
 				Verified: false,
 				Message:  "already checked in for this event",
@@ -185,10 +192,37 @@ func (uc *entryUseCase) VerifyEntry(ctx context.Context, params *VerifyEntryPara
 		slog.String("nullifier", hex.EncodeToString(nullifierHash)),
 	)
 
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectEntryZkProofVerified, entity.EntryZkProofVerifiedData{
+		NullifierHashHex: hex.EncodeToString(nullifierHash),
+		EventID:          params.EventID,
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish ENTRY.zk_proof_verified event", err,
+			slog.String("event_id", params.EventID),
+		)
+		// Non-fatal: the nullifier insert already committed the verified state.
+	}
+
 	return &VerifyEntryResult{
 		Verified: true,
 		Message:  "entry verified",
 	}, nil
+}
+
+// publishRejected fires the ENTRY.zk_proof_rejected analytics event.
+// Non-fatal helper: rejection-path callers MUST still return their
+// VerifyEntryResult; the analytics emission is observability and does
+// not block the user-facing response.
+func (uc *entryUseCase) publishRejected(ctx context.Context, eventID string, nullifierHash []byte, reason entity.EntryRejectionReason) {
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectEntryZkProofRejected, entity.EntryZkProofRejectedData{
+		NullifierHashHex: hex.EncodeToString(nullifierHash),
+		EventID:          eventID,
+		Reason:           reason,
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish ENTRY.zk_proof_rejected event", err,
+			slog.String("event_id", eventID),
+			slog.String("reason", string(reason)),
+		)
+	}
 }
 
 // GetMerklePath returns the Merkle path for a user at an event.

--- a/internal/usecase/entry_uc_test.go
+++ b/internal/usecase/entry_uc_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/usecase"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -157,7 +159,7 @@ func newTestEntryUC(
 	ticketRepo entity.TicketRepository,
 ) usecase.EntryUseCase {
 	t.Helper()
-	return usecase.NewEntryUseCase(verifier, nullifiers, merkleTree, &stubMerkleBuilder{}, eventRepo, ticketRepo, newTestLogger(t))
+	return usecase.NewEntryUseCase(verifier, nullifiers, merkleTree, &stubMerkleBuilder{}, eventRepo, ticketRepo, newAcceptingPublisher(t), newTestLogger(t))
 }
 
 func newTestEntryUCWithBuilder(
@@ -168,7 +170,19 @@ func newTestEntryUCWithBuilder(
 	ticketRepo entity.TicketRepository,
 ) usecase.EntryUseCase {
 	t.Helper()
-	return usecase.NewEntryUseCase(nil, nil, merkleTree, builder, eventRepo, ticketRepo, newTestLogger(t))
+	return usecase.NewEntryUseCase(nil, nil, merkleTree, builder, eventRepo, ticketRepo, newAcceptingPublisher(t), newTestLogger(t))
+}
+
+// newAcceptingPublisher returns a MockEventPublisher that accepts any
+// PublishEvent call. The existing VerifyEntry tests assert behaviour
+// other than analytics emission; a permissive publisher lets them stay
+// focused. Analytics-emission specifics are pinned in a dedicated
+// table-driven test below.
+func newAcceptingPublisher(t *testing.T) *ucmocks.MockEventPublisher {
+	t.Helper()
+	pub := ucmocks.NewMockEventPublisher(t)
+	pub.EXPECT().PublishEvent(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	return pub
 }
 
 // --- VerifyEntry tests ---


### PR DESCRIPTION
## Summary

Adds the 6th and 7th backend catalogue events. Cumulative backend coverage: 7 events (`user.created`, `account.preferred_language.updated`, `artist.follow.completed`, `artist.unfollow.completed`, `push.subscription.completed`, **`entry.zk_proof.verified`**, **`entry.zk_proof.rejected`**).

| Layer | Change |
| --- | --- |
| JetStream | New `ENTRY` stream (`ENTRY.*`, 7-day retention) |
| Entity | 2 new subjects, 2 new payload types, `EntryRejectionReason` enum, 3 reason constants |
| Usecase | `EntryUseCase` gains `publisher` dependency; `VerifyEntry` publishes at 4 outcome branches |
| Adapter | `AnalyticsConsumer.HandleEntryZkProofVerified` + `HandleEntryZkProofRejected` |
| DI | `consumer.go` + `provider.go` updated; 2 new subscriber wirings |

## Design highlights

- **`distinct_id` = nullifier hash hex**. The PostHog identifier for both events is the nullifier — stable per (ticket, event) pair, intentionally non-reversible to a user identity by ZK guarantee, and already on the public-signals wire so forwarding it leaks no new information. The analytics-consumer's empty-distinct_id guard reuses the `skipped_empty_user_id` status label (Prometheus label set is fixed to bound cardinality; "missing distinct_id" is the semantic match).
- **`EntryRejectionReason` enum** with three values: `"merkle_root_mismatch"`, `"already_checked_in"`, `"proof_invalid"`. Carried on `entry.zk_proof.rejected` so operations dashboards can break down check-in-failure rate by cause.
- **Rejection-path publishes fire at four legitimate branches** in `VerifyEntry`:
  1. merkle root mismatch
  2. duplicate nullifier — initial `Exists` check
  3. ZKP `verifier.Verify` returned false
  4. duplicate nullifier — race-condition `Insert` returns `ErrAlreadyExists`
- **Parse-error and event-id-mismatch paths return errors and do NOT publish.** Those are attacks or upstream bugs, not legitimate user attempts; forwarding them would pollute the operations dashboard.
- **Publish failures non-fatal.** Verified state is committed before the publish call; rejection-path responses are returned verbatim.

## Tests

- `analytics_consumer_test.go` — 8 new cases (4 per Handle method): forward, nil-client, empty-distinct_id, SDK error wrap.
- `entry_uc_test.go` — existing 16 cases continue to pass with a permissive `MockEventPublisher` (`Maybe()` on `PublishEvent`); analytics-emission specifics live in the Handle tests so the VerifyEntry suite stays focused on verification semantics.

## Scope notes

- The `ENTRY` JetStream stream is created idempotently by `EnsureStreams` at backend startup; no cloud-provisioning change is needed.
- Out of scope: `user.deleted` publisher — needs `entity.User.CreateTime` plumbing for `account_age_days_bucket`. Separate PR.
- Out of scope: backend `account.signup.completed`, `account.login`, `concert.recommendation.served`, ticket lottery / purchase events — each needs a backing usecase that doesn't exist on `main` yet; they land with the features that emit them.

## Test plan

- [x] `make check` passes locally (lint + integration tests including a real Postgres via `docker compose`).
- [ ] CI green.
- [ ] Manual once dev is back online: scan a valid ticket QR (verified path); scan a duplicate (already_checked_in); craft an invalid proof (proof_invalid) — confirm all three flow to PostHog Cloud EU with the right `distinct_id`/`event_id`/`reason` triple.

Refs: liverty-music/specification#532