### PR TITLE
refactor(analytics): rename PUSH stream + push.subscription event to notification.subscribed

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -257,25 +257,25 @@ func (c *AnalyticsConsumer) HandleArtistUnfollowed(msg *message.Message) error {
 	return nil
 }
 
-// HandlePushSubscriptionCompleted forwards the PUSH.subscription_completed
+// HandleNotificationSubscribed forwards the NOTIFICATION.subscribed
 // NATS subject as the catalogue event
-// usecase.EventPushSubscriptionCompleted. Properties: device_type
+// usecase.EventNotificationSubscribed. Properties: device_type
 // (classifier output from the endpoint host; the endpoint itself is
 // never forwarded).
-func (c *AnalyticsConsumer) HandlePushSubscriptionCompleted(msg *message.Message) error {
+func (c *AnalyticsConsumer) HandleNotificationSubscribed(msg *message.Message) error {
 	ctx := msg.Context()
 	defer c.recordLag(ctx, msg)
 
-	var data entity.PushSubscriptionCompletedData
+	var data entity.NotificationSubscribedData
 	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
-		c.logger.Error(ctx, "failed to parse PUSH.subscription_completed event", err)
+		c.logger.Error(ctx, "failed to parse NOTIFICATION.subscribed event", err)
 		c.metrics.RecordMessage(ctx, statusSkippedParseError)
-		return apperr.Wrap(err, codes.Internal, "parse PUSH.subscription_completed event")
+		return apperr.Wrap(err, codes.Internal, "parse NOTIFICATION.subscribed event")
 	}
 
 	if c.client == nil {
 		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
-			slog.String("event", string(usecase.EventPushSubscriptionCompleted)),
+			slog.String("event", string(usecase.EventNotificationSubscribed)),
 			slog.String("user_id", data.UserID),
 		)
 		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
@@ -283,7 +283,7 @@ func (c *AnalyticsConsumer) HandlePushSubscriptionCompleted(msg *message.Message
 	}
 
 	if data.UserID == "" {
-		c.logger.Warn(ctx, "PUSH.subscription_completed event missing user_id, skipping forward")
+		c.logger.Warn(ctx, "NOTIFICATION.subscribed event missing user_id, skipping forward")
 		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
 		return nil
 	}
@@ -292,9 +292,9 @@ func (c *AnalyticsConsumer) HandlePushSubscriptionCompleted(msg *message.Message
 		"device_type": data.DeviceType,
 	}
 
-	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventPushSubscriptionCompleted, properties); err != nil {
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventNotificationSubscribed, properties); err != nil {
 		c.logger.Error(ctx, "failed to enqueue analytics event", err,
-			slog.String("event", string(usecase.EventPushSubscriptionCompleted)),
+			slog.String("event", string(usecase.EventNotificationSubscribed)),
 			slog.String("user_id", data.UserID),
 		)
 		c.metrics.RecordMessage(ctx, statusEnqueueError)

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -482,16 +482,16 @@ func TestAnalyticsConsumer_HandleArtistUnfollowed(t *testing.T) {
 	}
 }
 
-// TestAnalyticsConsumer_HandlePushSubscriptionCompleted covers
-// PUSH.subscription_completed → push.subscription.completed routing.
+// TestAnalyticsConsumer_HandleNotificationSubscribed covers
+// NOTIFICATION.subscribed → notification.subscribed routing.
 // Property: device_type (the endpoint host classifier).
