### PR TITLE
ci: pin govulncheck to v1.3.0 to avoid the @latest generics panic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,11 @@ jobs:
 
       - name: Run govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          # Pinned: govulncheck@latest (v1.4.0, x/tools v0.46.0) panics on
+          # generics — "ForEachElement called on type containing *types.TypeParam".
+          # v1.3.0 (x/tools v0.44.0) predates that crash. Bump deliberately once
+          # upstream fixes the panic.
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck ./...
 
   vulnerability-check-skip:


### PR DESCRIPTION
## Why

The **Vulnerability Check** CI job is failing on every PR repo-wide, independent of the diff. It is not a real vulnerability finding — `govulncheck` itself **panics** during analysis:

```
panic: ForEachElement called on type containing *types.TypeParam
  golang.org/x/tools@v0.46.0/internal/typesinternal/element.go
```

The job runs `go install golang.org/x/vuln/cmd/govulncheck@latest`, and `@latest` recently floated to **v1.4.0**, which depends on **x/tools v0.46.0** — a version that crashes on generic code. Any PR (including ones with no dependency changes) hits this.

## What changes

Pin govulncheck to **v1.3.0** (depends on x/tools **v0.44.0**, before the crashing code path), restoring the last-known-good behaviour. A comment records why and to revert to `@latest` once upstream fixes the panic.

## Testing

- `v1.3.0` resolves to x/tools `v0.44.0`, which does not contain the panicking `ForEachElement` path that `v0.46.0` introduced. CI (Go 1.26.4) will validate the green run.

Refs: #571
