### PR TITLE
fix(messaging): add SALES_PHASE JetStream stream (consumer crash-loop)

### DIFF
--- a/internal/infrastructure/messaging/streams.go
+++ b/internal/infrastructure/messaging/streams.go
@@ -94,6 +94,20 @@ var streams = []nats.StreamConfig{
 		Duplicates: 2 * time.Minute,
 	},
 	{
+		Name: "SALES_PHASE",
+		// `>` (not `*`) because this domain has nested subjects:
+		// SALES_PHASE.discovered (one token) AND SALES_PHASE.reminder.due
+		// (two tokens). A single-token `SALES_PHASE.*` would not match the
+		// latter, so a subscriber would fail with "no stream matches subject".
+		Subjects:   []string{"SALES_PHASE.>"},
+		Retention:  nats.LimitsPolicy,
+		MaxAge:     7 * 24 * time.Hour,
+		Storage:    nats.FileStorage,
+		Discard:    nats.DiscardOld,
+		Replicas:   1,
+		Duplicates: 2 * time.Minute,
+	},
+	{
 		Name:       "POISON",
 		Subjects:   []string{"POISON.*"},
 		Retention:  nats.LimitsPolicy,


### PR DESCRIPTION
## Summary

**Prod incident fix.** The `consumer-app` is in `CrashLoopBackOff` in prod: it fails on startup with

```
cannot subscribe topic SALES_PHASE.discovered: cannot subscribe: nats: no stream matches subject
```

The sales-phase-timeline feature (shipped in v1.6.0) added consumer handlers for `SALES_PHASE.discovered` / `SALES_PHASE.reminder.due` and publishers in the discovery/reminder jobs, but **no JetStream stream captured those subjects** — `messaging/streams.go` listed only `CONCERT.* / VENUE.* / ARTIST.* / USER.* / NOTIFICATION.* / ENTRY.* / POISON.*`. `EnsureStreams` therefore never created a SALES_PHASE stream, and the v1.6.x consumer crash-loops, taking down **every** consumer handler (including `create-concerts` for `CONCERT.discovered`).

## Fix

Add a `SALES_PHASE` stream to `streams.go` with subjects `SALES_PHASE.>` — `>` (not `*`) because the domain has a nested subject (`SALES_PHASE.reminder.due`) that a single-token wildcard would miss. The consumer (and jobs/server) call `EnsureStreams` on startup, so deploying this **creates the stream and recovers the consumer**.

## Testing

- `make check` green.
- On release → rollout, `consumer-app`'s `EnsureStreams` creates the `SALES_PHASE` stream before subscribing; the crash-loop clears. Verified locally that `SALES_PHASE.>` matches both `SALES_PHASE.discovered` and `SALES_PHASE.reminder.due`.

Refs: #571
