### PR TITLE
fix(di): fail fast when NATS_URL is unset in non-local jobs

### DIFF
--- a/internal/di/job.go
+++ b/internal/di/job.go
@@ -90,6 +90,14 @@ func InitializeJobApp(ctx context.Context) (*JobApp, error) {
 	}
 
 	// Infrastructure - Messaging Publisher
+	//
+	// Fail fast in non-local environments: a missing NATS_URL would silently
+	// route published events to an in-process GoChannel that nothing consumes,
+	// dropping every event. Local development still falls back to the
+	// in-process GoChannel below.
+	if !cfg.IsLocal() && cfg.NATS.URL == "" {
+		return nil, fmt.Errorf("NATS_URL is required for the discovery job in non-local environments")
+	}
 	if err := messaging.EnsureStreams(ctx, cfg.NATS); err != nil {
 		return nil, fmt.Errorf("ensure NATS streams: %w", err)
 	}

--- a/internal/di/sales_phase_discovery_job.go
+++ b/internal/di/sales_phase_discovery_job.go
@@ -67,6 +67,14 @@ func InitializeSalesPhaseDiscoveryJobApp(ctx context.Context) (*SalesPhaseDiscov
 	salesPhaseRepo := rdb.NewSalesPhaseRepository(db)
 
 	// Messaging
+	//
+	// Fail fast in non-local environments: a missing NATS_URL would silently
+	// route published events to an in-process GoChannel that nothing consumes,
+	// dropping every event. Local development still falls back to the
+	// in-process GoChannel below.
+	if !cfg.IsLocal() && cfg.NATS.URL == "" {
+		return nil, fmt.Errorf("NATS_URL is required for the sales-phase-discovery job in non-local environments")
+	}
 	if err := messaging.EnsureStreams(ctx, cfg.NATS); err != nil {
 		return nil, fmt.Errorf("ensure NATS streams: %w", err)
 	}

--- a/internal/di/sales_reminders_job.go
+++ b/internal/di/sales_reminders_job.go
@@ -60,6 +60,14 @@ func InitializeSalesRemindersJobApp(ctx context.Context) (*SalesRemindersJobApp,
 	userRepo := rdb.NewUserRepository(db)
 
 	// Messaging
+	//
+	// Fail fast in non-local environments: a missing NATS_URL would silently
+	// route published events to an in-process GoChannel that nothing consumes,
+	// dropping every event. Local development still falls back to the
+	// in-process GoChannel below.
+	if !cfg.IsLocal() && cfg.NATS.URL == "" {
+		return nil, fmt.Errorf("NATS_URL is required for the sales-reminders job in non-local environments")
+	}
 	if err := messaging.EnsureStreams(ctx, cfg.NATS); err != nil {
 		return nil, fmt.Errorf("ensure NATS streams: %w", err)
 	}


### PR DESCRIPTION
## Why

The event-publishing CronJobs (`concert-discovery`, `sales-phase-discovery`, `sales-reminders`) silently fell back to an **in-process GoChannel** publisher whenever `NATS_URL` was empty. In cloud, an empty `NATS_URL` is a misconfiguration, not a valid mode — every published event (`CONCERT.*`, `SALES_PHASE.*`) is routed to a channel nothing consumes and is lost.

This is the exact failure mode behind the dropped sales-phase notifications: the prod cronjob configmaps were missing `NATS_URL` (fixed in cloud-provisioning #363) and nothing surfaced the problem because the jobs degraded silently instead of crashing.

`ConsumerConfig.Validate()` already guards this for the consumer (`!IsLocal() && NATS.URL == ""`). The job DIs did not. This PR adds the same fail-fast in each publishing job's initializer.

## What

- `internal/di/job.go` (concert-discovery)
- `internal/di/sales_phase_discovery_job.go`
- `internal/di/sales_reminders_job.go`

Each now returns an error on startup when `NATS_URL` is empty outside local, so the misconfiguration is immediately visible (CrashLoopBackOff) rather than silently discarding events. The GoChannel path now only applies in local development, where it is the intended test double. `image-sync` / `merch-discovery` are untouched (they don't publish to NATS).

## Deploy ordering

⚠️ This release MUST go out **after** cloud-provisioning #363 (which adds `NATS_URL` to the sales cronjob configmaps) is merged and synced — otherwise the sales jobs will CrashLoop on the missing variable.

## Verification

- `make check` passes (lint + full test suite).

Refs: #571