### PR TITLE
refactor(merch-discovery): harden searcher prompt, thinking=high, resolution liveness gate

### DIFF
--- a/internal/di/merch_discovery_job.go
+++ b/internal/di/merch_discovery_job.go
@@ -66,7 +66,7 @@ func InitializeMerchDiscoveryJobApp(ctx context.Context) (*MerchDiscoveryJobApp,
 		APIKey:        cfg.GCP.GeminiSearchAPIKey,
 		Model:         cfg.GCP.MerchModel(),
 		Temperature:   cfg.GCP.GeminiSearchTemperature,
-		ThinkingLevel: cfg.GCP.GeminiSearchThinkingLevel,
+		ThinkingLevel: cfg.GCP.MerchThinking(),
 	}, &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}, logger)
 	if err != nil {
 		return nil, err

--- a/internal/infrastructure/gcp/gemini/grounding_probe_integration_test.go
+++ b/internal/infrastructure/gcp/gemini/grounding_probe_integration_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+package gemini_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	genai "google.golang.org/genai"
+)
+
+// TestGemini_GroundingProbe is a minimal reproduction that isolates whether
+// Google Search grounding actually fires per model. It sends a prompt that
+// CANNOT be answered without a live web search and explicitly asks the model to
+// search, then dumps the grounding metadata. Comparing gemini-3.1-flash-lite vs
+// gemini-3.5-flash on the identical request distinguishes "the model chose not
+// to search (AUTO)" from "this model/SDK never grounds at all".
+//
+// Run (real, billed calls):
+//
+//	GCP_GEMINI_SEARCH_API_KEY=$(esc env get liverty-music/dev pulumiConfig.geminiSearchApiKey --show-secrets --value string) \
+//	MERCH_EVAL=1 go test -tags integration -run TestGemini_GroundingProbe -v ./internal/infrastructure/gcp/gemini/
+func TestGemini_GroundingProbe(t *testing.T) {
+	if os.Getenv(merchEvalEnvVar) != "1" {
+		t.Skipf("disabled; set %s=1 (and -tags integration) to run real Gemini calls", merchEvalEnvVar)
+	}
+	apiKey := os.Getenv(merchAPIKeyEnvVar)
+	if apiKey == "" {
+		t.Fatalf("%s is required", merchAPIKeyEnvVar)
+	}
+
+	ctx := context.Background()
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+		Backend: genai.BackendGeminiAPI,
+		APIKey:  apiKey,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// Requires fresh, post-training-cutoff web data + explicit search instruction.
+	const prompt = "You MUST use Google Search. Find one news headline published in June 2026 and output the headline followed by its source URL. Do not answer from memory."
+
+	for _, model := range []string{"gemini-3.1-flash-lite", "gemini-3.5-flash"} {
+		model := model
+		t.Run(model, func(t *testing.T) {
+			cfg := &genai.GenerateContentConfig{
+				Tools: []*genai.Tool{{GoogleSearch: &genai.GoogleSearch{}}},
+			}
+			reqCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+			defer cancel()
+
+			resp, err := client.Models.GenerateContent(reqCtx, model, genai.Text(prompt), cfg)
+			if err != nil {
+				t.Fatalf("GenerateContent(%s): %v", model, err)
+			}
+
+			var (
+				toolUse  int32
+				finish   string
+				queries  []string
+				chunkURL []string
+			)
+			if u := resp.UsageMetadata; u != nil {
+				toolUse = u.ToolUsePromptTokenCount
+			}
+			if len(resp.Candidates) > 0 {
+				c := resp.Candidates[0]
+				finish = string(c.FinishReason)
+				if g := c.GroundingMetadata; g != nil {
+					queries = g.WebSearchQueries
+					for _, ch := range g.GroundingChunks {
+						if ch != nil && ch.Web != nil {
+							chunkURL = append(chunkURL, ch.Web.URI)
+						}
+					}
+				}
+			}
+
+			t.Logf("model=%s finish=%s tool_use_tokens=%d web_search_queries=%v grounding_chunks=%d urls=%v",
+				model, finish, toolUse, queries, len(chunkURL), chunkURL)
+
+			// Evidence assertion: with a forcing prompt, a grounding-capable model
+			// MUST run at least one web search query. A model that documents
+			// "Search grounding: Supported" yet returns zero queries here is the
+			// reportable discrepancy.
+			if len(queries) == 0 {
+				t.Errorf("model %s ran ZERO web search queries despite a forcing prompt (grounding did not fire)", model)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/gcp/gemini/merch_searcher.go
+++ b/internal/infrastructure/gcp/gemini/merch_searcher.go
@@ -45,19 +45,22 @@ const (
 	// officialness — that judgement lives entirely in the prompt + grounding.
 	merchSystemInstruction = `あなたは音楽ファン向けサービスのための、公式グッズ情報URLを特定するエージェントです。
 
-ゴール: 指定アーティストの指定シリーズ（ツアー/単独公演/フェス）について、グッズ販売情報が最も充実している「単一の」URLを1つだけ返すこと。
+ゴール: 指定のアーティストのツアーで販売されるグッズ情報が掲載された公式ページのURLを返すこと。返すのは1つだけ。
 
 厳守ルール:
-1. 対象は「公式サイト」または「アーティスト公式SNSアカウントの投稿」のみ。非公式サイト・転売・まとめ・ファンサイトは絶対に採用しない。
-2. 公式SNSの投稿（例: X/Twitter のポスト）がグッズ情報を最も多く含む場合、その投稿URLを返してよい。
-3. 公式の確かな情報源が見つからない場合は、推測や当て推量で不確かなURLを返さず、必ず「NONE」とだけ出力する。
-4. 出力は URL 1つ、または「NONE」のみ。説明・前置き・引用・装飾は一切付けない。`
+1. 対象は「公式サイト」または「アーティスト公式SNSアカウントの投稿」のみ。非公式・転売・まとめ・ファンサイトは絶対に採用しない。
+2. 指定ツアーで販売されるグッズ情報が公式から発表されている場合、その販売グッズが「画像付きで」掲載された公式ページのURLを返す。販売グッズの画像が掲載されていることを絶対条件とする。
+3. 可能なら、ツアーのグッズ内容を告知する詳細ページ（例: 公式サイトの news/detail のグッズ告知ページ）を優先する。ただし正確なURLに確証が持てない場合は、確実に実在する公式グッズストアのトップ（例: store.plusmember.jp/<artist>/ のような公式EC）を返してよい。
+4. 架空のカテゴリID・記事IDなどを含む deep link を推測で組み立てて返してはならない。正確なIDに自信が無ければ、IDを含まない上位の安定したURL（公式ストアのトップ等）を返すこと。
+5. 公式SNSの投稿（例: X/Twitter）が販売グッズの画像を含み最も情報量が多い場合は、その投稿URLを返してよい。
+6. 公式の確かなページが見つからない場合は、推測せず必ず「NONE」とだけ出力する。
+7. 出力は URL 1つ、または「NONE」のみ。説明・前置き・引用・装飾は一切付けない。`
 
-	// merchPromptTemplate is filled with artist name and series title.
+	// merchPromptTemplate is filled with artist name and tour title.
 	merchPromptTemplate = `アーティスト名: %s
-シリーズ名: %s
+ツアータイトル: %s
 
-このシリーズの公式グッズ情報URLを1つだけ出力してください。見つからなければ NONE と出力してください。`
+上記アーティスト/ツアーについて、販売グッズが画像付きで掲載された公式ページのURLを1つだけ出力してください。グッズ告知の詳細ページを優先しますが、正確なURLに確証が無ければ公式グッズストアのトップURLで構いません。架空のID付き deep link は出力しないでください。見つからなければ NONE と出力してください。`
 )
 
 // merchURLPattern extracts the first http(s) URL from the model's response,
@@ -110,9 +113,15 @@ func (s *MerchSearcher) SearchMerchURL(ctx context.Context, artistName, seriesTi
 	temperature := s.config.Temperature
 	cfg := &genai.GenerateContentConfig{
 		SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: merchSystemInstruction}}},
-		Tools:             []*genai.Tool{{GoogleSearch: &genai.GoogleSearch{}}},
-		Temperature:       &temperature,
-		MaxOutputTokens:   merchMaxOutputTokens,
+		// GoogleSearch grounds discovery; URLContext lets the model fetch the
+		// candidate pages it finds so it can verify the page actually exists and
+		// shows the for-sale goods with images (instead of guessing a deep link).
+		Tools: []*genai.Tool{
+			{GoogleSearch: &genai.GoogleSearch{}},
+			{URLContext: &genai.URLContext{}},
+		},
+		Temperature:     &temperature,
+		MaxOutputTokens: merchMaxOutputTokens,
 	}
 	if level := thinkingLevelFromConfig(s.config.ThinkingLevel); level != genai.ThinkingLevelUnspecified {
 		cfg.ThinkingConfig = &genai.ThinkingConfig{ThinkingLevel: level}
@@ -120,22 +129,98 @@ func (s *MerchSearcher) SearchMerchURL(ctx context.Context, artistName, seriesTi
 
 	prompt := fmt.Sprintf(merchPromptTemplate, artistName, seriesTitle)
 
-	raw, err := s.generate(ctx, prompt, cfg, attrs)
+	raw, meta, err := s.generate(ctx, prompt, cfg, attrs)
 	if err != nil {
 		return "", err
 	}
 
 	url := parseMerchURL(raw)
+	// Note: existence of the resolved URL is verified downstream by the use
+	// case's HTTP liveness probe (SSRF-hardened). We intentionally do NOT gate
+	// on URLContext metadata here: when GoogleSearch grounding is involved the
+	// fetched-URL metadata reports opaque vertexaisearch redirect wrappers, not
+	// the real destination, so it cannot be matched against the resolved URL.
 	if s.logger != nil {
-		s.logger.Info(ctx, "merch search complete",
-			append(attrs, slog.Bool("found", url != ""))...)
+		// Emit the grounding / URL-context / usage metadata so the resolution is
+		// auditable: which web queries ran, which URLs were grounded, which were
+		// fetched and with what retrieval status, and the token cost.
+		s.logger.Info(ctx, "merch search complete", append(attrs,
+			slog.Bool("found", url != ""),
+			slog.String("resolved_url", url),
+			slog.String("finish_reason", meta.FinishReason),
+			slog.Any("web_search_queries", meta.WebSearchQueries),
+			slog.Any("grounding_urls", meta.GroundingURLs),
+			slog.Any("url_context_fetched", meta.URLContextFetched),
+			slog.Group("usage_tokens",
+				slog.Int("prompt", int(meta.PromptTokens)),
+				slog.Int("candidates", int(meta.CandidatesTokens)),
+				slog.Int("thoughts", int(meta.ThoughtsTokens)),
+				slog.Int("tool_use", int(meta.ToolUseTokens)),
+				slog.Int("total", int(meta.TotalTokens)),
+			),
+		)...)
 	}
 	return url, nil
 }
 
+// merchCallMeta captures the grounding / URL-context / usage metadata of a
+// single GenerateContent response for observability and debugging.
+type merchCallMeta struct {
+	ResponseID        string
+	FinishReason      string
+	PromptTokens      int32
+	CandidatesTokens  int32
+	ThoughtsTokens    int32
+	ToolUseTokens     int32
+	TotalTokens       int32
+	WebSearchQueries  []string
+	GroundingURLs     []string
+	URLContextFetched []string // "url (status)" pairs, for logging/audit
+}
+
+// extractMerchMeta pulls the auditable metadata off a GenerateContent response.
+func extractMerchMeta(resp *genai.GenerateContentResponse) merchCallMeta {
+	var m merchCallMeta
+	if resp == nil {
+		return m
+	}
+	m.ResponseID = resp.ResponseID
+	if u := resp.UsageMetadata; u != nil {
+		m.PromptTokens = u.PromptTokenCount
+		m.CandidatesTokens = u.CandidatesTokenCount
+		m.ThoughtsTokens = u.ThoughtsTokenCount
+		m.ToolUseTokens = u.ToolUsePromptTokenCount
+		m.TotalTokens = u.TotalTokenCount
+	}
+	if len(resp.Candidates) == 0 {
+		return m
+	}
+	c := resp.Candidates[0]
+	m.FinishReason = string(c.FinishReason)
+	if g := c.GroundingMetadata; g != nil {
+		m.WebSearchQueries = g.WebSearchQueries
+		for _, ch := range g.GroundingChunks {
+			if ch != nil && ch.Web != nil && ch.Web.URI != "" {
+				m.GroundingURLs = append(m.GroundingURLs, ch.Web.URI)
+			}
+		}
+	}
+	if c.URLContextMetadata != nil {
+		for _, um := range c.URLContextMetadata.URLMetadata {
+			if um == nil {
+				continue
+			}
+			m.URLContextFetched = append(m.URLContextFetched, um.RetrievedURL+" ("+string(um.URLRetrievalStatus)+")")
+		}
+	}
+	return m
+}
+
 // generate runs a single grounded GenerateContent call with bounded retries on
-// transient errors, returning the concatenated text of the first candidate.
-func (s *MerchSearcher) generate(ctx context.Context, prompt string, cfg *genai.GenerateContentConfig, attrs []slog.Attr) (string, error) {
+// transient errors, returning the concatenated text of the first candidate plus
+// the response metadata of the final attempt.
+func (s *MerchSearcher) generate(ctx context.Context, prompt string, cfg *genai.GenerateContentConfig, attrs []slog.Attr) (string, merchCallMeta, error) {
+	var meta merchCallMeta
 	bo := &backoff.ExponentialBackOff{
 		InitialInterval:     time.Second,
 		RandomizationFactor: 0.5,
@@ -143,7 +228,7 @@ func (s *MerchSearcher) generate(ctx context.Context, prompt string, cfg *genai.
 		MaxInterval:         30 * time.Second,
 	}
 
-	return backoff.Retry(ctx, func() (string, error) {
+	raw, err := backoff.Retry(ctx, func() (string, error) {
 		// Detach from the parent cancel only for the timeout dimension: a real
 		// SIGTERM/parent cancel still stops the retry loop between attempts,
 		// but a single in-flight call gets a bounded deadline of its own.
@@ -157,6 +242,8 @@ func (s *MerchSearcher) generate(ctx context.Context, prompt string, cfg *genai.
 			}
 			return "", err
 		}
+		// Capture metadata from every attempt; the final (successful) attempt wins.
+		meta = extractMerchMeta(resp)
 		if len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil {
 			// No candidate / filtered response → treat as "no source found".
 			return "", nil
@@ -171,6 +258,7 @@ func (s *MerchSearcher) generate(ctx context.Context, prompt string, cfg *genai.
 		}
 		return b.String(), nil
 	}, backoff.WithBackOff(bo), backoff.WithMaxTries(3))
+	return raw, meta, err
 }
 
 // parseMerchURL extracts the resolved URL from the model's raw text. It returns

--- a/internal/infrastructure/gcp/gemini/merch_searcher_integration_test.go
+++ b/internal/infrastructure/gcp/gemini/merch_searcher_integration_test.go
@@ -1,0 +1,289 @@
+//go:build integration
+
+package gemini_test
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/liverty-music/backend/internal/infrastructure/gcp/gemini"
+	"github.com/pannpers/go-logging/logging"
+)
+
+// isAcceptedURL reports whether got exactly matches one of the accepted
+// ground-truth URLs, tolerating only a single trailing slash difference. This
+// is deliberately strict: a fabricated or dead deep link that merely shares a
+// host with an accepted page does NOT match.
+func isAcceptedURL(got string, accepted []string) bool {
+	norm := func(s string) string { return strings.TrimRight(strings.TrimSpace(s), "/") }
+	g := norm(got)
+	for _, a := range accepted {
+		if g == norm(a) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOfficialURL matches a resolved URL against host-level ground truth after
+// stripping a leading "www.".
+//
+//   - An entry WITHOUT a slash matches the host OR any subdomain of it: the
+//     entry is treated as the official apex domain, so "yorushika.com" matches
+//     "store.yorushika.com" (the official store lives on a subdomain) but NOT
+//     "evil-yorushika.com" (subdomain match requires a "." boundary).
+//   - An entry WITH a slash matches host+path prefix, used to pin a specific
+//     official social / shared-EC account (e.g. "x.com/super_beaver" or
+//     "store.plusmember.jp/vaundy") where the host alone is shared
+//     infrastructure and the path proves ownership.
+func isOfficialURL(rawURL string, allow []string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.TrimPrefix(strings.ToLower(u.Host), "www.")
+	hostPath := host + u.EscapedPath()
+	for _, entry := range allow {
+		e := strings.ToLower(strings.TrimPrefix(entry, "www."))
+		if strings.Contains(e, "/") {
+			if strings.HasPrefix(hostPath, e) {
+				return true
+			}
+		} else if host == e || strings.HasSuffix(host, "."+e) {
+			return true
+		}
+	}
+	return false
+}
+
+// Live smoke for the merch-url searcher — mirrors the concert searcher's
+// build-tagged, env-gated harness. It makes REAL (billed) Gemini API calls, so
+// it never runs in the normal `make check` path: it requires both the
+// `integration` build tag AND MERCH_EVAL=1.
+//
+// Run:
+//
+//	GCP_GEMINI_SEARCH_API_KEY=$(esc env get liverty-music/dev pulumiConfig.geminiSearchApiKey --show-secrets --value string) \
+//	MERCH_EVAL=1 \
+//	go test -tags integration -run TestMerchSearcher_LiveSmoke -v ./internal/infrastructure/gcp/gemini/
+//
+// Optional overrides:
+//   - GCP_GEMINI_MERCH_MODEL  : model name (default: Flash-Lite via MerchConfig)
+//   - MERCH_EVAL_ARTIST       : single ad-hoc artist name (pairs with MERCH_EVAL_SERIES)
+//   - MERCH_EVAL_SERIES       : single ad-hoc series title
+const (
+	merchEvalEnvVar     = "MERCH_EVAL"
+	merchAPIKeyEnvVar   = "GCP_GEMINI_SEARCH_API_KEY"
+	merchModelEnvVar    = "GCP_GEMINI_MERCH_MODEL"
+	merchArtistEnvVar   = "MERCH_EVAL_ARTIST"
+	merchSeriesEnvVar   = "MERCH_EVAL_SERIES"
+	merchArtistsEnvVar  = "MERCH_EVAL_ARTISTS"  // CSV; intersect default cases by artist name
+	merchThinkingEnvVar = "MERCH_EVAL_THINKING" // "", minimal, low, medium, high (default low)
+)
+
+type merchCase struct {
+	artist string
+	series string
+	// expectFound is advisory only: the assertion never fails on found/not-found
+	// (merch availability is time-dependent and not deterministic). It is logged
+	// next to the result so a human can eyeball whether resolution matched
+	// expectation for this run.
+	expectFound bool
+	// acceptedURLs, when set, is the EXACT ground-truth allowlist: a non-empty
+	// result must equal (modulo a trailing slash) one of these real, live pages.
+	// This is stricter than officialHosts and is what rejects a plausible-but-
+	// non-existent deep link (e.g. a fabricated category_id) that merely sits on
+	// an official host.
+	acceptedURLs []string
+	// officialHosts is the looser host-level ground truth, used only when
+	// acceptedURLs is empty: a non-empty result must sit on one of these official
+	// hosts (or a subdomain). Catches non-official/hallucinated hosts.
+	officialHosts []string
+}
+
+func TestMerchSearcher_LiveSmoke(t *testing.T) {
+	if os.Getenv(merchEvalEnvVar) != "1" {
+		t.Skipf("live smoke disabled; set %s=1 (and -tags integration) to run real Gemini calls", merchEvalEnvVar)
+	}
+	apiKey := os.Getenv(merchAPIKeyEnvVar)
+	if apiKey == "" {
+		t.Fatalf("%s is required for the live smoke", merchAPIKeyEnvVar)
+	}
+
+	logger, err := logging.New()
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+
+	model := os.Getenv(merchModelEnvVar)
+	if model == "" {
+		model = "gemini-3.1-flash-lite" // mirrors config.defaultMerchModel
+	}
+	thinking := os.Getenv(merchThinkingEnvVar) // "", minimal, low, medium, high
+	if thinking == "" {
+		thinking = "low"
+	}
+
+	searcher, err := gemini.NewMerchSearcher(context.Background(), gemini.MerchConfig{
+		APIKey:        apiKey,
+		Model:         model,
+		Temperature:   1.0,
+		ThinkingLevel: thinking,
+	}, nil, logger)
+	if err != nil {
+		t.Fatalf("NewMerchSearcher: %v", err)
+	}
+
+	cases := defaultMerchCases()
+	if a, s := os.Getenv(merchArtistEnvVar), os.Getenv(merchSeriesEnvVar); a != "" && s != "" {
+		cases = []merchCase{{artist: a, series: s}}
+	} else if filter := strings.TrimSpace(os.Getenv(merchArtistsEnvVar)); filter != "" {
+		// Intersect the default cases by artist name (CSV), preserving each
+		// case's confirmed officialHosts ground truth.
+		want := map[string]bool{}
+		for _, name := range strings.Split(filter, ",") {
+			want[strings.TrimSpace(name)] = true
+		}
+		var filtered []merchCase
+		for _, c := range cases {
+			if want[c.artist] {
+				filtered = append(filtered, c)
+			}
+		}
+		cases = filtered
+	}
+
+	t.Logf("model=%s | cases=%d", model, len(cases))
+	for _, c := range cases {
+		c := c
+		t.Run(c.artist+" / "+c.series, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+			defer cancel()
+
+			got, err := searcher.SearchMerchURL(ctx, c.artist, c.series)
+			if err != nil {
+				// A transport/API failure is a real smoke failure (auth, model
+				// name, quota, grounding tool availability).
+				t.Fatalf("SearchMerchURL error: %v", err)
+			}
+
+			t.Logf("artist=%q series=%q expectFound=%v -> result=%q", c.artist, c.series, c.expectFound, got)
+
+			if got == "" {
+				// Empty is always a contract-valid outcome (no confident official
+				// source). For an expect-found case it is a soft signal worth a
+				// human look, but not a hard failure (merch pages are
+				// time-dependent and grounding is non-deterministic).
+				if c.expectFound {
+					t.Logf("⚠ expected an official URL for a real current tour but got empty — review searcher recall")
+				}
+				return
+			}
+			// Hard contract: a non-empty value MUST be a valid absolute http(s)
+			// URL (same rule validMerchURL enforces before persistence). Catches
+			// prose, a bare domain, or a NONE-with-trailing-text the parser missed.
+			u, perr := url.ParseRequestURI(got)
+			if perr != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+				t.Errorf("resolved value is not a valid http(s) URL: %q (%v)", got, perr)
+				return
+			}
+			if strings.EqualFold(strings.TrimSpace(got), "NONE") {
+				t.Errorf("parser leaked the NONE sentinel as a URL: %q", got)
+			}
+			// Hard ground-truth assertion. Prefer the EXACT accepted-URL set
+			// when defined: only the real, live merch pages count — a
+			// plausible-but-non-existent deep link on an official host (e.g. a
+			// fabricated category_id) is a failure, not a pass. Fall back to the
+			// host-level check when no exact set is pinned.
+			switch {
+			case len(c.acceptedURLs) > 0:
+				if !isAcceptedURL(got, c.acceptedURLs) {
+					t.Errorf("resolved URL is not one of the accepted real pages: %q (accepted: %v)", got, c.acceptedURLs)
+				}
+			case len(c.officialHosts) > 0:
+				if !isOfficialURL(got, c.officialHosts) {
+					t.Errorf("resolved URL is NOT a confirmed-official destination: %q (allowed: %v)", got, c.officialHosts)
+				}
+			}
+		})
+	}
+}
+
+// defaultMerchCases pairs real artists with their REAL 2026 tours (verified via
+// web research on 2026-06-03) and the confirmed official-host ground truth. The
+// final case is a negative control: a deliberately non-existent series for
+// which no confident official source should exist (expect empty).
+//
+// officialHosts ground truth (researched 2026-06-03):
+//   - store.plusmember.jp is the shared official EC platform; the per-artist
+//     path (/uverworld, /vaundy) proves ownership.
+//   - official-goods-store.jp is SUPER BEAVER's official tour-goods store.
+func defaultMerchCases() []merchCase {
+	return []merchCase{
+		{
+			// Strongest positive control: the official goods detail page for this
+			// tour is already PUBLISHED pre-tour, and the official EC lists the
+			// "一人称" collection. The searcher should resolve to exactly one of
+			// the two real, live pages below — and, per the priority rule, should
+			// prefer the goods-announcement detail page over the EC store root.
+			artist:      "ヨルシカ",
+			series:      "ヨルシカ LIVE TOUR 2026「一人称」",
+			expectFound: true,
+			acceptedURLs: []string{
+				"https://yorushika.com/news/detail/11751",
+				"https://store.plusmember.jp/yorushika/",
+			},
+		},
+		{
+			artist:      "UVERworld",
+			series:      "UVERworld ZERO LAG TOUR",
+			expectFound: true,
+			officialHosts: []string{
+				"uverworld.com", "uverworld.jp",
+				"store.plusmember.jp/uverworld",
+				"x.com/UVERworld_dR2", "twitter.com/UVERworld_dR2",
+				"x.com/Info_UVERworld", "twitter.com/Info_UVERworld",
+				"instagram.com/uverworld_official",
+			},
+		},
+		{
+			artist:      "Vaundy",
+			series:      `Vaundy DOME TOUR 2026 "SILENCE"`,
+			expectFound: true,
+			officialHosts: []string{
+				"vaundy.jp", "member.vaundy.jp",
+				"store.plusmember.jp/vaundy",
+			},
+		},
+		{
+			artist:      "SUPER BEAVER",
+			series:      "都会のラクダ DOME TOUR 2026",
+			expectFound: true,
+			officialHosts: []string{
+				"super-beaver.com", "sp.super-beaver.com",
+				"official-goods-store.jp/super-beaver",
+				"superbeaver.thebase.in",
+				"x.com/super_beaver", "twitter.com/super_beaver",
+			},
+		},
+		{
+			// Negative control: a series that does not exist. The official-only
+			// + empty-if-uncertain rules should ideally yield no URL; if the
+			// model instead falls back to the artist's official site that is
+			// tolerable, but a non-official host is still a hard failure.
+			artist:      "SUPER BEAVER",
+			series:      "都会のラクダ PHANTOM TOUR 2099",
+			expectFound: false,
+			officialHosts: []string{
+				"super-beaver.com", "sp.super-beaver.com",
+				"official-goods-store.jp/super-beaver",
+				"superbeaver.thebase.in",
+				"x.com/super_beaver", "twitter.com/super_beaver",
+			},
+		},
+	}
+}

--- a/internal/usecase/merch_uc.go
+++ b/internal/usecase/merch_uc.go
@@ -120,6 +120,15 @@ func (uc *merchDiscoveryUseCase) ResolveMerchURL(ctx context.Context, candidate 
 			append(attrs, slog.String("resolved_url", resolved))...)
 		return MerchOutcomeInvalidDiscarded, nil
 	}
+	// Independent existence gate: probe the resolved URL ourselves (SSRF-hardened
+	// liveness checker) so a definitively dead link is never persisted, even if
+	// the searcher's own URLContext verification was bypassed. Defense-in-depth
+	// against a plausible-but-non-existent page (e.g. a fabricated deep link).
+	if uc.checker.IsDeadLink(ctx, resolved) {
+		uc.logger.Warn(ctx, "resolved merch url failed liveness check; discarding",
+			append(attrs, slog.String("resolved_url", resolved))...)
+		return MerchOutcomeInvalidDiscarded, nil
+	}
 
 	if err := uc.seriesRepo.SetMerchURL(ctx, candidate.SeriesID, resolved); err != nil {
 		return "", err

--- a/internal/usecase/merch_uc_test.go
+++ b/internal/usecase/merch_uc_test.go
@@ -80,6 +80,7 @@ func TestMerchDiscoveryUseCase_ResolveMerchURL(t *testing.T) {
 			merchURL: "",
 			setup: func(d *merchTestDeps) {
 				d.searcher.EXPECT().SearchMerchURL(mock.Anything, "Test Artist", "Summer Tour 2026").Return(officialURL, nil)
+				d.checker.EXPECT().IsDeadLink(mock.Anything, officialURL).Return(false)
 				d.seriesRepo.EXPECT().SetMerchURL(mock.Anything, mock.Anything, officialURL).Return(nil)
 			},
 			wantOutcome: usecase.MerchOutcomeFilled,
@@ -89,9 +90,20 @@ func TestMerchDiscoveryUseCase_ResolveMerchURL(t *testing.T) {
 			merchURL: "",
 			setup: func(d *merchTestDeps) {
 				d.searcher.EXPECT().SearchMerchURL(mock.Anything, mock.Anything, mock.Anything).Return(socialURL, nil)
+				d.checker.EXPECT().IsDeadLink(mock.Anything, socialURL).Return(false)
 				d.seriesRepo.EXPECT().SetMerchURL(mock.Anything, mock.Anything, socialURL).Return(nil)
 			},
 			wantOutcome: usecase.MerchOutcomeFilled,
+		},
+		{
+			name:     "empty field, resolved url is dead, discarded",
+			merchURL: "",
+			setup: func(d *merchTestDeps) {
+				d.searcher.EXPECT().SearchMerchURL(mock.Anything, mock.Anything, mock.Anything).Return(officialURL, nil)
+				d.checker.EXPECT().IsDeadLink(mock.Anything, officialURL).Return(true)
+				// no SetMerchURL expected
+			},
+			wantOutcome: usecase.MerchOutcomeInvalidDiscarded,
 		},
 		{
 			name:     "empty field, no confident source",
@@ -127,6 +139,7 @@ func TestMerchDiscoveryUseCase_ResolveMerchURL(t *testing.T) {
 				d.checker.EXPECT().IsDeadLink(mock.Anything, deadURL).Return(true)
 				d.seriesRepo.EXPECT().ClearMerchURL(mock.Anything, mock.Anything).Return(nil)
 				d.searcher.EXPECT().SearchMerchURL(mock.Anything, mock.Anything, mock.Anything).Return(officialURL, nil)
+				d.checker.EXPECT().IsDeadLink(mock.Anything, officialURL).Return(false)
 				d.seriesRepo.EXPECT().SetMerchURL(mock.Anything, mock.Anything, officialURL).Return(nil)
 			},
 			wantOutcome: usecase.MerchOutcomeFilled,
@@ -163,6 +176,7 @@ func TestMerchDiscoveryUseCase_ResolveMerchURL(t *testing.T) {
 			merchURL: "",
 			setup: func(d *merchTestDeps) {
 				d.searcher.EXPECT().SearchMerchURL(mock.Anything, mock.Anything, mock.Anything).Return(officialURL, nil)
+				d.checker.EXPECT().IsDeadLink(mock.Anything, officialURL).Return(false)
 				d.seriesRepo.EXPECT().SetMerchURL(mock.Anything, mock.Anything, officialURL).Return(errors.New("db down"))
 			},
 			wantErr: true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -347,6 +347,13 @@ type GCPConfig struct {
 	// so this is far shorter than the concert-discovery horizon. Empty/zero
 	// falls back to defaultMerchDiscoveryWindow (60 days).
 	MerchDiscoveryWindow time.Duration `envconfig:"GCP_MERCH_DISCOVERY_WINDOW"`
+
+	// Thinking level for the merch-url search. Empty falls back to
+	// defaultMerchThinkingLevel ("high"). Live A/B showed Flash-Lite only obeys
+	// the "never fabricate an ID-bearing deep link; fall back to the stable
+	// store-top URL" rule at "high"; "low"/"medium" hallucinate a category_id.
+	// Accepted: "", minimal, low, medium, high.
+	GeminiMerchThinkingLevel string `envconfig:"GCP_GEMINI_MERCH_THINKING_LEVEL"`
 }
 
 // Default models for each step of the two-step grounded-extract search
@@ -373,6 +380,10 @@ const (
 const (
 	defaultMerchModel           = "gemini-3.1-flash-lite"
 	defaultMerchDiscoveryWindow = 60 * 24 * time.Hour
+	// defaultMerchThinkingLevel is "high": only at "high" does Flash-Lite
+	// reliably return the stable ID-free official store URL instead of a
+	// fabricated category_id deep link (verified 5/5 in live A/B).
+	defaultMerchThinkingLevel = "high"
 )
 
 // MerchModel returns the model name for the merch-url discovery search.
@@ -391,6 +402,15 @@ func (c *GCPConfig) MerchWindow() time.Duration {
 		return c.MerchDiscoveryWindow
 	}
 	return defaultMerchDiscoveryWindow
+}
+
+// MerchThinking returns the thinking level for the merch-url search.
+// Resolution: env override (GCP_GEMINI_MERCH_THINKING_LEVEL) → built-in default ("high").
+func (c *GCPConfig) MerchThinking() string {
+	if c.GeminiMerchThinkingLevel != "" {
+		return c.GeminiMerchThinkingLevel
+	}
+	return defaultMerchThinkingLevel
 }
 
 // SearchCacheTTL returns the search-log freshness window. Resolution:
@@ -569,6 +589,9 @@ func (c *GCPConfig) Validate() error {
 	}
 	if !slices.Contains(validThinkingLevels, c.GeminiSearchThinkingParse) {
 		return fmt.Errorf("invalid GCP_GEMINI_SEARCH_THINKING_PARSE: %q (allowed: \"\", minimal, low, medium, high)", c.GeminiSearchThinkingParse)
+	}
+	if !slices.Contains(validThinkingLevels, c.GeminiMerchThinkingLevel) {
+		return fmt.Errorf("invalid GCP_GEMINI_MERCH_THINKING_LEVEL: %q (allowed: \"\", minimal, low, medium, high)", c.GeminiMerchThinkingLevel)
 	}
 	// A non-parseable duration already fails at envconfig.Process (Load);
 	// here we reject negatives so a stray "-1h" cannot disable the cache.


### PR DESCRIPTION
## 🔗 Related Issue

Refs #569

<!-- Follow-up hardening on top of the shipped v1.5.0 merch-discovery job. -->

## 📝 Summary of Changes

Live runs of the merch-url searcher (shipped in v1.5.0) surfaced two problems:

1. With GoogleSearch in AUTO mode, **Flash-Lite frequently answered from memory and fabricated a deep-link ID** — a different store `category_id` / news article id on every run (3830 → 3619 → 3401 …), i.e. plausible-but-non-existent URLs.
2. There was **no resolution-time existence check** before persisting.

This hardens the searcher so it never persists a fabricated or dead URL, and adds the observability needed to reason about grounding.

**Changes**
- **Prompt**: require an official, image-bearing goods page; *softly* prefer the goods-announcement detail page, but when unsure of the exact URL fall back to the stable **ID-free official store top**; explicitly **forbid fabricating an ID-bearing deep link**.
- **Thinking level**: default the merch search to **`high`** (new `GCP_GEMINI_MERCH_THINKING_LEVEL`, default `high`). Live A/B: Flash-Lite only obeys the no-fabrication / stable-URL rule at `high` (5/5 returned the clean store top); `low`/`medium` fabricated a `category_id`.
- **Resolution liveness gate**: probe the resolved URL with the SSRF-hardened liveness checker *before* persisting → a definitively dead/fabricated link is discarded (defense-in-depth, model-independent).
- **Observability**: capture + log grounding / URLContext / usage metadata (web-search queries, grounded URLs, fetched URLs + retrieval status, token counts). Note: URLContext metadata can't be used as a content gate because GoogleSearch grounding reports opaque `vertexaisearch` redirect wrappers, not the real destination URL.
- **Test harness**: gated live-smoke + grounding-probe (`//go:build integration` + `MERCH_EVAL=1`; never run in `make check`).

No schema/API change; behavior-only. Model stays `gemini-3.1-flash-lite` (cost).

## 📋 Commit Log

- `refactor(merch-discovery): harden searcher prompt, thinking=high, add resolution liveness gate`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [x] I have updated the relevant documentation. <!-- N/A -->
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed (make check green with docker).
- [x] My code follows the architecture and style guidelines of the project.

## 📸 Screenshots or Logs

Live smoke (Yorushika, `gemini-3.1-flash-lite`, thinking=high), 5/5:
```
resolved_url=https://store.plusmember.jp/yorushika/   (clean, ID-free official store top)
```
`low`/`medium` instead returned a fabricated `…/products/list.php?category_id=<varies>`, which the resolution liveness gate rejects.