-func TestAnalyticsConsumer_HandlePushSubscriptionCompleted(t *testing.T) {
+func TestAnalyticsConsumer_HandleNotificationSubscribed(t *testing.T) {
 	t.Parallel()
 
 	const validUserID = "11111111-2222-3333-4444-555555555555"
 
 	type args struct {
-		data entity.PushSubscriptionCompletedData
+		data entity.NotificationSubscribedData
 	}
 	type want struct {
 		err              error
@@ -507,7 +507,7 @@ func TestAnalyticsConsumer_HandlePushSubscriptionCompleted(t *testing.T) {
 	}{
 		{
 			name: "forwards with device_type when client + UserID present",
-			args: args{data: entity.PushSubscriptionCompletedData{
+			args: args{data: entity.NotificationSubscribedData{
 				UserID:     validUserID,
 				DeviceType: "android",
 			}},
@@ -515,7 +515,7 @@ func TestAnalyticsConsumer_HandlePushSubscriptionCompleted(t *testing.T) {
 		},
 		{
 			name: "skips forward when client is nil",
-			args: args{data: entity.PushSubscriptionCompletedData{
+			args: args{data: entity.NotificationSubscribedData{
 				UserID:     validUserID,
 				DeviceType: "apple",
 			}},
@@ -524,7 +524,7 @@ func TestAnalyticsConsumer_HandlePushSubscriptionCompleted(t *testing.T) {
 		},
 		{
 			name: "skips forward when UserID is empty",
-			args: args{data: entity.PushSubscriptionCompletedData{
+			args: args{data: entity.NotificationSubscribedData{
 				UserID:     "",
 				DeviceType: "android",
 			}},
@@ -532,7 +532,7 @@ func TestAnalyticsConsumer_HandlePushSubscriptionCompleted(t *testing.T) {
 		},
 		{
 			name: "wraps Enqueue error as apperr.ErrInternal",
-			args: args{data: entity.PushSubscriptionCompletedData{
+			args: args{data: entity.NotificationSubscribedData{
 				UserID:     validUserID,
 				DeviceType: "other",
 			}},
@@ -559,7 +559,7 @@ func TestAnalyticsConsumer_HandlePushSubscriptionCompleted(t *testing.T) {
 						Enqueue(
 							mock.Anything,
 							tt.args.data.UserID,
-							usecase.EventPushSubscriptionCompleted,
+							usecase.EventNotificationSubscribed,
 							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
 								return props["device_type"] == tt.args.data.DeviceType
 							}),
@@ -578,7 +578,7 @@ func TestAnalyticsConsumer_HandlePushSubscriptionCompleted(t *testing.T) {
 				Once()
 
 			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
-			err := handler.HandlePushSubscriptionCompleted(makeAnalyticsMsg(t, tt.args.data))
+			err := handler.HandleNotificationSubscribed(makeAnalyticsMsg(t, tt.args.data))
 
 			if tt.want.err != nil {
 				assert.ErrorIs(t, err, tt.want.err)

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -238,10 +238,10 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	)
 
 	router.AddConsumerHandler(
-		"forward-push-subscription-completed-to-analytics",
-		entity.SubjectPushSubscriptionCompleted,
+		"forward-notification-subscribed-to-analytics",
+		entity.SubjectNotificationSubscribed,
 		subscriber,
-		analyticsConsumer.HandlePushSubscriptionCompleted,
+		analyticsConsumer.HandleNotificationSubscribed,
 	)
 
 	router.AddConsumerHandler(

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -15,7 +15,7 @@ const (
 	SubjectArtistUnfollowed             = "ARTIST.unfollowed"
 	SubjectUserCreated                  = "USER.created"
 	SubjectUserPreferredLanguageUpdated = "USER.preferred_language_updated"
-	SubjectPushSubscriptionCompleted    = "PUSH.subscription_completed"
+	SubjectNotificationSubscribed       = "NOTIFICATION.subscribed"
 	SubjectEntryZkProofVerified         = "ENTRY.zk_proof_verified"
 	SubjectEntryZkProofRejected         = "ENTRY.zk_proof_rejected"
 )
@@ -139,11 +139,14 @@ type EntryZkProofRejectedData struct {
 	Reason           EntryRejectionReason `json:"reason"`
 }
 
-// PushSubscriptionCompletedData is the payload for PUSH.subscription_completed.
-// Mapped to the catalogue event push.subscription.completed by the
+// NotificationSubscribedData is the payload for NOTIFICATION.subscribed.
+// Mapped to the catalogue event notification.subscribed by the
 // analytics-consumer. Published by PushNotificationUseCase.Create after the
-// repository persists the subscription record.
-type PushSubscriptionCompletedData struct {
+// repository persists the Web Push subscription record. Although the
+// underlying transport is the W3C Push API, the analytics surface stays
+// scoped under the notification domain — see specification/docs/analytics/
+// event-catalog.md.
+type NotificationSubscribedData struct {
 	// UserID is the platform-internal user identifier of the subscriber.
 	// Used as the PostHog distinct_id.
 	UserID string `json:"user_id"`

--- a/internal/entity/push_subscription.go
+++ b/internal/entity/push_subscription.go
@@ -28,7 +28,7 @@ type PushSubscription struct {
 }
 
 // DeviceTypeFromEndpoint classifies a Web Push endpoint URL into a coarse
-// device-family label suitable for the push.subscription.completed analytics
+// device-family label suitable for the notification.subscribed analytics
 // event. The endpoint host identifies the push service vendor, which in turn
 // identifies the browser/OS family. The endpoint itself is sensitive (it
 // uniquely identifies the user's browser session) and MUST NOT leak into

--- a/internal/infrastructure/messaging/streams.go
+++ b/internal/infrastructure/messaging/streams.go
@@ -74,8 +74,8 @@ var streams = []nats.StreamConfig{
 		Duplicates: 2 * time.Minute,
 	},
 	{
-		Name:       "PUSH",
-		Subjects:   []string{"PUSH.*"},
+		Name:       "NOTIFICATION",
+		Subjects:   []string{"NOTIFICATION.*"},
 		Retention:  nats.LimitsPolicy,
 		MaxAge:     7 * 24 * time.Hour,
 		Storage:    nats.FileStorage,

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -11,8 +11,8 @@ package usecase
 // Frontend-only events are NOT listed here; they live in
 // frontend/src/services/analytics-events.ts. Trust-critical events whose
 // accuracy must survive client tampering (ticket purchases, ZK proof
-// verification, push delivery, account state changes) are emitted only
-// from the backend through these constants.
+// verification, notification delivery, account state changes) are emitted
+// only from the backend through these constants.
 type AnalyticsEventName string
 
 // Account lifecycle events emitted from the backend.
@@ -98,16 +98,19 @@ const (
 	EventEntryZkProofRejected AnalyticsEventName = "entry.zk_proof.rejected"
 )
 
-// Push notification lifecycle events emitted from the backend.
+// Notification lifecycle events emitted from the backend. The underlying
+// transport is the W3C Push API, but the analytics surface is scoped under
+// the notification domain to align with the user-facing concept — see
+// specification/docs/analytics/event-catalog.md.
 const (
-	// EventPushSubscriptionCompleted is recorded after a Web Push
+	// EventNotificationSubscribed is recorded after a Web Push
 	// subscription has been persisted against the user record.
-	EventPushSubscriptionCompleted AnalyticsEventName = "push.subscription.completed"
+	EventNotificationSubscribed AnalyticsEventName = "notification.subscribed"
 
-	// EventPushNotificationDelivered is recorded when the push provider
+	// EventNotificationDelivered is recorded when the push provider
 	// accepts a notification for delivery. The frontend records the
 	// downstream open/dismiss separately.
-	EventPushNotificationDelivered AnalyticsEventName = "push.notification.delivered"
+	EventNotificationDelivered AnalyticsEventName = "notification.delivered"
 )
 
 // knownBackendEvents is the allowlist of AnalyticsEventName constants
@@ -133,8 +136,8 @@ var knownBackendEvents = map[AnalyticsEventName]struct{}{
 	EventTicketPurchaseFailed:            {},
 	EventEntryZkProofVerified:            {},
 	EventEntryZkProofRejected:            {},
-	EventPushSubscriptionCompleted:       {},
-	EventPushNotificationDelivered:       {},
+	EventNotificationSubscribed:          {},
+	EventNotificationDelivered:           {},
 }
 
 // IsKnownEvent reports whether name is registered in the backend event

--- a/internal/usecase/push_notification_uc.go
+++ b/internal/usecase/push_notification_uc.go
@@ -105,11 +105,11 @@ func (uc *pushNotificationUseCase) Create(ctx context.Context, userID, endpoint,
 		return nil, fmt.Errorf("failed to persist push subscription: %w", err)
 	}
 
-	if err := uc.publisher.PublishEvent(ctx, entity.SubjectPushSubscriptionCompleted, entity.PushSubscriptionCompletedData{
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectNotificationSubscribed, entity.NotificationSubscribedData{
 		UserID:     userID,
 		DeviceType: entity.DeviceTypeFromEndpoint(endpoint),
 	}); err != nil {
-		uc.logger.Error(ctx, "failed to publish PUSH.subscription_completed event", err,
+		uc.logger.Error(ctx, "failed to publish NOTIFICATION.subscribed event", err,
 			slog.String("user_id", userID),
 		)
 		// Non-fatal: the subscription is already persisted.

--- a/internal/usecase/push_notification_uc_test.go
+++ b/internal/usecase/push_notification_uc_test.go
@@ -97,7 +97,7 @@ func TestPushNotificationUseCase_Create(t *testing.T) {
 					Return(nil).
 					Once()
 				d.publisher.EXPECT().
-					PublishEvent(ctx, entity.SubjectPushSubscriptionCompleted, entity.PushSubscriptionCompletedData{
+					PublishEvent(ctx, entity.SubjectNotificationSubscribed, entity.NotificationSubscribedData{
 						UserID:     "user-1",
 						DeviceType: "android",
 					}).


### PR DESCRIPTION
## Summary

Aligns backend with the rename merged in [specification#552](https://github.com/liverty-music/specification/pull/552). The underlying transport is still the W3C Push API (\`push_subscription_repo\`, \`PushNotificationUseCase\`, \`webpush\` sender — all unchanged), but the analytics surface and the NATS aggregate root are now scoped under the **notification** domain to match the user-facing concept.

## What changes

| Surface | Old | New |
| --- | --- | --- |
| NATS stream | \`PUSH\` (\`PUSH.*\`) | \`NOTIFICATION\` (\`NOTIFICATION.*\`) |
| NATS subject | \`PUSH.subscription_completed\` | \`NOTIFICATION.subscribed\` |
| Payload struct | \`entity.PushSubscriptionCompletedData\` | \`entity.NotificationSubscribedData\` |
| Subject const | \`entity.SubjectPushSubscriptionCompleted\` | \`entity.SubjectNotificationSubscribed\` |
| Catalogue event | \`push.subscription.completed\` | \`notification.subscribed\` |
| Catalogue event | \`push.notification.delivered\` | \`notification.delivered\` |
| Event const | \`usecase.EventPushSubscriptionCompleted\` | \`usecase.EventNotificationSubscribed\` |
| Event const | \`usecase.EventPushNotificationDelivered\` | \`usecase.EventNotificationDelivered\` |
| Handler | \`HandlePushSubscriptionCompleted\` | \`HandleNotificationSubscribed\` |
| watermill router name | \`forward-push-subscription-completed-to-analytics\` | \`forward-notification-subscribed-to-analytics\` |

## What does NOT change

The transport-layer Web Push surface stays as is — those names refer to the actual W3C Push API, not the analytics domain:

- \`PushNotificationUseCase\`, \`PushSubscriptionRepository\`
- \`push_subscription.go\`, \`push_subscription_repo.go\`, \`push_notification_uc.go\`
- \`infrastructure/webpush/\` (sender, key management)
- \`adapter/rpc/push_notification_handler.go\`

## Production-state notes

- The analytics catalogue event \`push.subscription.completed\` shipped in backend v1.3.0 (PR #319) but **has never fired in prod** — KEDA gap on PUSH consumer + zero Web Push opt-ins since launch. The NATS/catalogue rename is purely forward-looking; no message replay needed.
- The orphaned \`PUSH\` JetStream in prod holds 0 messages — manually removed in a follow-up runbook step (\`nats stream rm PUSH\`). Stream provisioning is idempotent and additive: the new \`NOTIFICATION\` stream is created on next startup; the old \`PUSH\` stream is harmless to leave behind until cleanup.
- \`EventNotificationDelivered\` has no publisher yet (task 5.7); the const rename is a pure source-of-truth update.

## Verification

- \`make check\` (lint + lint-schema + modernize + test) passes locally.
- Unit tests updated for the renamed handler, payload struct, and event const expectations.

## Downstream

- **Frontend rename PR** (separate) — \`Events.PushSubscriptionRequested\` → \`Events.NotificationRequested\` with value \`notification.requested\`.
- **cloud-provisioning** — KEDA \`ScaledObject\` needs the new consumer name \`NOTIFICATION_subscribed\` (separate follow-up).

Refs: liverty-music/specification#532