### PR TITLE
refactor(server): serve admin RPCs from a dedicated Connect server

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -65,10 +65,18 @@ func run() error {
 	// separate goroutines. The webhook listener runs on a distinct port
 	// (default 9090) that is only exposed by the internal-only
 	// `server-webhook-svc` Service — not by the public Gateway.
-	errChan := make(chan error, 2)
+	errChan := make(chan error, 3)
 
 	go func() {
 		if err := app.Server.Start(); err != nil {
+			errChan <- err
+		}
+	}()
+
+	// Admin Connect server — second listener in this binary on its own port,
+	// exposed only via the internal admin Service / `api.admin.{env}` route.
+	go func() {
+		if err := app.AdminServer.Start(); err != nil {
 			errChan <- err
 		}
 	}()

--- a/internal/adapter/rpc/concert_moderation_handler.go
+++ b/internal/adapter/rpc/concert_moderation_handler.go
@@ -16,7 +16,10 @@ import (
 var _ adminv1connect.ConcertModerationServiceHandler = (*ConcertModerationHandler)(nil)
 
 // ConcertModerationHandler implements the ConcertModerationService Connect interface.
-// All methods require the caller to hold the "admin" Zitadel project role.
+//
+// Admin authorization is enforced at the admin server boundary by its server-wide
+// RequireRoleInterceptor (admin role), not by per-method checks here; the handler
+// is pure proto<->entity mapping. See internal/infrastructure/auth/authz.go.
 type ConcertModerationHandler struct {
 	concertApprovalUseCase usecase.ConcertApprovalUseCase
 	logger                 *logging.Logger
@@ -39,10 +42,6 @@ func (h *ConcertModerationHandler) ListPendingConcerts(
 	ctx context.Context,
 	_ *connect.Request[adminv1.ListPendingConcertsRequest],
 ) (*connect.Response[adminv1.ListPendingConcertsResponse], error) {
-	if err := auth.RequireRole(ctx, "admin"); err != nil {
-		return nil, err
-	}
-
 	reviews, err := h.concertApprovalUseCase.ListPending(ctx)
 	if err != nil {
 		return nil, err
@@ -65,10 +64,6 @@ func (h *ConcertModerationHandler) ApproveConcert(
 	ctx context.Context,
 	req *connect.Request[adminv1.ApproveConcertRequest],
 ) (*connect.Response[adminv1.ApproveConcertResponse], error) {
-	if err := auth.RequireRole(ctx, "admin"); err != nil {
-		return nil, err
-	}
-
 	stagedID := req.Msg.GetStagedId().GetValue()
 	if err := h.concertApprovalUseCase.Approve(ctx, stagedID); err != nil {
 		return nil, err
@@ -83,10 +78,6 @@ func (h *ConcertModerationHandler) RejectConcert(
 	ctx context.Context,
 	req *connect.Request[adminv1.RejectConcertRequest],
 ) (*connect.Response[adminv1.RejectConcertResponse], error) {
-	if err := auth.RequireRole(ctx, "admin"); err != nil {
-		return nil, err
-	}
-
 	claims, ok := auth.GetClaims(ctx)
 	reviewerSub := ""
 	if ok && claims != nil {

--- a/internal/adapter/rpc/concert_moderation_handler_test.go
+++ b/internal/adapter/rpc/concert_moderation_handler_test.go
@@ -27,13 +27,9 @@ func adminCtx() context.Context {
 	})
 }
 
-// noRoleCtx returns a context with claims but no admin role.
-func noRoleCtx() context.Context {
-	return auth.WithClaims(context.Background(), &auth.Claims{
-		Sub:   "regular-sub-456",
-		Roles: []string{"viewer"},
-	})
-}
+// Admin-role enforcement lives in the admin server's boundary
+// RequireRoleInterceptor (see internal/infrastructure/auth/authz_test.go), not in
+// these handler methods, so these tests exercise only proto<->entity mapping.
 
 func newModerationHandler(
 	t *testing.T,
@@ -145,15 +141,6 @@ func TestConcertModerationHandler_ListPendingConcerts(t *testing.T) {
 				assert.Nil(t, pc.GetSourceUrl())
 			},
 		},
-		{
-			name: "deny caller without admin role",
-			args: args{ctx: noRoleCtx()},
-			dep: dep{
-				approvalUC: func(_ *usecasemocks.MockConcertApprovalUseCase) {},
-			},
-			wantErr:  true,
-			wantCode: connect.CodePermissionDenied,
-		},
 	}
 
 	for _, tt := range tests {
@@ -208,15 +195,6 @@ func TestConcertModerationHandler_ApproveConcert(t *testing.T) {
 					m.EXPECT().Approve(mock.Anything, "staged-abc").Return(nil).Once()
 				},
 			},
-		},
-		{
-			name: "deny caller without admin role",
-			args: args{ctx: noRoleCtx(), stagedID: "staged-abc"},
-			dep: dep{
-				approvalUC: func(_ *usecasemocks.MockConcertApprovalUseCase) {},
-			},
-			wantErr:  true,
-			wantCode: connect.CodePermissionDenied,
 		},
 	}
 
@@ -276,15 +254,6 @@ func TestConcertModerationHandler_RejectConcert(t *testing.T) {
 					m.EXPECT().Reject(mock.Anything, "staged-xyz", "wrong date", "admin-sub-123").Return(nil).Once()
 				},
 			},
-		},
-		{
-			name: "deny caller without admin role",
-			args: args{ctx: noRoleCtx(), stagedID: "staged-xyz", reason: "wrong date"},
-			dep: dep{
-				approvalUC: func(_ *usecasemocks.MockConcertApprovalUseCase) {},
-			},
-			wantErr:  true,
-			wantCode: connect.CodePermissionDenied,
 		},
 	}
 

--- a/internal/di/app.go
+++ b/internal/di/app.go
@@ -13,6 +13,10 @@ import (
 // holds only the references needed by cmd/ entry points.
 type App struct {
 	Server *server.ConnectServer
+	// AdminServer is a second Connect listener in the same binary serving only
+	// admin-scoped RPCs on its own port and ingress host, with boundary-level
+	// admin-role authorization. See `internal/infrastructure/server/connect.go`.
+	AdminServer *server.ConnectServer
 	// WebhookServer handles Zitadel Actions v2 callbacks
 	// (/pre-access-token) on a separate internal-only port. See
 	// `internal/infrastructure/server/webhook.go` for the port-isolation

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -252,14 +252,21 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		return grpchealth.NewHandler(healthChecker, opts...)
 	}
 
-	// RPC handlers (protected by authn middleware)
-	handlers := []server.RPCHandlerFunc{
+	// Admin RPC handlers — served ONLY by the dedicated admin server, whose
+	// server-wide RequireRoleInterceptor gates every procedure on the "admin"
+	// role. The consumer server below does NOT register these, so the admin
+	// surface cannot be reached via the consumer host.
+	adminHandlers := []server.RPCHandlerFunc{
 		func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return adminconnect.NewConcertModerationServiceHandler(
 				rpc.NewConcertModerationHandler(concertApprovalUC, logger),
 				opts...,
 			)
 		},
+	}
+
+	// Consumer RPC handlers (protected by authn middleware)
+	handlers := []server.RPCHandlerFunc{
 		func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return userconnect.NewUserServiceHandler(
 				rpc.NewUserHandler(userUC, emailVerifier, logger),
@@ -355,7 +362,20 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		AnonBurst: cfg.Server.RateLimit.AnonBurst,
 	}, time.Minute)
 
-	srv := server.NewConnectServer(cfg.Server, logger, authFunc, rateLimiter, healthHandler, longTimeoutHandlers, handlers...)
+	// Consumer Connect server — all consumer services, no admin service, no
+	// extra interceptors.
+	srv := server.NewConnectServer(cfg.Server, logger, authFunc, rateLimiter, healthHandler, nil, longTimeoutHandlers, handlers...)
+
+	// Admin Connect server — a second listener in the same binary on its own
+	// port and CORS allowlist, serving ONLY admin services. Its server-wide
+	// RequireRoleInterceptor (admin role) is the sole, structural authorization
+	// gate (handlers carry no per-method role check). It shares the auth func,
+	// rate limiter, and health checker with the consumer server.
+	adminServerCfg := cfg.Server
+	adminServerCfg.Port = cfg.Server.AdminPort
+	adminServerCfg.AllowedOrigins = cfg.Server.AdminAllowedOrigins
+	adminInterceptors := []connect.Interceptor{auth.NewRequireRoleInterceptor("admin")}
+	adminSrv := server.NewConnectServer(adminServerCfg, logger, authFunc, rateLimiter, healthHandler, adminInterceptors, nil, adminHandlers...)
 
 	// Zitadel Actions v2 webhook listener — runs on a separate port so the
 	// webhook paths are unreachable via the public GKE Gateway. Validators
@@ -372,7 +392,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	// Register shutdown phases.
 	// Drain: health → NOT_SERVING, then servers drain in-flight requests,
 	// then cache cleanup goroutine stops.
-	shutdown.AddDrainPhase(healthChecker, srv, webhookSrv, rateLimiter, artistCache)
+	shutdown.AddDrainPhase(healthChecker, srv, adminSrv, webhookSrv, rateLimiter, artistCache)
 	shutdown.AddFlushPhase(publisher)
 	externalClosers := []io.Closer{lastfmClient, musicbrainzClient}
 	if sbtCloser != nil {
@@ -384,6 +404,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 
 	return &App{
 		Server:          srv,
+		AdminServer:     adminSrv,
 		WebhookServer:   webhookSrv,
 		Logger:          logger,
 		ShutdownTimeout: cfg.ShutdownTimeout,

--- a/internal/infrastructure/auth/authz.go
+++ b/internal/infrastructure/auth/authz.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+)
+
+// RequireRoleInterceptor enforces, at the server boundary, that every RPC caller
+// holds the named Zitadel project role. It reads the bridged claims (see
+// ClaimsBridgeInterceptor) and rejects callers without the role with
+// CodePermissionDenied before any handler runs.
+//
+// It is applied server-wide on the admin Connect server so that admin RPCs are
+// gated structurally rather than by per-method discipline: because the admin
+// server hosts only admin services and this layer is server-wide, it is
+// impossible to register an un-gated admin RPC. It must be ordered after the
+// claims bridge (so the bridged claims are present) and before validation.
+type RequireRoleInterceptor struct {
+	role string
+}
+
+// NewRequireRoleInterceptor creates an interceptor that requires every caller to
+// hold the given role.
+func NewRequireRoleInterceptor(role string) RequireRoleInterceptor {
+	return RequireRoleInterceptor{role: role}
+}
+
+// WrapUnary enforces the required role for unary RPCs.
+func (i RequireRoleInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if err := RequireRole(ctx, i.role); err != nil {
+			return nil, err
+		}
+		return next(ctx, req)
+	}
+}
+
+// WrapStreamingClient is a no-op for client streaming.
+func (i RequireRoleInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+// WrapStreamingHandler enforces the required role for streaming RPCs.
+func (i RequireRoleInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		if err := RequireRole(ctx, i.role); err != nil {
+			return err
+		}
+		return next(ctx, conn)
+	}
+}

--- a/internal/infrastructure/auth/authz_test.go
+++ b/internal/infrastructure/auth/authz_test.go
@@ -1,0 +1,79 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireRoleInterceptor_WrapUnary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ctx      func() context.Context
+		wantErr  bool
+		wantCode connect.Code
+		wantNext bool
+	}{
+		{
+			name: "allow caller holding the required role",
+			ctx: func() context.Context {
+				return auth.WithClaims(context.Background(), &auth.Claims{
+					Sub:   "admin-user",
+					Roles: []string{"admin"},
+				})
+			},
+			wantNext: true,
+		},
+		{
+			name: "deny authenticated caller without the role",
+			ctx: func() context.Context {
+				return auth.WithClaims(context.Background(), &auth.Claims{
+					Sub:   "regular-user",
+					Roles: []string{"viewer"},
+				})
+			},
+			wantErr:  true,
+			wantCode: connect.CodePermissionDenied,
+		},
+		{
+			name: "deny unauthenticated caller (no claims)",
+			ctx: func() context.Context {
+				return context.Background()
+			},
+			wantErr:  true,
+			wantCode: connect.CodePermissionDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			nextCalled := false
+			next := connect.UnaryFunc(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+				nextCalled = true
+				return connect.NewResponse(&struct{}{}), nil
+			})
+
+			interceptor := auth.NewRequireRoleInterceptor("admin")
+			_, err := interceptor.WrapUnary(next)(tt.ctx(), connect.NewRequest(&struct{}{}))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				var connErr *connect.Error
+				require.ErrorAs(t, err, &connErr)
+				assert.Equal(t, tt.wantCode, connErr.Code())
+				assert.False(t, nextCalled, "handler must not run when authorization fails")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantNext, nextCalled)
+		})
+	}
+}

