### PR TITLE
build: bump Go toolchain to 1.26.4 (GO-2026-5037/5039)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: false
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Download dependencies
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Run govulncheck
@@ -223,7 +223,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Download dependencies

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/liverty-music/backend
 
 go 1.26
 
+// Pin the minimum toolchain to 1.26.4, which fixes the Go stdlib advisories
+// GO-2026-5037 (crypto/x509) and GO-2026-5039 (net/textproto) flagged by
+// govulncheck. Every `go` invocation (local, CI) uses at least this toolchain.
+toolchain go1.26.4
+
 tool (
 	github.com/bufbuild/buf/cmd/buf
 	github.com/go-delve/delve/cmd/dlv


### PR DESCRIPTION
## 🔗 Related Issue

Closes #326

## 📝 Summary of Changes

`govulncheck` (Test workflow) started failing on every backend PR as of 2026-06-03 with two **Go standard library** advisories, reachable from existing code (`http.Server.Serve`, `x509`):

- **GO-2026-5037** — `crypto/x509` — fixed in **go1.26.4**
- **GO-2026-5039** — `net/textproto` — fixed in **go1.26.4**

Published after main's last green run (2026-06-01), so this is a **repo-wide** breakage, not feature-specific. Fix at the source of truth:

- `go.mod`: add `toolchain go1.26.4` — every `go` invocation (local + CI) uses at least the fixed stdlib.
- `lint.yml` / `test.yml`: pin `go-version: "1.26.4"` for deterministic toolchain selection.

Runtime image (`golang:1.26-alpine`) already floats to the latest patch, so no Dockerfile change.

## 📋 Commit Log

- `build: bump Go toolchain to 1.26.4 for GO-2026-5037/5039`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes. <!-- N/A — toolchain bump -->
- [x] I have updated the relevant documentation. <!-- N/A -->
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed. <!-- `make check` green on go1.26.4 -->
- [x] My code follows the architecture and style guidelines of the project.

## 📸 Screenshots or Logs

`go version` reexecs to `go1.26.4` via the toolchain directive; `make check` passes; govulncheck no longer reports GO-2026-5037 / GO-2026-5039 (both fixed in 1.26.4).
