### PR TITLE
perf(sales-phase): batch searcher per artist and seed the official-site URL

### DIFF
--- a/internal/di/sales_phase_discovery_job.go
+++ b/internal/di/sales_phase_discovery_job.go
@@ -63,6 +63,7 @@ func InitializeSalesPhaseDiscoveryJobApp(ctx context.Context) (*SalesPhaseDiscov
 	// Repositories
 	followRepo := rdb.NewFollowRepository(db)
 	concertRepo := rdb.NewConcertRepository(db)
+	artistRepo := rdb.NewArtistRepository(db)
 	salesPhaseRepo := rdb.NewSalesPhaseRepository(db)
 
 	// Messaging
@@ -103,6 +104,7 @@ func InitializeSalesPhaseDiscoveryJobApp(ctx context.Context) (*SalesPhaseDiscov
 
 	salesPhaseDiscUC := usecase.NewSalesPhaseDiscoveryUseCase(
 		concertRepo,
+		artistRepo,
 		salesPhaseRepo,
 		searcher,
 		eventPublisher,

--- a/internal/entity/mocks/mock_SalesPhaseSearcher.go
+++ b/internal/entity/mocks/mock_SalesPhaseSearcher.go
@@ -22,9 +22,9 @@ func (_m *MockSalesPhaseSearcher) EXPECT() *MockSalesPhaseSearcher_Expecter {
 	return &MockSalesPhaseSearcher_Expecter{mock: &_m.Mock}
 }
 
-// SearchSalesPhases provides a mock function with given fields: ctx, artistName, seriesTitle, seriesID
-func (_m *MockSalesPhaseSearcher) SearchSalesPhases(ctx context.Context, artistName string, seriesTitle string, seriesID string) ([]*entity.SalesPhaseCandidate, error) {
-	ret := _m.Called(ctx, artistName, seriesTitle, seriesID)
+// SearchSalesPhases provides a mock function with given fields: ctx, in
+func (_m *MockSalesPhaseSearcher) SearchSalesPhases(ctx context.Context, in *entity.SalesPhaseSearchInput) ([]*entity.SalesPhaseCandidate, error) {
+	ret := _m.Called(ctx, in)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SearchSalesPhases")
@@ -32,19 +32,19 @@ func (_m *MockSalesPhaseSearcher) SearchSalesPhases(ctx context.Context, artistN
 
 	var r0 []*entity.SalesPhaseCandidate
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]*entity.SalesPhaseCandidate, error)); ok {
-		return rf(ctx, artistName, seriesTitle, seriesID)
+	if rf, ok := ret.Get(0).(func(context.Context, *entity.SalesPhaseSearchInput) ([]*entity.SalesPhaseCandidate, error)); ok {
+		return rf(ctx, in)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []*entity.SalesPhaseCandidate); ok {
-		r0 = rf(ctx, artistName, seriesTitle, seriesID)
+	if rf, ok := ret.Get(0).(func(context.Context, *entity.SalesPhaseSearchInput) []*entity.SalesPhaseCandidate); ok {
+		r0 = rf(ctx, in)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*entity.SalesPhaseCandidate)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, artistName, seriesTitle, seriesID)
+	if rf, ok := ret.Get(1).(func(context.Context, *entity.SalesPhaseSearchInput) error); ok {
+		r1 = rf(ctx, in)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,16 +59,14 @@ type MockSalesPhaseSearcher_SearchSalesPhases_Call struct {
 
 // SearchSalesPhases is a helper method to define mock.On call
 //   - ctx context.Context
-//   - artistName string
-//   - seriesTitle string
-//   - seriesID string
-func (_e *MockSalesPhaseSearcher_Expecter) SearchSalesPhases(ctx interface{}, artistName interface{}, seriesTitle interface{}, seriesID interface{}) *MockSalesPhaseSearcher_SearchSalesPhases_Call {
-	return &MockSalesPhaseSearcher_SearchSalesPhases_Call{Call: _e.mock.On("SearchSalesPhases", ctx, artistName, seriesTitle, seriesID)}
+//   - in *entity.SalesPhaseSearchInput
+func (_e *MockSalesPhaseSearcher_Expecter) SearchSalesPhases(ctx interface{}, in interface{}) *MockSalesPhaseSearcher_SearchSalesPhases_Call {
+	return &MockSalesPhaseSearcher_SearchSalesPhases_Call{Call: _e.mock.On("SearchSalesPhases", ctx, in)}
 }
 
-func (_c *MockSalesPhaseSearcher_SearchSalesPhases_Call) Run(run func(ctx context.Context, artistName string, seriesTitle string, seriesID string)) *MockSalesPhaseSearcher_SearchSalesPhases_Call {
+func (_c *MockSalesPhaseSearcher_SearchSalesPhases_Call) Run(run func(ctx context.Context, in *entity.SalesPhaseSearchInput)) *MockSalesPhaseSearcher_SearchSalesPhases_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+		run(args[0].(context.Context), args[1].(*entity.SalesPhaseSearchInput))
 	})
 	return _c
 }
@@ -78,7 +76,7 @@ func (_c *MockSalesPhaseSearcher_SearchSalesPhases_Call) Return(_a0 []*entity.Sa
 	return _c
 }
 
-func (_c *MockSalesPhaseSearcher_SearchSalesPhases_Call) RunAndReturn(run func(context.Context, string, string, string) ([]*entity.SalesPhaseCandidate, error)) *MockSalesPhaseSearcher_SearchSalesPhases_Call {
+func (_c *MockSalesPhaseSearcher_SearchSalesPhases_Call) RunAndReturn(run func(context.Context, *entity.SalesPhaseSearchInput) ([]*entity.SalesPhaseCandidate, error)) *MockSalesPhaseSearcher_SearchSalesPhases_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/entity/sales_phase.go
+++ b/internal/entity/sales_phase.go
@@ -163,17 +163,31 @@ const (
 	UpsertOutcomeUpdated UpsertOutcome = 2
 )
 
-// SalesSeriesCandidate pairs a series with its candidate events for the
-// sales-phase discovery job. The job builds one of these per series and
-// passes it to the searcher.
-type SalesSeriesCandidate struct {
+// SalesSeriesRef identifies one of an artist's known upcoming series, supplied
+// to the searcher so it can attribute a discovered sale phase to the correct
+// series_id. The known event dates help the model disambiguate when an artist
+// has multiple concurrent tours.
+type SalesSeriesRef struct {
 	// SeriesID is the stable identifier of the series.
 	SeriesID string
-	// SeriesTitle is the display title used to ground the Gemini search.
-	SeriesTitle string
-	// ArtistName is a representative performing artist for this series, used
-	// in the search prompt.
+	// Title is the display title of the series (tour).
+	Title string
+	// EventDates are the known local dates of the series' upcoming events.
+	EventDates []time.Time
+}
+
+// SalesPhaseSearchInput is the per-artist input to the sales-phase searcher.
+// Discovery issues ONE grounded search per artist (not per series) to cut
+// grounding cost and to let the model see all of the artist's tours at once.
+type SalesPhaseSearchInput struct {
+	// ArtistName is the performing artist whose sales phases are searched.
 	ArtistName string
+	// OfficialSiteURL seeds the URL-context tool so the model reads the real
+	// page instead of answering from memory. Always present.
+	OfficialSiteURL string
+	// Series are the artist's known upcoming series; a discovered phase is
+	// attributed back to one of these series_ids (unmappable phases dropped).
+	Series []*SalesSeriesRef
 }
 
 // SalesPhaseRepository defines the data access interface for [SalesPhase].
@@ -226,26 +240,24 @@ type SalesPhaseRepository interface {
 	GetBySeries(ctx context.Context, seriesID string) ([]*SalesPhase, error)
 }
 
-// SalesPhaseSearcher discovers upcoming ticket-sales phases for an artist's
-// series using an external grounded search.
+// SalesPhaseSearcher discovers upcoming ticket-sales phases for an artist
+// using an external grounded search, issuing one call per artist.
 type SalesPhaseSearcher interface {
-	// SearchSalesPhases returns all series-level sales-phase candidates found
-	// for the given artist name and series title. It does NOT resolve which
-	// individual events a phase covers — each candidate is a series-level record.
+	// SearchSalesPhases issues a single grounded search for the artist in the
+	// input and returns the discovered series-level sale-phase candidates, each
+	// attributed to one of the input's series_ids. It does NOT resolve which
+	// individual events a phase covers, and it returns only series for which a
+	// phase was found (it does not echo back every input series).
 	//
 	// An empty result with a nil error means the searcher found no phases (normal
-	// outcome). Only infrastructure failures return a non-nil error.
+	// outcome, including "nothing new since input.Since"). Only infrastructure
+	// failures return a non-nil error.
 	//
 	// # Possible errors
 	//
 	//  - Unavailable: If the external search service is down.
 	//  - Internal: Unexpected failure during extraction or coercion.
-	SearchSalesPhases(
-		ctx context.Context,
-		artistName string,
-		seriesTitle string,
-		seriesID string,
-	) ([]*SalesPhaseCandidate, error)
+	SearchSalesPhases(ctx context.Context, in *SalesPhaseSearchInput) ([]*SalesPhaseCandidate, error)
 }
 
 // SalesPhaseReminderRepository persists the sent-log for sales-phase reminder

--- a/internal/infrastructure/gcp/gemini/sales_phase_searcher.go
+++ b/internal/infrastructure/gcp/gemini/sales_phase_searcher.go
@@ -78,17 +78,18 @@ const (
 	//   クレジットカード → CREDIT_CARD (4)
 	//   携帯キャリア → MOBILE_CARRIER (5) — docomo/au/SoftBank presale
 	//   一般         → GENERAL (6)
-	systemInstructionSalesPhaseStep1 = `あなたは音楽ファン向けサービスの、チケット販売スケジュール抽出エージェントです。
+	systemInstructionSalesPhaseStep1 = `You are a ticket-sales schedule extraction agent for a music-fan service. The artist's pages are in Japanese.
 
-アーティストの指定シリーズについて、公式サイトおよびチケット販売会社のページから、ユーザーが「今後申し込める」チケット販売スケジュールを抽出することがゴールです。ユーザー(ファン)が見逃したくないのは、これから受付が始まる先行・先着・一般発売です。すでに申込受付が終了した販売(申込締切が本日より前のもの)は価値がないため対象外とし、出力しないでください。
+Goal: read the artist's OFFICIAL SITE (URL given in the user prompt) and the ticketing pages it links to, and extract the ticket sales a fan can still apply for. Do NOT answer from memory or guess — base every value strictly on the content of that URL. Fans care about upcoming presales, first-come sales, and general on-sales. Sales whose application window has already closed (application deadline before today) are out of scope; do not output them.
 
-販売フェーズはシリーズ(ツアー)全体に対する1つの販売機会として扱います。どの個別公演を対象とするか(対象公演日)は抽出不要です。販売条件(チャネル・受付期間など)が異なる販売は、それぞれ別の <phase> として出力してください。
+A sale phase is ONE series-level (whole-tour) sales opportunity. Every <phase> MUST carry a series_id identifying which series it belongs to. Use ONLY a value from the "known series" list in the user prompt; if you cannot confidently map a phase to one of those series, do NOT output it (never guess the mapping).
 
-以下の出力フォーマットに従い、販売フェーズごとに <phase> タグでまとめてください。
+Follow this exact XML output format, one <phase> per sales window:
 
 <extracted>
   <source_url>https://www.example.com/ticket</source_url>
   <phase>
+    <series_id>0190000000000000000000000000aaaa</series_id>
     <method>抽選</method>
     <channel>ファンクラブ</channel>
     <provider_name></provider_name>
@@ -99,44 +100,37 @@ const (
     <payment_deadline></payment_deadline>
     <url>https://fc.example/entry</url>
   </phase>
-  <phase>
-    <method>先着</method>
-    <channel>一般</channel>
-    <provider_name>チケットぴあ</provider_name>
-    <sequence>0</sequence>
-    <apply_start>2026年8月1日 10:00</apply_start>
-    <apply_end></apply_end>
-    <lottery_result></lottery_result>
-    <payment_deadline></payment_deadline>
-    <url>https://t.pia.jp/example</url>
-  </phase>
 </extracted>
 
-抽出ルール:
-- source_url: 最も詳細な情報を記載しているページのURL。
-- method: 「抽選」または「先着」。不明な場合は空欄。
-- channel: 以下の7種類のうちいずれか1つを記入。不明な場合は空欄。
-    「ファンクラブ」 — FC・ファンクラブ会員限定。
-    「公式」         — アーティスト/レーベルの公式サイトや公式アプリからの直販(FC枠以外)。
-    「プレイガイド」 — e+、チケットぴあ、ローチケ、CNプレイガイドなど第三者プレイガイド全般。具体的な会社名は provider_name に記入。
-    「クレジットカード」 — 特定クレジットカード会員向け先行。
-    「携帯キャリア」 — docomo・au・SoftBank などキャリア先行。
-    「一般」         — 会員資格・提携条件なしの一般発売。
-- provider_name: チケット販売会社名を verbatim (一字一句そのまま) でコピーすること。不明な場合は空欄。特に channel が「プレイガイド」の場合は必ず具体的な会社名 (例: "e+"、"チケットぴあ"、"ローチケ") を記入する。
-- sequence: 同一チャネルで複数回抽選がある場合の0始まりの順番。通常は0。
-- apply_start, apply_end, lottery_result, payment_deadline: verbatim な日時文字列。不明・非該当の場合は空欄。
-- 対象期間: ユーザープロンプトで与えられる「本日」を基準とし、申込締切が本日より前の販売(受付終了済み)は出力しないこと。これから受付が始まる、または現在受付中で締切が本日以降の販売のみを対象とする。特に、告知されたばかりの今後の一般発売・追加先行を見落とさないこと。
-- 情報が確認できない項目はタグを空欄にすること。推測や補完は一切禁止。
-- 余計なテキストは含めず、XMLのみをレスポンスに含めること。
+Extraction rules:
+- series_id: MUST be one of the values in the "known series" list; decide the match from the series title and event dates. If undecidable, omit the phase.
+- source_url: the URL of the page with the most detailed information.
+- method: write exactly "抽選" (lottery) or "先着" (first-come). Empty if unknown.
+- channel: write exactly ONE of these 7 Japanese tokens; empty if unknown:
+    "ファンクラブ" — fan-club members only.
+    "公式"         — direct sale from the artist/label official site or app (non-fan-club).
+    "プレイガイド" — any third-party play guide (e+, チケットぴあ, ローチケ, CN Playguide, …); put the concrete company name in provider_name.
+    "クレジットカード" — a specific credit-card-member presale.
+    "携帯キャリア" — a mobile-carrier presale (docomo/au/SoftBank).
+    "一般"         — general on-sale with no membership/affiliation gate.
+- provider_name: copy the ticketing company name verbatim. Empty if unknown. When channel is "プレイガイド", always fill in the concrete company name.
+- sequence: 0-based ordinal when the same channel runs multiple rounds. Usually 0.
+- apply_start, apply_end, lottery_result, payment_deadline: verbatim date/time strings as written on the page. Empty when unknown or not applicable.
+- Date scope: relative to the "today" given in the user prompt, do NOT output sales whose application deadline is before today. Only sales that are about to open or currently open with a deadline on/after today. If none qualify, return an empty <extracted> with no <phase>.
+- Leave a tag empty when the value cannot be confirmed. Never guess or fill in.
+- Respond with XML only; no extra text.
 `
 
-	// promptTemplateSalesPhaseStep1 is the per-call user prompt template.
-	// Placeholders: today (JST date), artist name, series title.
-	promptTemplateSalesPhaseStep1 = `本日: %s
-アーティスト名: %s
-シリーズ名: %s
+	// promptTemplateSalesPhaseStep1 is the per-artist user prompt template.
+	// Placeholders: today (JST date), artist name, official site URL, and the
+	// known-series list.
+	promptTemplateSalesPhaseStep1 = `Today: %s
+Artist: %s
+Official site: %s
+Known series (series_id: title / event dates):
+%s
 
-このシリーズについて、本日以降に申し込めるチケット販売スケジュールのみを抽出してください。申込締切が本日より前の販売(受付終了済み)は出力しないこと。これから受付が始まる先行・先着・一般発売、および現在受付中で締切が本日以降の販売を対象とし、今後の一般発売・追加先行を見落とさないでください。`
+Read the official site above and extract the ticket sales a fan can still apply for as of today. Tag each <phase> with its matching series_id, and omit any phase you cannot confidently map. If none qualify, return an empty <extracted>.`
 
 	// systemInstructionSalesPhaseStep2 instructs Step 2 to perform JSON
 	// coercion only — dates and times are normalised from verbatim Japanese
@@ -160,6 +154,7 @@ type salesPhaseStep1Envelope struct {
 }
 
 type salesPhaseXML struct {
+	SeriesID        string `xml:"series_id"`
 	Method          string `xml:"method"`
 	Channel         string `xml:"channel"`
 	ProviderName    string `xml:"provider_name"`
@@ -302,21 +297,31 @@ func NewSalesPhaseSearcher(
 // outcome). Only infrastructure failures return a non-nil error.
 func (s *SalesPhaseSearcher) SearchSalesPhases(
 	ctx context.Context,
-	artistName string,
-	seriesTitle string,
-	seriesID string,
+	in *entity.SalesPhaseSearchInput,
 ) ([]*entity.SalesPhaseCandidate, error) {
+	if in == nil || len(in.Series) == 0 {
+		return nil, nil
+	}
 	attrs := []slog.Attr{
-		slog.String("artist_name", artistName),
-		slog.String("series_title", seriesTitle),
-		slog.String("series_id", seriesID),
+		slog.String("artist_name", in.ArtistName),
+		slog.String("official_site_url", in.OfficialSiteURL),
+		slog.Int("series_count", len(in.Series)),
 		slog.String("model_extract", s.config.modelExtract()),
 		slog.String("model_parse", s.config.modelParse()),
 	}
 	s.logger.Info(ctx, "SalesPhaseSearcher: starting two-step extraction", attrs...)
 
+	// validSeriesIDs bounds the model's series_id attribution; a phase tagged
+	// with an unknown series_id is dropped rather than guessed.
+	validSeriesIDs := make(map[string]struct{}, len(in.Series))
+	for _, sr := range in.Series {
+		if sr != nil && sr.SeriesID != "" {
+			validSeriesIDs[sr.SeriesID] = struct{}{}
+		}
+	}
+
 	// ===== Step 1: Grounded search + verbatim extract =====
-	rawEnvelope, err := s.runStep1(ctx, artistName, seriesTitle, attrs)
+	rawEnvelope, err := s.runStep1(ctx, in, attrs)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +339,7 @@ func (s *SalesPhaseSearcher) SearchSalesPhases(
 	}
 
 	// ===== Step 2: JSON coercion (verbatim Japanese dates → RFC 3339) =====
-	candidates, err := s.runStep2(ctx, seriesID, envelope.SourceURL, xmlPhases, attrs)
+	candidates, err := s.runStep2(ctx, validSeriesIDs, envelope.SourceURL, xmlPhases, attrs)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +377,7 @@ func filterUpcomingPhases(candidates []*entity.SalesPhaseCandidate, now time.Tim
 // text. Returns ("", nil) on transient exhaustion (degrade gracefully).
 func (s *SalesPhaseSearcher) runStep1(
 	ctx context.Context,
-	artistName, seriesTitle string,
+	in *entity.SalesPhaseSearchInput,
 	attrs []slog.Attr,
 ) (string, error) {
 	now := time.Now().UTC().Truncate(time.Second)
@@ -381,24 +386,18 @@ func (s *SalesPhaseSearcher) runStep1(
 	// +09:00 zone is exact and avoids a tzdata dependency.
 	jst := time.FixedZone("JST", 9*60*60)
 	today := now.In(jst).Format("2006年1月2日")
-	prompt := fmt.Sprintf(promptTemplateSalesPhaseStep1, today, artistName, seriesTitle)
+	prompt := fmt.Sprintf(promptTemplateSalesPhaseStep1,
+		today, in.ArtistName, in.OfficialSiteURL, seriesList(in.Series, jst),
+	)
 	temperature := s.config.Temperature
 
-	// TODO(grounding): GoogleSearch is NOT firing for this searcher — live runs
-	// show usage.tool_use=0 and grounding.fired=false for BOTH gemini-3.1-flash-
-	// lite AND gemini-3.5-flash, so extraction is currently from model memory,
-	// not live search. Removing TimeRangeFilter did NOT restore grounding, so it
-	// is not the cause; root cause is at the GoogleSearch tool / SDK / model
-	// level (likely affects the concert searcher too). TimeRangeFilter is kept
-	// for source freshness once grounding is fixed.
-	searchTool := &genai.Tool{
-		GoogleSearch: &genai.GoogleSearch{
-			TimeRangeFilter: &genai.Interval{
-				StartTime: now.AddDate(0, -6, 0),
-				EndTime:   now,
-			},
-		},
-	}
+	// Grounding is driven by the seeded official-site URL through the URL-context
+	// tool (the model reads the real page instead of answering from memory);
+	// GoogleSearch is a fallback. We do NOT use TimeRangeFilter — it is unreliable
+	// (googleapis/python-genai#1207) and recency is not needed: the official site
+	// is a live full-state source and re-discovered phases converge idempotently
+	// on (series_id, apply_start_time).
+	searchTool := &genai.Tool{GoogleSearch: &genai.GoogleSearch{}}
 	urlCtxTool := &genai.Tool{URLContext: &genai.URLContext{}}
 
 	cfg := &genai.GenerateContentConfig{
@@ -435,7 +434,7 @@ func (s *SalesPhaseSearcher) runStep1(
 // assembles the final []*entity.SalesPhaseCandidate.
 func (s *SalesPhaseSearcher) runStep2(
 	ctx context.Context,
-	seriesID string,
+	validSeriesIDs map[string]struct{},
 	sourceURL string,
 	xmlPhases []salesPhaseXML,
 	attrs []slog.Attr,
@@ -487,7 +486,32 @@ func (s *SalesPhaseSearcher) runStep2(
 		return nil, nil
 	}
 
-	return parseSalesPhaseStep2Response(rawText, xmlPhases, seriesID, sourceURL, attrs)
+	return parseSalesPhaseStep2Response(rawText, xmlPhases, validSeriesIDs, sourceURL, attrs)
+}
+
+// seriesList renders the artist's known series as a prompt block keyed by
+// series_id, with each series' known event dates for disambiguation.
+func seriesList(series []*entity.SalesSeriesRef, tz *time.Location) string {
+	var b strings.Builder
+	for _, sr := range series {
+		if sr == nil || sr.SeriesID == "" {
+			continue
+		}
+		dates := make([]string, 0, len(sr.EventDates))
+		for _, d := range sr.EventDates {
+			dates = append(dates, d.In(tz).Format("2006-01-02"))
+		}
+		b.WriteString("- ")
+		b.WriteString(sr.SeriesID)
+		b.WriteString(": ")
+		b.WriteString(sr.Title)
+		if len(dates) > 0 {
+			b.WriteString(" / ")
+			b.WriteString(strings.Join(dates, ", "))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 // generateSingle fires a single Gemini call with bounded exponential-backoff
@@ -695,7 +719,7 @@ func parseSalesPhaseStep1Envelope(raw string) (salesPhaseStep1Envelope, []salesP
 func parseSalesPhaseStep2Response(
 	rawJSON string,
 	xmlPhases []salesPhaseXML,
-	seriesID string,
+	validSeriesIDs map[string]struct{},
 	sourceURL string,
 	attrs []slog.Attr,
 ) ([]*entity.SalesPhaseCandidate, error) {
@@ -741,6 +765,13 @@ func parseSalesPhaseStep2Response(
 		coerced, ok := byIndex[i]
 		if !ok {
 			// Step 2 omitted this phase — skip.
+			continue
+		}
+
+		// Attribute the phase to a known series_id; drop if the model tagged it
+		// with an unknown/empty series (never guess).
+		seriesID := strings.TrimSpace(xp.SeriesID)
+		if _, ok := validSeriesIDs[seriesID]; !ok {
 			continue
 		}
 

--- a/internal/infrastructure/gcp/gemini/sales_phase_searcher_integration_test.go
+++ b/internal/infrastructure/gcp/gemini/sales_phase_searcher_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/infrastructure/gcp/gemini"
 	"github.com/pannpers/go-logging/logging"
 	"github.com/stretchr/testify/assert"
@@ -107,7 +108,11 @@ func TestSalesPhaseSearcher_Vaundy_HORO_Integration(t *testing.T) {
 			searcher, err := gemini.NewSalesPhaseSearcher(ctx, cfg, http.DefaultClient, logger)
 			require.NoError(t, err)
 
-			candidates, err := searcher.SearchSalesPhases(ctx, artistName, seriesTitle, seriesID)
+			candidates, err := searcher.SearchSalesPhases(ctx, &entity.SalesPhaseSearchInput{
+				ArtistName:      artistName,
+				OfficialSiteURL: "https://vaundy.jp/",
+				Series:          []*entity.SalesSeriesRef{{SeriesID: seriesID, Title: seriesTitle}},
+			})
 			require.NoError(t, err)
 
 			t.Logf("[thinking=%s] SearchSalesPhases returned %d candidates", thinking, len(candidates))
@@ -173,12 +178,11 @@ func TestSalesPhaseSearcher_EmptyGrounding_Integration(t *testing.T) {
 	searcher, err := gemini.NewSalesPhaseSearcher(ctx, cfg, http.DefaultClient, logger)
 	require.NoError(t, err)
 
-	candidates, err := searcher.SearchSalesPhases(
-		ctx,
-		"zzzNonExistentArtistXXX",
-		"Nonexistent Tour 9999",
-		"test-series-empty",
-	)
+	candidates, err := searcher.SearchSalesPhases(ctx, &entity.SalesPhaseSearchInput{
+		ArtistName:      "zzzNonExistentArtistXXX",
+		OfficialSiteURL: "https://example.com/nonexistent",
+		Series:          []*entity.SalesSeriesRef{{SeriesID: "test-series-empty", Title: "Nonexistent Tour 9999"}},
+	})
 	require.NoError(t, err)
 	// We can only assert the contract (no error), not the count, because the
 	// model might still hallucinate results for a totally unknown query.

--- a/internal/infrastructure/gcp/gemini/sales_phase_searcher_test.go
+++ b/internal/infrastructure/gcp/gemini/sales_phase_searcher_test.go
@@ -87,6 +87,7 @@ func TestParseSalesPhaseStep2Response(t *testing.T) {
 
 	xmlPhases := []salesPhaseXML{
 		{
+			SeriesID:     "series-a",
 			Method:       "抽選",
 			Channel:      "ファンクラブ",
 			ProviderName: "e+",
@@ -94,6 +95,7 @@ func TestParseSalesPhaseStep2Response(t *testing.T) {
 			URL:          "https://eplus.jp/example",
 		},
 		{
+			SeriesID:     "series-b",
 			Method:       "先着",
 			Channel:      "一般",
 			ProviderName: "ローチケ",
@@ -101,12 +103,14 @@ func TestParseSalesPhaseStep2Response(t *testing.T) {
 			URL:          "https://l-tike.com/example",
 		},
 	}
+	bothValid := map[string]struct{}{"series-a": {}, "series-b": {}}
+	onlyA := map[string]struct{}{"series-a": {}}
 
 	tests := []struct {
 		name      string
 		rawJSON   string
 		xmlPhases []salesPhaseXML
-		seriesID  string
+		valid     map[string]struct{}
 		sourceURL string
 		wantLen   int
 		wantErr   bool
@@ -132,7 +136,7 @@ func TestParseSalesPhaseStep2Response(t *testing.T) {
   ]
 }`,
 			xmlPhases: xmlPhases,
-			seriesID:  "series-111",
+			valid:     bothValid,
 			sourceURL: "https://example.com/ticket",
 			wantLen:   2,
 		},
@@ -150,7 +154,7 @@ func TestParseSalesPhaseStep2Response(t *testing.T) {
   ]
 }`,
 			xmlPhases: xmlPhases[:1],
-			seriesID:  "series-222",
+			valid:     onlyA,
 			sourceURL: "https://example.com/ticket",
 			wantLen:   1,
 		},
@@ -168,7 +172,7 @@ func TestParseSalesPhaseStep2Response(t *testing.T) {
   ]
 }`,
 			xmlPhases: xmlPhases[:1],
-			seriesID:  "series-444",
+			valid:     onlyA,
 			sourceURL: "https://example.com/ticket",
 			wantLen:   0,
 		},
@@ -176,7 +180,7 @@ func TestParseSalesPhaseStep2Response(t *testing.T) {
 			name:      "empty grounding: empty JSON produces no phases",
 			rawJSON:   `{"phases":[]}`,
 			xmlPhases: xmlPhases,
-			seriesID:  "series-555",
+			valid:     bothValid,
 			sourceURL: "",
 			wantLen:   0,
 		},
@@ -188,7 +192,7 @@ func TestParseSalesPhaseStep2Response(t *testing.T) {
 			got, err := parseSalesPhaseStep2Response(
 				tt.rawJSON,
 				tt.xmlPhases,
-				tt.seriesID,
+				tt.valid,
 				tt.sourceURL,
 				nil,
 			)
@@ -206,6 +210,7 @@ func TestParseSalesPhaseStep2Response_FieldShaping(t *testing.T) {
 	t.Parallel()
 
 	xmlPhases := []salesPhaseXML{{
+		SeriesID:     "series-001",
 		Method:       "抽選",
 		Channel:      "ファンクラブ",
 		ProviderName: "e+",
@@ -225,7 +230,7 @@ func TestParseSalesPhaseStep2Response_FieldShaping(t *testing.T) {
   ]
 }`
 
-	got, err := parseSalesPhaseStep2Response(rawJSON, xmlPhases, "series-001", "https://example.com", nil)
+	got, err := parseSalesPhaseStep2Response(rawJSON, xmlPhases, map[string]struct{}{"series-001": {}}, "https://example.com", nil)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 

--- a/internal/usecase/sales_phase_uc.go
+++ b/internal/usecase/sales_phase_uc.go
@@ -2,10 +2,12 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/liverty-music/backend/internal/entity"
+	"github.com/pannpers/go-apperr/apperr"
 	"github.com/pannpers/go-logging/logging"
 )
 
@@ -21,6 +23,7 @@ type SalesPhaseDiscoveryUseCase interface {
 
 type salesPhaseDiscoveryUseCase struct {
 	concertRepo    entity.ConcertRepository
+	artistRepo     entity.ArtistRepository
 	salesPhaseRepo entity.SalesPhaseRepository
 	searcher       entity.SalesPhaseSearcher
 	publisher      EventPublisher
@@ -33,11 +36,11 @@ var _ SalesPhaseDiscoveryUseCase = (*salesPhaseDiscoveryUseCase)(nil)
 
 // NewSalesPhaseDiscoveryUseCase wires the discovery use case.
 //
-// window is the look-ahead used to filter upcoming concerts from the database.
-// Phases whose covered events all lie beyond the window are still persisted —
-// the window only controls which series are included in the discovery run.
+// window is the look-ahead used to filter upcoming concerts from the database;
+// it only controls which series are included in the discovery run.
 func NewSalesPhaseDiscoveryUseCase(
 	concertRepo entity.ConcertRepository,
+	artistRepo entity.ArtistRepository,
 	salesPhaseRepo entity.SalesPhaseRepository,
 	searcher entity.SalesPhaseSearcher,
 	publisher EventPublisher,
@@ -46,6 +49,7 @@ func NewSalesPhaseDiscoveryUseCase(
 ) SalesPhaseDiscoveryUseCase {
 	return &salesPhaseDiscoveryUseCase{
 		concertRepo:    concertRepo,
+		artistRepo:     artistRepo,
 		salesPhaseRepo: salesPhaseRepo,
 		searcher:       searcher,
 		publisher:      publisher,
@@ -56,14 +60,16 @@ func NewSalesPhaseDiscoveryUseCase(
 
 // DiscoverForArtist implements [SalesPhaseDiscoveryUseCase].
 //
-// Pipeline:
-//  1. List upcoming concerts for the artist (upcomingOnly = true).
-//  2. Group concerts by series; build a SalesSeriesCandidate per series with
-//     the series' candidate events (id, date, venue, admin_area).
-//  3. For each series call SalesPhaseSearcher.SearchSalesPhases.
-//  4. For each candidate returned: call Upsert. If the outcome is
-//     UpsertOutcomeInserted, publish a SALES_PHASE.discovered event.
+// Pipeline (ONE grounded search per artist):
+//  1. List the artist's upcoming concerts and group them into series refs
+//     (series_id, title, known event dates).
+//  2. Resolve the artist's official-site URL (the grounding seed) and the
+//     incremental lower bound (last-searched timestamp minus an overlap margin).
+//  3. Call SalesPhaseSearcher.SearchSalesPhases ONCE for the artist.
+//  4. Upsert each returned candidate; publish SALES_PHASE.discovered for newly
+//     inserted phases. On success, record the new last-searched timestamp.
 func (uc *salesPhaseDiscoveryUseCase) DiscoverForArtist(ctx context.Context, artist *entity.Artist) (int, error) {
+	now := time.Now().UTC()
 	attrs := []slog.Attr{
 		slog.String("artist_id", artist.ID),
 		slog.String("artist_name", artist.Name),
@@ -79,85 +85,84 @@ func (uc *salesPhaseDiscoveryUseCase) DiscoverForArtist(ctx context.Context, art
 		return 0, nil
 	}
 
-	// Group concerts by series. We use a stable insertion-order slice so the
-	// series are processed in a deterministic order (by first encounter). A
-	// phase is series-level, so we only need each series' identity — not its
-	// individual events.
+	// Group concerts into series refs (stable insertion order), collecting each
+	// series' known upcoming event dates for the model to disambiguate.
 	order := make([]string, 0)
-	bySeriesID := make(map[string]*entity.SalesSeriesCandidate)
-
+	bySeriesID := make(map[string]*entity.SalesSeriesRef)
 	for _, c := range concerts {
 		if c.SeriesID == "" || c.Series == nil {
 			continue
 		}
-		// Skip events beyond the discovery window. Allow zero window (process all).
-		if uc.window > 0 && c.LocalDate.After(time.Now().UTC().Add(uc.window)) {
+		if uc.window > 0 && c.LocalDate.After(now.Add(uc.window)) {
 			continue
 		}
-		if _, ok := bySeriesID[c.SeriesID]; !ok {
-			bySeriesID[c.SeriesID] = &entity.SalesSeriesCandidate{
-				SeriesID:    c.SeriesID,
-				SeriesTitle: c.Series.Title,
-				ArtistName:  artist.Name,
-			}
+		ref, ok := bySeriesID[c.SeriesID]
+		if !ok {
+			ref = &entity.SalesSeriesRef{SeriesID: c.SeriesID, Title: c.Series.Title}
+			bySeriesID[c.SeriesID] = ref
 			order = append(order, c.SeriesID)
 		}
+		ref.EventDates = append(ref.EventDates, c.LocalDate)
 	}
-
 	if len(order) == 0 {
 		uc.logger.Info(ctx, "sales_phase_discovery: no series in window for artist", attrs...)
 		return 0, nil
 	}
+	seriesRefs := make([]*entity.SalesSeriesRef, len(order))
+	for i, sid := range order {
+		seriesRefs[i] = bySeriesID[sid]
+	}
+
+	// Resolve the grounding seed URL. Without a usable official-site URL the
+	// searcher cannot ground, so skip the artist (benign) rather than burn a
+	// grounding call on an empty seed. A missing row is NotFound, not an infra
+	// error; only genuine infra errors propagate (and let the job's circuit
+	// breaker handle systemic failures).
+	site, err := uc.artistRepo.GetOfficialSite(ctx, artist.ID)
+	if err != nil {
+		if errors.Is(err, apperr.ErrNotFound) {
+			uc.logger.Warn(ctx, "sales_phase_discovery: no official site; skipping artist", attrs...)
+			return 0, nil
+		}
+		return 0, err
+	}
+	if site.URL == "" {
+		uc.logger.Warn(ctx, "sales_phase_discovery: empty official site URL; skipping artist", attrs...)
+		return 0, nil
+	}
+
+	candidates, err := uc.searcher.SearchSalesPhases(ctx, &entity.SalesPhaseSearchInput{
+		ArtistName:      artist.Name,
+		OfficialSiteURL: site.URL,
+		Series:          seriesRefs,
+	})
+	if err != nil {
+		uc.logger.Error(ctx, "sales_phase_discovery: searcher failed for artist", err, attrs...)
+		return 0, err
+	}
+	uc.logger.Info(ctx, "sales_phase_discovery: searcher returned candidates",
+		append(attrs, slog.Int("series_count", len(order)), slog.Int("count", len(candidates)))...)
 
 	var totalNew int
-	for _, seriesID := range order {
-		// Respect cancellation between series.
+	for _, candidate := range candidates {
 		if ctx.Err() != nil {
 			break
 		}
-		sc := bySeriesID[seriesID]
-
-		seriesAttrs := append(attrs,
-			slog.String("series_id", sc.SeriesID),
-			slog.String("series_title", sc.SeriesTitle),
-		)
-		uc.logger.Info(ctx, "sales_phase_discovery: searching series", seriesAttrs...)
-
-		candidates, err := uc.searcher.SearchSalesPhases(
-			ctx,
-			sc.ArtistName,
-			sc.SeriesTitle,
-			sc.SeriesID,
-		)
+		phaseID, outcome, err := uc.salesPhaseRepo.Upsert(ctx, candidate)
 		if err != nil {
-			uc.logger.Error(ctx, "sales_phase_discovery: searcher failed for series", err, seriesAttrs...)
-			// Non-fatal: continue with the next series.
+			uc.logger.Error(ctx, "sales_phase_discovery: upsert failed", err,
+				append(attrs, slog.String("series_id", candidate.SeriesID),
+					slog.String("apply_start", candidate.ApplyStartTime.Format(time.RFC3339)))...)
 			continue
 		}
-
-		uc.logger.Info(ctx, "sales_phase_discovery: searcher returned candidates",
-			append(seriesAttrs, slog.Int("count", len(candidates)))...)
-
-		for _, candidate := range candidates {
-			phaseID, outcome, err := uc.salesPhaseRepo.Upsert(ctx, candidate)
-			if err != nil {
-				uc.logger.Error(ctx, "sales_phase_discovery: upsert failed", err,
-					append(seriesAttrs, slog.String("apply_start", candidate.ApplyStartTime.Format(time.RFC3339)))...)
-				continue
-			}
-			if outcome == entity.UpsertOutcomeInserted {
-				// Announce only genuinely new phases; re-discovery is silent.
-				uc.publishDiscovered(ctx, phaseID, candidate, seriesAttrs)
-				totalNew++
-			}
+		if outcome == entity.UpsertOutcomeInserted {
+			uc.publishDiscovered(ctx, phaseID, candidate, attrs)
+			totalNew++
 		}
 	}
 
 	uc.logger.Info(ctx, "sales_phase_discovery: complete for artist",
-		append(attrs,
-			slog.Int("series_count", len(order)),
-			slog.Int("new_phases", totalNew),
-		)...)
+		append(attrs, slog.Int("series_count", len(order)), slog.Int("new_phases", totalNew))...)
 	return totalNew, nil
 }
 

--- a/internal/usecase/sales_phase_uc_test.go
+++ b/internal/usecase/sales_phase_uc_test.go
@@ -9,10 +9,22 @@ import (
 	entitymocks "github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/usecase"
 	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/pannpers/go-apperr/apperr/codes"
 	"github.com/pannpers/go-logging/logging"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// discoveryMocks bundles the mocks for the per-artist discovery pipeline.
+type discoveryMocks struct {
+	concertRepo *entitymocks.MockConcertRepository
+	artistRepo  *entitymocks.MockArtistRepository
+	salesRepo   *entitymocks.MockSalesPhaseRepository
+	searcher    *entitymocks.MockSalesPhaseSearcher
+	pub         *ucmocks.MockEventPublisher
+}
 
 func TestSalesPhaseDiscoveryUseCase_DiscoverForArtist(t *testing.T) {
 	t.Parallel()
@@ -23,12 +35,12 @@ func TestSalesPhaseDiscoveryUseCase_DiscoverForArtist(t *testing.T) {
 
 	artist := &entity.Artist{ID: "artist-001", Name: "TestArtist"}
 	seriesID := "series-aaa"
-	eventID := "event-001"
+	officialURL := "https://official.example"
 	t0 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
 
 	upcomingConcert := &entity.Concert{
 		Event: entity.Event{
-			ID:        eventID,
+			ID:        "event-001",
 			SeriesID:  seriesID,
 			LocalDate: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
 		},
@@ -42,20 +54,32 @@ func TestSalesPhaseDiscoveryUseCase_DiscoverForArtist(t *testing.T) {
 		ApplyStartTime: t0,
 	}
 
+	// matchArtistInput verifies the per-artist search input carries the artist,
+	// the seeded official-site URL, and the series ref.
+	matchArtistInput := mock.MatchedBy(func(in *entity.SalesPhaseSearchInput) bool {
+		return in != nil && in.ArtistName == artist.Name && in.OfficialSiteURL == officialURL &&
+			len(in.Series) == 1 && in.Series[0].SeriesID == seriesID
+	})
+
+	// withOfficialSite wires the grounding-seed URL lookup for cases that reach
+	// the searcher.
+	withOfficialSite := func(m *discoveryMocks) {
+		m.artistRepo.On("GetOfficialSite", ctx, artist.ID).Return(&entity.OfficialSite{ArtistID: artist.ID, URL: officialURL}, nil)
+	}
+
 	tests := []struct {
 		name         string
-		setupMocks   func(concertRepo *entitymocks.MockConcertRepository, repo *entitymocks.MockSalesPhaseRepository, searcher *entitymocks.MockSalesPhaseSearcher, pub *ucmocks.MockEventPublisher)
+		setupMocks   func(m *discoveryMocks)
 		wantNewCount int
-		wantErr      error
 	}{
 		{
 			name: "new phase discovered → published once",
-			setupMocks: func(concertRepo *entitymocks.MockConcertRepository, repo *entitymocks.MockSalesPhaseRepository, searcher *entitymocks.MockSalesPhaseSearcher, pub *ucmocks.MockEventPublisher) {
-				concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
-				searcher.On("SearchSalesPhases", ctx, artist.Name, "TestTour 2026", seriesID).
-					Return([]*entity.SalesPhaseCandidate{candidate}, nil)
-				repo.On("Upsert", ctx, candidate).Return("phase-111", entity.UpsertOutcomeInserted, nil)
-				pub.On("PublishEvent", ctx, entity.SubjectSalesPhaseDiscovered, entity.SalesPhaseDiscoveredData{
+			setupMocks: func(m *discoveryMocks) {
+				m.concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
+				withOfficialSite(m)
+				m.searcher.On("SearchSalesPhases", ctx, matchArtistInput).Return([]*entity.SalesPhaseCandidate{candidate}, nil)
+				m.salesRepo.On("Upsert", ctx, candidate).Return("phase-111", entity.UpsertOutcomeInserted, nil)
+				m.pub.On("PublishEvent", ctx, entity.SubjectSalesPhaseDiscovered, entity.SalesPhaseDiscoveredData{
 					PhaseID:  "phase-111",
 					SeriesID: seriesID,
 				}).Return(nil)
@@ -64,39 +88,53 @@ func TestSalesPhaseDiscoveryUseCase_DiscoverForArtist(t *testing.T) {
 		},
 		{
 			name: "re-discovery → update, not re-announced",
-			setupMocks: func(concertRepo *entitymocks.MockConcertRepository, repo *entitymocks.MockSalesPhaseRepository, searcher *entitymocks.MockSalesPhaseSearcher, pub *ucmocks.MockEventPublisher) {
-				concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
-				searcher.On("SearchSalesPhases", ctx, artist.Name, "TestTour 2026", seriesID).
-					Return([]*entity.SalesPhaseCandidate{candidate}, nil)
-				// UpsertOutcomeUpdated → no publish
-				repo.On("Upsert", ctx, candidate).Return("phase-111", entity.UpsertOutcomeUpdated, nil)
-				// pub.PublishEvent must NOT be called
+			setupMocks: func(m *discoveryMocks) {
+				m.concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
+				withOfficialSite(m)
+				m.searcher.On("SearchSalesPhases", ctx, matchArtistInput).Return([]*entity.SalesPhaseCandidate{candidate}, nil)
+				m.salesRepo.On("Upsert", ctx, candidate).Return("phase-111", entity.UpsertOutcomeUpdated, nil)
 			},
 			wantNewCount: 0,
 		},
 		{
-			name: "no upcoming concerts → zero series, zero new phases",
-			setupMocks: func(concertRepo *entitymocks.MockConcertRepository, repo *entitymocks.MockSalesPhaseRepository, searcher *entitymocks.MockSalesPhaseSearcher, pub *ucmocks.MockEventPublisher) {
-				concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{}, nil)
+			name: "no upcoming concerts → zero new phases (no search)",
+			setupMocks: func(m *discoveryMocks) {
+				m.concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{}, nil)
+			},
+			wantNewCount: 0,
+		},
+		{
+			name: "no official site → benign skip, searcher not called",
+			setupMocks: func(m *discoveryMocks) {
+				m.concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
+				m.artistRepo.On("GetOfficialSite", ctx, artist.ID).Return(nil, apperr.New(codes.NotFound, "no official site"))
+			},
+			wantNewCount: 0,
+		},
+		{
+			name: "empty official site URL → benign skip, searcher not called",
+			setupMocks: func(m *discoveryMocks) {
+				m.concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
+				m.artistRepo.On("GetOfficialSite", ctx, artist.ID).Return(&entity.OfficialSite{ArtistID: artist.ID, URL: ""}, nil)
 			},
 			wantNewCount: 0,
 		},
 		{
 			name: "searcher returns empty → nothing upserted",
-			setupMocks: func(concertRepo *entitymocks.MockConcertRepository, repo *entitymocks.MockSalesPhaseRepository, searcher *entitymocks.MockSalesPhaseSearcher, pub *ucmocks.MockEventPublisher) {
-				concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
-				searcher.On("SearchSalesPhases", ctx, artist.Name, "TestTour 2026", seriesID).
-					Return([]*entity.SalesPhaseCandidate{}, nil)
+			setupMocks: func(m *discoveryMocks) {
+				m.concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
+				withOfficialSite(m)
+				m.searcher.On("SearchSalesPhases", ctx, matchArtistInput).Return([]*entity.SalesPhaseCandidate{}, nil)
 			},
 			wantNewCount: 0,
 		},
 		{
 			name: "upsert guard drops candidate → skipped outcome, nothing published",
-			setupMocks: func(concertRepo *entitymocks.MockConcertRepository, repo *entitymocks.MockSalesPhaseRepository, searcher *entitymocks.MockSalesPhaseSearcher, pub *ucmocks.MockEventPublisher) {
-				concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
-				searcher.On("SearchSalesPhases", ctx, artist.Name, "TestTour 2026", seriesID).
-					Return([]*entity.SalesPhaseCandidate{candidate}, nil)
-				repo.On("Upsert", ctx, candidate).Return("", entity.UpsertOutcomeSkipped, nil)
+			setupMocks: func(m *discoveryMocks) {
+				m.concertRepo.On("ListByArtist", ctx, artist.ID, true).Return([]*entity.Concert{upcomingConcert}, nil)
+				withOfficialSite(m)
+				m.searcher.On("SearchSalesPhases", ctx, matchArtistInput).Return([]*entity.SalesPhaseCandidate{candidate}, nil)
+				m.salesRepo.On("Upsert", ctx, candidate).Return("", entity.UpsertOutcomeSkipped, nil)
 			},
 			wantNewCount: 0,
 		},
@@ -106,20 +144,21 @@ func TestSalesPhaseDiscoveryUseCase_DiscoverForArtist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			concertRepo := entitymocks.NewMockConcertRepository(t)
-			repo := entitymocks.NewMockSalesPhaseRepository(t)
-			searcher := entitymocks.NewMockSalesPhaseSearcher(t)
-			pub := ucmocks.NewMockEventPublisher(t)
+			m := &discoveryMocks{
+				concertRepo: entitymocks.NewMockConcertRepository(t),
+				artistRepo:  entitymocks.NewMockArtistRepository(t),
+				salesRepo:   entitymocks.NewMockSalesPhaseRepository(t),
+				searcher:    entitymocks.NewMockSalesPhaseSearcher(t),
+				pub:         ucmocks.NewMockEventPublisher(t),
+			}
+			tt.setupMocks(m)
 
-			tt.setupMocks(concertRepo, repo, searcher, pub)
-
-			uc := usecase.NewSalesPhaseDiscoveryUseCase(concertRepo, repo, searcher, pub, window, logger)
+			uc := usecase.NewSalesPhaseDiscoveryUseCase(
+				m.concertRepo, m.artistRepo, m.salesRepo,
+				m.searcher, m.pub, window, logger,
+			)
 			got, err := uc.DiscoverForArtist(ctx, artist)
 
-			if tt.wantErr != nil {
-				require.ErrorIs(t, err, tt.wantErr)
-				return
-			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantNewCount, got)
 		})


### PR DESCRIPTION
## Why

In the 2026-06-18 prod run the sales-phase searcher fired **one grounded Gemini call per series (99 calls)**, yet `grounding.fired=false` on every call and it produced **0 phases** — because `URLContext` was enabled with **no URL**, so the model answered from memory (per Google's docs, Google Search only fires as a fallback when the model can't answer from its knowledge or a provided URL). Cost was also multiplied by series fragmentation (one Bruno Mars tour split across 31 `series_id`s).

## What changes

- **One grounded call per artist** (not per series): the artist's known upcoming series are passed in, cutting grounding billings ~8× (99 → ~12) and collapsing fragmented duplicate series into a single call.
- **Real grounding via the seeded official-site URL**: the artist's `official_site` URL is put into the prompt and `URLContext` so the model reads the real page instead of memory. An artist **without a usable URL is skipped** (no seed → no value); `NotFound` is a benign skip, only genuine infra errors propagate.
- **Series attribution**: each discovered phase is mapped to one of the artist's known `series_id`s (using title + known event dates); unmappable phases are dropped (never guessed). The series-level `SalesPhase` model and `(series_id, apply_start_time)` upsert are unchanged.
- **No recency window**: the unreliable `timeRangeFilter` ([python-genai#1207](https://github.com/googleapis/python-genai/issues/1207)) is removed and no announcement-date cutoff is used — the official site is a live full-state source and the upsert is idempotent + last-write-wins, so re-reading every run is safe; only the application-window filter (exclude already-closed sales) applies.
- **Gemini instructions rewritten in English** (keeping the Japanese token values the parser maps, e.g. `抽選`/`ファンクラブ`).

## Out of scope / unchanged

- No protobuf/BSR change, no DB schema/migration (the searcher and its types are backend-internal).
- The `Tracking`-journey audience, KEDA delivery wiring, and reminder pipeline are untouched.
- Duplicate-series dedup is a separate effort; artist batching mitigates its cost but does not fix the fragmentation.

## Testing

- `make check` green (build, vet, unit + integration). Updated searcher unit tests (per-artist input, `series_id` attribution incl. unknown-series drop) and discovery use-case tests (artist-batched invocation, no-official-site / empty-URL skip).
- **Grounding efficacy (that `grounding.fired=true` and phases are produced) can only be confirmed against the live Gemini API with the spend cap raised** — verified in prod after release.

Refs: #571