--- a/internal/infrastructure/server/connect.go
+++ b/internal/infrastructure/server/connect.go
@@ -43,6 +43,15 @@ type LongTimeoutRPCHandler struct {
 }
 
 // NewConnectServer creates a new Connect server instance.
+//
+// It is the shared factory for both the consumer and the admin Connect servers:
+// the two are built identically except for the port and CORS origins (carried by
+// serverCfg), the handler set (longTimeoutHandlers/handlerFuncs), and any
+// extraInterceptors. The consumer server passes no extra interceptors; the admin
+// server passes its boundary admin-authorization interceptor. extraInterceptors are
+// inserted after the claims bridge and before validation, preserving the
+// interceptor-chain-ordering invariants for both servers.
+//
 // longTimeoutHandlers are wrapped with their own http.TimeoutHandler instead of the default.
 func NewConnectServer(
 	serverCfg config.ServerSettings,
@@ -50,6 +59,7 @@ func NewConnectServer(
 	authFunc authn.AuthFunc,
 	rateLimiter *ratelimit.Limiter,
 	healthHandler HealthHandlerFunc,
+	extraInterceptors []connect.Interceptor,
 	longTimeoutHandlers []LongTimeoutRPCHandler,
 	handlerFuncs ...RPCHandlerFunc,
 ) *ConnectServer {
@@ -83,12 +93,21 @@ func NewConnectServer(
 	//                                   context from [1]. Inside [3] so access log still fires.
 	//   [6] claimsBridgeInterceptor        — Reads authn.infoKey (set by HTTP-layer authn.Middleware)
 	//                                        and writes auth.claimsKey for handlers.
+	//   [6b] extraInterceptors             — Optional per-server layers (e.g. the admin server's
+	//                                        REQUIRE-ADMIN authorization). Run after the claims bridge
+	//                                        so they see bridged claims, before validation.
 	//   [7] validationInterceptor          — Validates request proto via protovalidate. Innermost layer.
 	//
 	// Response path (innermost → outermost):
-	//   handler error (AppErr) → [7] pass → [6] pass → [5] pass (or catch panic) →
+	//   handler error (AppErr) → [7] pass → [6b] pass → [6] pass → [5] pass (or catch panic) →
 	//   [4] convert to *connect.Error → [3] log with correct status → [2] rate limit pass → [1] end span
 	//
+	// The claims bridge runs first so the bridged claims are visible to any
+	// extraInterceptors; validation runs last so it is innermost.
+	innerInterceptors := []connect.Interceptor{auth.ClaimsBridgeInterceptor{}}
+	innerInterceptors = append(innerInterceptors, extraInterceptors...)
+	innerInterceptors = append(innerInterceptors, validationInterceptor)
+
 	handlerOpts := []connect.HandlerOption{
 		connect.WithInterceptors(
 			tracingInterceptor,
@@ -97,10 +116,7 @@ func NewConnectServer(
 			apperr_connect.NewErrorHandlingInterceptor(logger),
 		),
 		newRecoverHandler(logger),
-		connect.WithInterceptors(
-			auth.ClaimsBridgeInterceptor{},
-			validationInterceptor,
-		),
+		connect.WithInterceptors(innerInterceptors...),
 	}
 
 	// Health check opts — minimal chain for Kubernetes probes.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -174,6 +174,15 @@ type ServerSettings struct {
 	// Allowed CORS origins
 	AllowedOrigins []string `envconfig:"CORS_ALLOWED_ORIGINS"`
 
+	// AdminPort is the port for the dedicated admin Connect server (admin-scoped
+	// RPCs only). It runs as a second listener in the same backend binary on its
+	// own ingress host, governed independently of the consumer API.
+	AdminPort int `envconfig:"ADMIN_SERVER_PORT" default:"8090"`
+
+	// AdminAllowedOrigins is the CORS allowlist for the admin server (admin
+	// origins only), configured independently of AllowedOrigins.
+	AdminAllowedOrigins []string `envconfig:"ADMIN_CORS_ALLOWED_ORIGINS"`
+
 	// Rate limiting configuration
 	RateLimit RateLimitConfig `envconfig:""`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -73,6 +73,8 @@ func TestLoad_ServerConfig(t *testing.T) {
 					ConcertHandlerTimeout: 120 * time.Second,
 					IdleTimeout:           3 * time.Second,
 					AllowedOrigins:        nil,
+					AdminPort:             8090,
+					AdminAllowedOrigins:   nil,
 					RateLimit:             RateLimitConfig{AuthRPS: 100, AuthBurst: 200, AnonRPS: 30, AnonBurst: 60},
 				},
 				Webhook: WebhookSettings{
@@ -116,6 +118,8 @@ func TestLoad_ServerConfig(t *testing.T) {
 				"SERVER_HANDLER_TIMEOUT":          "10s",
 				"SERVER_CONCERT_HANDLER_TIMEOUT":  "180s",
 				"SERVER_IDLE_TIMEOUT":             "45s",
+				"ADMIN_SERVER_PORT":               "9190",
+				"ADMIN_CORS_ALLOWED_ORIGINS":      "https://admin.example.com",
 				"DATABASE_NAME":                   "testdb",
 				"DATABASE_USER":                   "testuser",
 				"LOGGING_LEVEL":                   "debug",
@@ -164,6 +168,8 @@ func TestLoad_ServerConfig(t *testing.T) {
 					ConcertHandlerTimeout: 180 * time.Second,
 					IdleTimeout:           45 * time.Second,
 					AllowedOrigins:        nil,
+					AdminPort:             9190,
+					AdminAllowedOrigins:   []string{"https://admin.example.com"},
 					RateLimit:             RateLimitConfig{AuthRPS: 100, AuthBurst: 200, AnonRPS: 30, AnonBurst: 60},
 				},
 				Webhook: WebhookSettings{


### PR DESCRIPTION
## Why

The admin moderation RPCs (`ConcertModerationService`) shared the consumer server's port, CORS allowlist, authn middleware, and interceptor chain — only a per-method `auth.RequireRole(ctx, "admin")` separated the admin surface from the public one. A single missed check would silently expose an admin op to any authenticated fan, and the admin surface could not be governed independently of the public API.

## What

- Extract a shared server factory; build a **second in-process admin Connect server** (port `8090`, admin-only CORS) differing only by a fixed boundary `RequireRoleInterceptor` (admin role) inserted after the claims bridge / before validation.
- `ConcertModerationService` is now registered **only** on the admin server; the per-method `RequireRole` calls are removed (handler is pure mapping). Both servers drain on shutdown.
- New config: `ADMIN_SERVER_PORT` (8090) + `ADMIN_CORS_ALLOWED_ORIGINS`.

## Verification

`make check` green (lint + unit + integration). New `RequireRoleInterceptor` tests: admin allowed, non-admin/unauth → `PERMISSION_DENIED` (handler never runs).

## Cutover (see specification#615 §5)

Part of a coordinated cutover: cloud-provisioning stands up `api.admin` first, **then** this backend release moves moderation to the admin port (consumer stops serving it in the same release), then the frontend flips to `api.admin`. Brief `unimplemented` gap on the internal admin tool between backend & frontend releases — no security exposure.

Refs: liverty-music/specification#615