### PR TITLE
feat(concert): cost-saving skip conditions for Gemini concert search

### DIFF
--- a/internal/di/job.go
+++ b/internal/di/job.go
@@ -106,7 +106,7 @@ func InitializeJobApp(ctx context.Context) (*JobApp, error) {
 	// Use Cases
 	eventPublisher := messaging.NewEventPublisher(publisher)
 	centroidResolver := geo.NewCentroidResolver()
-	concertUC := usecase.NewConcertUseCase(artistRepo, concertRepo, venueRepo, searchLogRepo, geminiSearcher, centroidResolver, eventPublisher, infratelemetry.NewBusinessMetrics(), logger)
+	concertUC := usecase.NewConcertUseCase(artistRepo, concertRepo, venueRepo, searchLogRepo, geminiSearcher, centroidResolver, eventPublisher, infratelemetry.NewBusinessMetrics(), cfg.GCP.SearchCacheTTL(), cfg.GCP.SearchDiscoveryWindow(), logger)
 
 	// Register shutdown phases.
 	shutdown.Init(logger)

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -189,7 +189,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	eventPublisher := messaging.NewEventPublisher(publisher)
 	userUC := usecase.NewUserUseCase(userRepo, eventPublisher, logger)
 	centroidResolver := geo.NewCentroidResolver()
-	concertUC := usecase.NewConcertUseCase(artistRepo, concertRepo, venueRepo, searchLogRepo, geminiSearcher, centroidResolver, eventPublisher, businessMetrics, logger)
+	concertUC := usecase.NewConcertUseCase(artistRepo, concertRepo, venueRepo, searchLogRepo, geminiSearcher, centroidResolver, eventPublisher, businessMetrics, cfg.GCP.SearchCacheTTL(), cfg.GCP.SearchDiscoveryWindow(), logger)
 	artistUC := usecase.NewArtistUseCase(artistRepo, lastfmClient, musicbrainzClient, eventPublisher, artistCache, logger)
 	followUC := usecase.NewFollowUseCase(followRepo, artistRepo, musicbrainzClient, concertUC, searchLogRepo, eventPublisher, businessMetrics, logger)
 	ticketJourneyUC := usecase.NewTicketJourneyUseCase(ticketJourneyRepo, logger)

--- a/internal/entity/mocks/mock_SearchLogRepository.go
+++ b/internal/entity/mocks/mock_SearchLogRepository.go
@@ -128,6 +128,53 @@ func (_c *MockSearchLogRepository_GetByArtistID_Call) RunAndReturn(run func(cont
 	return _c
 }
 
+// MarkFound provides a mock function with given fields: ctx, artistID
+func (_m *MockSearchLogRepository) MarkFound(ctx context.Context, artistID string) error {
+	ret := _m.Called(ctx, artistID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkFound")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, artistID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockSearchLogRepository_MarkFound_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkFound'
+type MockSearchLogRepository_MarkFound_Call struct {
+	*mock.Call
+}
+
+// MarkFound is a helper method to define mock.On call
+//   - ctx context.Context
+//   - artistID string
+func (_e *MockSearchLogRepository_Expecter) MarkFound(ctx interface{}, artistID interface{}) *MockSearchLogRepository_MarkFound_Call {
+	return &MockSearchLogRepository_MarkFound_Call{Call: _e.mock.On("MarkFound", ctx, artistID)}
+}
+
+func (_c *MockSearchLogRepository_MarkFound_Call) Run(run func(ctx context.Context, artistID string)) *MockSearchLogRepository_MarkFound_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockSearchLogRepository_MarkFound_Call) Return(_a0 error) *MockSearchLogRepository_MarkFound_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSearchLogRepository_MarkFound_Call) RunAndReturn(run func(context.Context, string) error) *MockSearchLogRepository_MarkFound_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateStatus provides a mock function with given fields: ctx, artistID, status
 func (_m *MockSearchLogRepository) UpdateStatus(ctx context.Context, artistID string, status entity.SearchLogStatus) error {
 	ret := _m.Called(ctx, artistID, status)

--- a/internal/entity/search_log.go
+++ b/internal/entity/search_log.go
@@ -26,6 +26,9 @@ type SearchLog struct {
 	SearchTime time.Time
 	// Status is the current state of the search job.
 	Status SearchLogStatus
+	// LastFoundTime is the timestamp of the most recent search that discovered
+	// at least one new concert. Zero means no discovery has ever been recorded.
+	LastFoundTime time.Time
 }
 
 // IsFresh reports whether this search log represents a recently completed search
@@ -38,6 +41,17 @@ func (sl *SearchLog) IsFresh(now time.Time, ttl time.Duration) bool {
 // that has not yet exceeded the given timeout. Returns false if the status is not Pending.
 func (sl *SearchLog) IsPending(now time.Time, timeout time.Duration) bool {
 	return sl.Status == SearchLogStatusPending && now.Sub(sl.SearchTime) < timeout
+}
+
+// WasRecentlyDiscovered reports whether a new concert was discovered for this
+// artist within the given window. Returns false when no discovery has ever been
+// recorded (LastFoundTime is zero), so an artist that never yielded a concert is
+// never skipped on this basis.
+func (sl *SearchLog) WasRecentlyDiscovered(now time.Time, window time.Duration) bool {
+	if sl.LastFoundTime.IsZero() {
+		return false
+	}
+	return now.Sub(sl.LastFoundTime) < window
 }
 
 // SearchLogRepository defines the data access interface for search logs.
@@ -62,6 +76,15 @@ type SearchLogRepository interface {
 	//
 	//  - Internal: If the update fails.
 	UpdateStatus(ctx context.Context, artistID string, status SearchLogStatus) error
+
+	// MarkFound records that a search discovered at least one new concert by
+	// setting the artist's last_found_at to the current time. It assumes the
+	// row already exists (created by the pending Upsert before the search).
+	//
+	// # Possible errors
+	//
+	//  - Internal: If the update fails.
+	MarkFound(ctx context.Context, artistID string) error
 
 	// Delete removes the search log for a specific artist.
 	//

--- a/internal/entity/search_log_test.go
+++ b/internal/entity/search_log_test.go
@@ -133,3 +133,46 @@ func TestSearchLog_IsPending(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchLog_WasRecentlyDiscovered(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 25, 12, 0, 0, 0, time.UTC)
+	window := 14 * 24 * time.Hour
+
+	tests := []struct {
+		name string
+		sl   *entity.SearchLog
+		want bool
+	}{
+		{
+			name: "never discovered (zero) is not recent",
+			sl:   &entity.SearchLog{},
+			want: false,
+		},
+		{
+			name: "discovered within window is recent",
+			sl:   &entity.SearchLog{LastFoundTime: now.Add(-2 * 24 * time.Hour)},
+			want: true,
+		},
+		{
+			name: "discovered exactly at window boundary is not recent",
+			sl:   &entity.SearchLog{LastFoundTime: now.Add(-window)},
+			want: false,
+		},
+		{
+			name: "discovered beyond window is not recent",
+			sl:   &entity.SearchLog{LastFoundTime: now.Add(-15 * 24 * time.Hour)},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.sl.WasRecentlyDiscovered(now, window)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/infrastructure/database/rdb/schema/schema.sql
+++ b/internal/infrastructure/database/rdb/schema/schema.sql
@@ -197,6 +197,7 @@ CREATE TABLE IF NOT EXISTS latest_search_logs (
     artist_id UUID NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
     searched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     status TEXT NOT NULL DEFAULT 'completed',
+    last_found_at TIMESTAMPTZ,
     PRIMARY KEY (artist_id)
 );
 
@@ -204,6 +205,7 @@ COMMENT ON TABLE latest_search_logs IS 'Tracks when each artist was last searche
 COMMENT ON COLUMN latest_search_logs.artist_id IS 'Reference to the artist that was searched';
 COMMENT ON COLUMN latest_search_logs.searched_at IS 'Timestamp of the most recent external search';
 COMMENT ON COLUMN latest_search_logs.status IS 'Search job status: pending, completed, or failed';
+COMMENT ON COLUMN latest_search_logs.last_found_at IS 'Timestamp of the most recent search that discovered at least one new concert; NULL if none ever found';
 
 -- Tickets table (Soulbound Ticket ERC-5192)
 CREATE TABLE IF NOT EXISTS tickets (

--- a/internal/infrastructure/database/rdb/search_log_repo.go
+++ b/internal/infrastructure/database/rdb/search_log_repo.go
@@ -3,6 +3,7 @@ package rdb
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/liverty-music/backend/internal/entity"
 )
@@ -14,7 +15,7 @@ type SearchLogRepository struct {
 
 const (
 	getSearchLogByArtistIDQuery = `
-		SELECT artist_id, searched_at, status
+		SELECT artist_id, searched_at, status, last_found_at
 		FROM latest_search_logs
 		WHERE artist_id = $1
 	`
@@ -26,6 +27,11 @@ const (
 	updateSearchLogStatusQuery = `
 		UPDATE latest_search_logs
 		SET status = $2
+		WHERE artist_id = $1
+	`
+	markSearchLogFoundQuery = `
+		UPDATE latest_search_logs
+		SET last_found_at = NOW()
 		WHERE artist_id = $1
 	`
 	deleteSearchLogQuery = `
@@ -42,10 +48,16 @@ func NewSearchLogRepository(db *Database) *SearchLogRepository {
 // GetByArtistID retrieves the search log for a specific artist.
 func (r *SearchLogRepository) GetByArtistID(ctx context.Context, artistID string) (*entity.SearchLog, error) {
 	var log entity.SearchLog
+	// last_found_at is nullable; scan into a pointer so a NULL maps to the
+	// zero value rather than a scan error.
+	var lastFound *time.Time
 	err := r.db.Pool.QueryRow(ctx, getSearchLogByArtistIDQuery, artistID).
-		Scan(&log.ArtistID, &log.SearchTime, &log.Status)
+		Scan(&log.ArtistID, &log.SearchTime, &log.Status, &lastFound)
 	if err != nil {
 		return nil, toAppErr(err, "failed to get search log", slog.String("artist_id", artistID))
+	}
+	if lastFound != nil {
+		log.LastFoundTime = *lastFound
 	}
 	return &log, nil
 }
@@ -64,6 +76,17 @@ func (r *SearchLogRepository) UpdateStatus(ctx context.Context, artistID string,
 	_, err := r.db.Pool.Exec(ctx, updateSearchLogStatusQuery, artistID, string(status))
 	if err != nil {
 		return toAppErr(err, "failed to update search log status", slog.String("artist_id", artistID))
+	}
+	return nil
+}
+
+// MarkFound records that a search for the artist discovered at least one new
+// concert by setting last_found_at to the current time. It assumes a row
+// already exists (the pending Upsert creates it before the search runs).
+func (r *SearchLogRepository) MarkFound(ctx context.Context, artistID string) error {
+	_, err := r.db.Pool.Exec(ctx, markSearchLogFoundQuery, artistID)
+	if err != nil {
+		return toAppErr(err, "failed to mark search log found", slog.String("artist_id", artistID))
 	}
 	return nil
 }

--- a/internal/infrastructure/database/rdb/search_log_repo_test.go
+++ b/internal/infrastructure/database/rdb/search_log_repo_test.go
@@ -112,6 +112,35 @@ func TestSearchLogRepository_GetByArtistID(t *testing.T) {
 		log, err := searchLogRepo.GetByArtistID(ctx, artistID)
 		require.NoError(t, err)
 		assert.Equal(t, entity.SearchLogStatusFailed, log.Status)
+		// last_found_at defaults to NULL → zero time until a discovery is recorded.
+		assert.True(t, log.LastFoundTime.IsZero())
+	})
+}
+
+func TestSearchLogRepository_MarkFound(t *testing.T) {
+	repo := rdb.NewSearchLogRepository(testDB)
+	ctx := context.Background()
+
+	t.Run("sets last_found_at on existing row without disturbing searched_at", func(t *testing.T) {
+		cleanDatabase(t)
+		artistID := seedArtist(t, "MarkFound Test Artist", "aaaaaaaa-aaaa-aaaa-aaaa-f0e74f1b4d01")
+
+		err := repo.Upsert(ctx, artistID, entity.SearchLogStatusPending)
+		require.NoError(t, err)
+
+		before, err := repo.GetByArtistID(ctx, artistID)
+		require.NoError(t, err)
+		require.True(t, before.LastFoundTime.IsZero())
+
+		err = repo.MarkFound(ctx, artistID)
+		require.NoError(t, err)
+
+		after, err := repo.GetByArtistID(ctx, artistID)
+		require.NoError(t, err)
+		assert.False(t, after.LastFoundTime.IsZero())
+		assert.WithinDuration(t, time.Now(), after.LastFoundTime, 5*time.Second)
+		// searched_at is unaffected by MarkFound.
+		assert.True(t, after.SearchTime.Equal(before.SearchTime))
 	})
 }
 

--- a/internal/usecase/concert_uc.go
+++ b/internal/usecase/concert_uc.go
@@ -71,11 +71,14 @@ type concertUseCase struct {
 	centroidResolver CentroidResolver
 	publisher        EventPublisher
 	metrics          ConcertMetrics
-	logger           *logging.Logger
+	// searchCacheTTL is how long a completed search is reused before a repeat
+	// external call is allowed. Configured per environment (prod runs longer).
+	searchCacheTTL time.Duration
+	// discoveryWindow is how long after a successful discovery the external
+	// search is skipped, since announcements arrive in batches then go quiet.
+	discoveryWindow time.Duration
+	logger          *logging.Logger
 }
-
-// searchCacheTTL is the duration for which a completed search log is considered fresh.
-const searchCacheTTL = 24 * time.Hour
 
 // pendingTimeout is the maximum age of a pending search log before it is
 // considered stale and treated as failed (self-healing for crashed workers).
@@ -100,6 +103,8 @@ func NewConcertUseCase(
 	centroidResolver CentroidResolver,
 	publisher EventPublisher,
 	metrics ConcertMetrics,
+	searchCacheTTL time.Duration,
+	discoveryWindow time.Duration,
 	logger *logging.Logger,
 ) ConcertUseCase {
 	return &concertUseCase{
@@ -111,6 +116,8 @@ func NewConcertUseCase(
 		centroidResolver: centroidResolver,
 		publisher:        publisher,
 		metrics:          metrics,
+		searchCacheTTL:   searchCacheTTL,
+		discoveryWindow:  discoveryWindow,
 		logger:           logger,
 	}
 }
@@ -169,10 +176,20 @@ func (uc *concertUseCase) SearchNewConcerts(ctx context.Context, artistID string
 	}
 	if searchLog != nil {
 		now := time.Now()
-		if searchLog.IsFresh(now, searchCacheTTL) {
+		if searchLog.IsFresh(now, uc.searchCacheTTL) {
 			uc.logger.Debug(ctx, "skipping external search, recently searched",
 				slog.String("artist_id", artistID),
 				slog.Time("search_time", searchLog.SearchTime),
+			)
+			return nil, nil
+		}
+		// Skip even when the last search is stale if a new concert was found
+		// recently: announcements arrive in batches then go quiet, so a repeat
+		// search would just re-find the same events and dedup to nothing.
+		if searchLog.WasRecentlyDiscovered(now, uc.discoveryWindow) {
+			uc.logger.Debug(ctx, "skipping external search, recently discovered new concert",
+				slog.String("artist_id", artistID),
+				slog.Time("last_found_at", searchLog.LastFoundTime),
 			)
 			return nil, nil
 		}
@@ -316,6 +333,10 @@ func (uc *concertUseCase) executeSearch(ctx context.Context, artistID string) (_
 		slog.Int("concert_count", len(newScraped)),
 	)
 
+	// Record the discovery so the discoveryWindow skip suppresses redundant
+	// re-searches until the next announcement cycle is likely.
+	uc.markSearchFound(ctx, artistID)
+
 	// Build Concert entities from the deduplicated scraped data to return to the caller.
 	// Event / Venue IDs stay empty because the search path returns concerts for
 	// immediate display rather than persistence. The series ID is generated
@@ -348,6 +369,19 @@ func (uc *concertUseCase) markSearchCompleted(ctx context.Context, artistID stri
 
 	if err := uc.searchLogRepo.UpdateStatus(updateCtx, artistID, entity.SearchLogStatusCompleted); err != nil {
 		uc.logger.Error(ctx, "failed to mark search as completed", err, slog.String("artist_id", artistID))
+	}
+}
+
+// markSearchFound records that the search discovered at least one new concert.
+// Failure is non-fatal and only logged: the discovery event was already
+// published, so a missed last_found_at update merely lets the next CronJob tick
+// re-search this artist sooner than the discoveryWindow would otherwise allow.
+func (uc *concertUseCase) markSearchFound(ctx context.Context, artistID string) {
+	updateCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), statusUpdateTimeout)
+	defer cancel()
+
+	if err := uc.searchLogRepo.MarkFound(updateCtx, artistID); err != nil {
+		uc.logger.Error(ctx, "failed to mark search as found", err, slog.String("artist_id", artistID))
 	}
 }
 

--- a/internal/usecase/concert_uc_test.go
+++ b/internal/usecase/concert_uc_test.go
@@ -19,6 +19,13 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// Default skip windows used to construct the use case in tests; they mirror the
+// production defaults so the timing-boundary cases reason about a 24h TTL.
+const (
+	testSearchCacheTTL  = 24 * time.Hour
+	testDiscoveryWindow = 14 * 24 * time.Hour
+)
+
 // concertTestDeps holds all dependencies for ConcertUseCase tests.
 type concertTestDeps struct {
 	artistRepo       *mocks.MockArtistRepository
@@ -53,7 +60,7 @@ func newConcertTestDeps(t *testing.T) *concertTestDeps {
 		centroidResolver: noopCentroidResolver{},
 		publisher:        pub,
 	}
-	d.uc = usecase.NewConcertUseCase(d.artistRepo, d.concertRepo, d.venueRepo, d.searchLogRepo, d.searcher, d.centroidResolver, messaging.NewEventPublisher(pub), noopMetrics{}, logger)
+	d.uc = usecase.NewConcertUseCase(d.artistRepo, d.concertRepo, d.venueRepo, d.searchLogRepo, d.searcher, d.centroidResolver, messaging.NewEventPublisher(pub), noopMetrics{}, testSearchCacheTTL, testDiscoveryWindow, logger)
 	t.Cleanup(func() { _ = pub.Close() })
 	return d
 }
@@ -263,6 +270,7 @@ func TestConcertUseCase_SearchNewConcerts(t *testing.T) {
 				d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(nil, nil).Once()
 				d.searcher.EXPECT().Search(mock.Anything, artist, site, mock.AnythingOfType("time.Time")).Return(scraped, nil).Once()
 				d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+				d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
 			},
 			wantErr: nil,
 		},
@@ -325,6 +333,7 @@ func TestConcertUseCase_SearchNewConcerts(t *testing.T) {
 				d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(nil, nil).Once()
 				d.searcher.EXPECT().Search(mock.Anything, artist, (*entity.OfficialSite)(nil), mock.AnythingOfType("time.Time")).Return(scraped, nil).Once()
 				d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+				d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
 			},
 			wantErr: nil,
 		},
@@ -350,6 +359,9 @@ func TestConcertUseCase_SearchNewConcerts(t *testing.T) {
 				d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(existing, nil).Once()
 				d.searcher.EXPECT().Search(mock.Anything, artist, (*entity.OfficialSite)(nil), mock.AnythingOfType("time.Time")).Return(scraped, nil).Once()
 				d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+				// Existing has a nil venue name; the (date, venue) key differs, so the
+				// scraped concert is new and published → last_found_at is recorded.
+				d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
 			},
 			wantErr: nil,
 		},
@@ -436,6 +448,7 @@ func TestSearchNewConcerts_TimingBoundaries(t *testing.T) {
 			d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(nil, nil).Once()
 			d.searcher.EXPECT().Search(mock.Anything, artist, (*entity.OfficialSite)(nil), mock.AnythingOfType("time.Time")).Return(scraped, nil).Once()
 			d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+			d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
 
 			sub, err := d.publisher.Subscribe(ctx, entity.SubjectConcertDiscovered)
 			assert.NoError(t, err)
@@ -492,6 +505,7 @@ func TestSearchNewConcerts_TimingBoundaries(t *testing.T) {
 			d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(nil, nil).Once()
 			d.searcher.EXPECT().Search(mock.Anything, artist, (*entity.OfficialSite)(nil), mock.AnythingOfType("time.Time")).Return(scraped, nil).Once()
 			d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+			d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
 
 			sub, err := d.publisher.Subscribe(ctx, entity.SubjectConcertDiscovered)
 			assert.NoError(t, err)
@@ -501,6 +515,113 @@ func TestSearchNewConcerts_TimingBoundaries(t *testing.T) {
 
 			got := receivePublishedConcerts(t, ctx, sub)
 			assert.Equal(t, 1, got, "stale pending should trigger re-search and publish")
+		})
+	})
+}
+
+// TestSearchNewConcerts_DiscoveryWindow verifies the recent-discovery skip gate:
+// a stale search is still skipped when a new concert was found within the
+// discovery window, but proceeds when last_found_at is unset (null) or beyond
+// the window.
+func TestSearchNewConcerts_DiscoveryWindow(t *testing.T) {
+	t.Parallel()
+
+	artistID := "artist-1"
+	artist := &entity.Artist{ID: artistID, Name: "Test Artist", MBID: "11111111-1111-1111-1111-111111111111"}
+	scraped := []*entity.ScrapedConcert{
+		{Title: "New Concert", ListedVenueName: "Test Venue", LocalDate: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), SourceURL: "https://example.com"},
+	}
+
+	t.Run("stale search but recent discovery is skipped (last_found_at < discoveryWindow)", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := context.Background()
+			d := newConcertTestDeps(t)
+
+			// Search is well past the TTL, but a concert was discovered "now".
+			now := time.Now()
+			d.searchLogRepo.EXPECT().GetByArtistID(ctx, artistID).Return(&entity.SearchLog{
+				ArtistID:      artistID,
+				SearchTime:    now,
+				Status:        entity.SearchLogStatusCompleted,
+				LastFoundTime: now,
+			}, nil).Once()
+
+			time.Sleep(48 * time.Hour) // past 24h TTL but within 14d discovery window
+
+			got, err := d.uc.SearchNewConcerts(ctx, artistID)
+			assert.NoError(t, err)
+			assert.Nil(t, got, "recent discovery should suppress the external search")
+		})
+	})
+
+	t.Run("stale search with no prior discovery proceeds (last_found_at null)", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := context.Background()
+			d := newConcertTestDeps(t)
+
+			// Stale completed search, never discovered anything (zero LastFoundTime).
+			now := time.Now()
+			d.searchLogRepo.EXPECT().GetByArtistID(ctx, artistID).Return(&entity.SearchLog{
+				ArtistID:   artistID,
+				SearchTime: now,
+				Status:     entity.SearchLogStatusCompleted,
+			}, nil).Once()
+
+			time.Sleep(25 * time.Hour) // past TTL; discovery gate must not fire on zero time
+
+			d.searchLogRepo.EXPECT().Upsert(ctx, artistID, entity.SearchLogStatusPending).Return(nil).Once()
+			d.artistRepo.EXPECT().Get(ctx, artistID).Return(artist, nil).Once()
+			d.artistRepo.EXPECT().GetOfficialSite(ctx, artistID).Return(nil, apperr.ErrNotFound).Once()
+			d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(nil, nil).Once()
+			d.searcher.EXPECT().Search(mock.Anything, artist, (*entity.OfficialSite)(nil), mock.AnythingOfType("time.Time")).Return(scraped, nil).Once()
+			d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+			d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
+
+			sub, err := d.publisher.Subscribe(ctx, entity.SubjectConcertDiscovered)
+			assert.NoError(t, err)
+
+			_, err = d.uc.SearchNewConcerts(ctx, artistID)
+			assert.NoError(t, err)
+
+			got := receivePublishedConcerts(t, ctx, sub)
+			assert.Equal(t, 1, got, "null last_found_at must not skip; search should publish")
+		})
+	})
+
+	t.Run("stale search and stale discovery proceeds (last_found_at > discoveryWindow)", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := context.Background()
+			d := newConcertTestDeps(t)
+
+			now := time.Now()
+			d.searchLogRepo.EXPECT().GetByArtistID(ctx, artistID).Return(&entity.SearchLog{
+				ArtistID:      artistID,
+				SearchTime:    now,
+				Status:        entity.SearchLogStatusCompleted,
+				LastFoundTime: now,
+			}, nil).Once()
+
+			time.Sleep(15 * 24 * time.Hour) // past both the TTL and the 14d discovery window
+
+			d.searchLogRepo.EXPECT().Upsert(ctx, artistID, entity.SearchLogStatusPending).Return(nil).Once()
+			d.artistRepo.EXPECT().Get(ctx, artistID).Return(artist, nil).Once()
+			d.artistRepo.EXPECT().GetOfficialSite(ctx, artistID).Return(nil, apperr.ErrNotFound).Once()
+			d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(nil, nil).Once()
+			d.searcher.EXPECT().Search(mock.Anything, artist, (*entity.OfficialSite)(nil), mock.AnythingOfType("time.Time")).Return(scraped, nil).Once()
+			d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+			d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
+
+			sub, err := d.publisher.Subscribe(ctx, entity.SubjectConcertDiscovered)
+			assert.NoError(t, err)
+
+			_, err = d.uc.SearchNewConcerts(ctx, artistID)
+			assert.NoError(t, err)
+
+			got := receivePublishedConcerts(t, ctx, sub)
+			assert.Equal(t, 1, got, "discovery beyond the window must not skip")
 		})
 	})
 }
@@ -657,6 +778,10 @@ func TestSearchNewConcerts_Deduplication(t *testing.T) {
 				d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(tt.existing, nil).Once()
 				d.searcher.EXPECT().Search(mock.Anything, artist, (*entity.OfficialSite)(nil), mock.AnythingOfType("time.Time")).Return(tt.scraped, nil).Once()
 				d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+				// A published discovery records last_found_at; no publish → no MarkFound.
+				if tt.wantNewConcerts > 0 {
+					d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
+				}
 
 				_, err = d.uc.SearchNewConcerts(ctx, artistID)
 				assert.NoError(t, err)

--- a/k8s/atlas/base/kustomization.yaml
+++ b/k8s/atlas/base/kustomization.yaml
@@ -69,3 +69,4 @@ configMapGenerator:
   - migrations/20260520120000_change_default_hype_to_nearby.sql
   - migrations/20260521083536_drop_users_preferred_language_default.sql
   - migrations/20260523145447_add_series_hierarchy.sql
+  - migrations/20260601120000_add_last_found_at_to_search_logs.sql

--- a/k8s/atlas/base/migrations/20260601120000_add_last_found_at_to_search_logs.sql
+++ b/k8s/atlas/base/migrations/20260601120000_add_last_found_at_to_search_logs.sql
@@ -1,0 +1,4 @@
+-- Modify "latest_search_logs" table
+ALTER TABLE "latest_search_logs" ADD COLUMN "last_found_at" timestamptz NULL;
+-- Set comment to column: "last_found_at" on table: "latest_search_logs"
+COMMENT ON COLUMN "latest_search_logs"."last_found_at" IS 'Timestamp of the most recent search that discovered at least one new concert; NULL if none ever found';

--- a/k8s/atlas/base/migrations/atlas.sum
+++ b/k8s/atlas/base/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:tPEmmkIex0k+KAmjL5fiZAHHnNRL+yEkQ8CbnbPROYQ=
+h1:nKuk1/LHF/yRjYReB/eorswP4niqRYtwNTNHwalQavg=
 20250726000000_bootstrap_app_schema.sql h1:nKAFSMmbY+9pdhajenyx25jK6t5SAHc5x/JpNt9EgFM=
 20250726081442_initial_schema.sql h1:cWOx1AMHpgE784lJBtFmEj1oXRBkeqv56bKw1XV8ThI=
 20250726101741_add_foreign_key_to_posts.sql h1:Yq6yocwX7/UQHaMneA16MoHzImLamXDe7PvGYiGWudw=
@@ -55,3 +55,4 @@ h1:tPEmmkIex0k+KAmjL5fiZAHHnNRL+yEkQ8CbnbPROYQ=
 20260520120000_change_default_hype_to_nearby.sql h1:Ajn8f4CdBt+GkM2TGDTNI+ad+LrEp+gPamBzBNiF5VQ=
 20260521083536_drop_users_preferred_language_default.sql h1:FMjScRBRZqefpPxyJ8BGYaAZ34D7omn25V1SXBY6gts=
 20260523145447_add_series_hierarchy.sql h1:oEn1OrF2g2ps+Va7HKNvfa14s4OkzTI6CHRZ+klEViA=
+20260601120000_add_last_found_at_to_search_logs.sql h1:gvHcynfuA4CLZYlMX6uBi+hbOpy+TbqOh38LTnmhxR4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -323,6 +323,17 @@ type GCPConfig struct {
 	// https://aistudio.google.com/apikey and apply API restrictions
 	// (Generative Language API only) before 2026-06-19.
 	GeminiSearchAPIKey string `envconfig:"GCP_GEMINI_SEARCH_API_KEY"`
+
+	// Freshness window for the search-log cache. A completed search within
+	// this window suppresses a repeat external call. Empty/zero falls back
+	// to defaultSearchCacheTTL via SearchCacheTTL(); prod sets 72h.
+	GeminiSearchCacheTTL time.Duration `envconfig:"GCP_GEMINI_SEARCH_CACHE_TTL"`
+
+	// Skip window after a successful discovery. If a new concert was found
+	// for an artist within this window, the external search is skipped
+	// (announcements are batch-then-quiet, so re-searching just re-finds the
+	// same events). Empty/zero falls back to defaultSearchDiscoveryWindow.
+	GeminiSearchDiscoveryWindow time.Duration `envconfig:"GCP_GEMINI_SEARCH_DISCOVERY_WINDOW"`
 }
 
 // Default models for each step of the two-step grounded-extract search
@@ -333,6 +344,33 @@ const (
 	defaultSearchModelExtract = "gemini-3.5-flash"
 	defaultSearchModelParse   = "gemini-3.1-flash-lite"
 )
+
+// Defaults for the concert-search skip windows. The freshness TTL bounds how
+// long a completed search is reused; the discovery window bounds how long a
+// fresh discovery suppresses re-searching. Both are env-overridable per
+// environment (prod runs a longer TTL); dev/unset inherit these.
+const (
+	defaultSearchCacheTTL        = 24 * time.Hour
+	defaultSearchDiscoveryWindow = 14 * 24 * time.Hour
+)
+
+// SearchCacheTTL returns the search-log freshness window. Resolution:
+// env override (GCP_GEMINI_SEARCH_CACHE_TTL) → built-in default.
+func (c *GCPConfig) SearchCacheTTL() time.Duration {
+	if c.GeminiSearchCacheTTL > 0 {
+		return c.GeminiSearchCacheTTL
+	}
+	return defaultSearchCacheTTL
+}
+
+// SearchDiscoveryWindow returns the post-discovery skip window. Resolution:
+// env override (GCP_GEMINI_SEARCH_DISCOVERY_WINDOW) → built-in default.
+func (c *GCPConfig) SearchDiscoveryWindow() time.Duration {
+	if c.GeminiSearchDiscoveryWindow > 0 {
+		return c.GeminiSearchDiscoveryWindow
+	}
+	return defaultSearchDiscoveryWindow
+}
 
 // SearchModelExtract returns the model name for Step 1 (grounded extract:
 // GoogleSearch + URLContext, no schema). Resolution: step-specific env
@@ -492,6 +530,14 @@ func (c *GCPConfig) Validate() error {
 	}
 	if !slices.Contains(validThinkingLevels, c.GeminiSearchThinkingParse) {
 		return fmt.Errorf("invalid GCP_GEMINI_SEARCH_THINKING_PARSE: %q (allowed: \"\", minimal, low, medium, high)", c.GeminiSearchThinkingParse)
+	}
+	// A non-parseable duration already fails at envconfig.Process (Load);
+	// here we reject negatives so a stray "-1h" cannot disable the cache.
+	if c.GeminiSearchCacheTTL < 0 {
+		return fmt.Errorf("invalid GCP_GEMINI_SEARCH_CACHE_TTL: %s (must be >= 0)", c.GeminiSearchCacheTTL)
+	}
+	if c.GeminiSearchDiscoveryWindow < 0 {
+		return fmt.Errorf("invalid GCP_GEMINI_SEARCH_DISCOVERY_WINDOW: %s (must be >= 0)", c.GeminiSearchDiscoveryWindow)
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -435,6 +435,53 @@ func TestGCPConfig_ParserModelResolution(t *testing.T) {
 	}
 }
 
+func TestGCPConfig_SearchCacheTTLResolution(t *testing.T) {
+	t.Run("env override takes precedence", func(t *testing.T) {
+		c := GCPConfig{GeminiSearchCacheTTL: 72 * time.Hour}
+		assert.Equal(t, 72*time.Hour, c.SearchCacheTTL())
+	})
+	t.Run("default applied when unset", func(t *testing.T) {
+		c := GCPConfig{}
+		assert.Equal(t, defaultSearchCacheTTL, c.SearchCacheTTL())
+		assert.Equal(t, 24*time.Hour, c.SearchCacheTTL())
+	})
+}
+
+func TestGCPConfig_SearchDiscoveryWindowResolution(t *testing.T) {
+	t.Run("env override takes precedence", func(t *testing.T) {
+		c := GCPConfig{GeminiSearchDiscoveryWindow: 168 * time.Hour}
+		assert.Equal(t, 168*time.Hour, c.SearchDiscoveryWindow())
+	})
+	t.Run("default applied when unset", func(t *testing.T) {
+		c := GCPConfig{}
+		assert.Equal(t, defaultSearchDiscoveryWindow, c.SearchDiscoveryWindow())
+		assert.Equal(t, 14*24*time.Hour, c.SearchDiscoveryWindow())
+	})
+}
+
+func TestGCPConfig_Validate_SearchDurations(t *testing.T) {
+	t.Run("accepts zero (falls back to default)", func(t *testing.T) {
+		c := GCPConfig{}
+		assert.NoError(t, c.Validate())
+	})
+	t.Run("accepts positive durations", func(t *testing.T) {
+		c := GCPConfig{GeminiSearchCacheTTL: 72 * time.Hour, GeminiSearchDiscoveryWindow: 336 * time.Hour}
+		assert.NoError(t, c.Validate())
+	})
+	t.Run("rejects negative TTL", func(t *testing.T) {
+		c := GCPConfig{GeminiSearchCacheTTL: -1 * time.Hour}
+		err := c.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "GCP_GEMINI_SEARCH_CACHE_TTL")
+	})
+	t.Run("rejects negative discovery window", func(t *testing.T) {
+		c := GCPConfig{GeminiSearchDiscoveryWindow: -1 * time.Hour}
+		err := c.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "GCP_GEMINI_SEARCH_DISCOVERY_WINDOW")
+	})
+}
+
 func TestGCPConfig_Validate_ThinkingLevel(t *testing.T) {
 	for _, lvl := range []string{"", "low", "medium", "high"} {
 		t.Run("accepts "+lvl, func(t *testing.T) {


### PR DESCRIPTION
## Why

The `concert-discovery` CronJob calls the Gemini search API once per followed artist on every run, but most calls find nothing new. Japanese tour line-ups are announced as a single batch then stay quiet for weeks, so re-searching an artist soon after a discovery just re-finds the same events and dedups to nothing. With a small user base, notification latency is cheap and Gemini cost is the priority — so we skip more aggressively.

## What changed

- **Configurable freshness TTL** — `GCP_GEMINI_SEARCH_CACHE_TTL` (default 24h), resolved via `GCPConfig.SearchCacheTTL()`. The `searchCacheTTL` constant is removed; the use case takes the TTL via DI. Prod sets **72h** (cloud-provisioning PR).
- **Recent-discovery skip** — skip the external search when a new concert was discovered for the artist within `GCP_GEMINI_SEARCH_DISCOVERY_WINDOW` (default 14d). OR-combined with the existing freshness gate in `SearchNewConcerts`.
- **`last_found_at` tracking** — new nullable column on `latest_search_logs`, written (`MarkFound`) only when `executeSearch` publishes ≥1 post-dedup new concert. NULL = never discovered → never skipped on this basis.
- Atlas migration `20260601120000_add_last_found_at_to_search_logs.sql` (additive nullable column).

## Tests

- config: TTL/window resolution + negative-duration validation.
- entity: `WasRecentlyDiscovered` (null / within / boundary / beyond).
- repository: `MarkFound` sets `last_found_at` without touching `searched_at`; default-null read.
- use case: skip-on-recent-discovery, no-skip-when-null, stale-beyond-window proceeds, discovery recorded only on non-empty new set.
- `make check` green (lint + unit + rdb integration with the migration applied).

## Notes

- Migration was hand-authored + `atlas migrate hash` (the local ephemeral dev-DB can't snapshot the `app` search_path with atlas v1.0.1); it matches `schema.sql` and applied cleanly in `make check`.
- Prod TTL=72h and the prod image pin bump ship in a follow-up cloud-provisioning PR after release.

OpenSpec change: `reduce-gemini-search-cost`.

Refs: #323