### PR TITLE
fix(webpush): set push TTL and high Urgency

### DIFF
--- a/internal/infrastructure/webpush/sender.go
+++ b/internal/infrastructure/webpush/sender.go
@@ -15,6 +15,14 @@ import (
 	"github.com/pannpers/go-apperr/apperr/codes"
 )
 
+// pushTTLSeconds is the Time-To-Live (in seconds) sent to the push service.
+// A non-zero TTL is essential: with TTL=0 (the webpush-go zero value) the push
+// service only delivers if the user agent is connected at that instant and
+// silently drops the message otherwise — yet still returns 201, so the failure
+// is invisible. 24h lets the push service store-and-forward across an offline
+// device (e.g. overnight) so a sales-phase announcement is not missed.
+const pushTTLSeconds = 24 * 60 * 60
+
 // Sender implements entity.PushNotificationSender using the webpush-go library.
 type Sender struct {
 	httpClient     *http.Client
@@ -50,6 +58,8 @@ func (s *Sender) Send(_ context.Context, payload []byte, sub *entity.PushSubscri
 		VAPIDPublicKey:  s.vapidPublicKey,
 		VAPIDPrivateKey: s.vapidPrivate,
 		Subscriber:      s.vapidContact,
+		TTL:             pushTTLSeconds,
+		Urgency:         wpush.UrgencyHigh,
 	})
 
 	if resp != nil {

--- a/internal/infrastructure/webpush/sender_test.go
+++ b/internal/infrastructure/webpush/sender_test.go
@@ -120,3 +120,24 @@ func TestSender_Send(t *testing.T) {
 		})
 	}
 }
+
+// TestSender_Send_DeliveryHeaders asserts the Send request carries a non-zero
+// TTL and a high Urgency so the push service stores and prioritizes the message
+// for offline devices instead of dropping it (the TTL=0 default).
+func TestSender_Send_DeliveryHeaders(t *testing.T) {
+	var gotTTL, gotUrgency string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTTL = r.Header.Get("TTL")
+		gotUrgency = r.Header.Get("Urgency")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	sender := webpush.NewSender("testPublic", "testKey", "mailto:test@example.com")
+	sub := testSubscription(t, server.URL)
+
+	err := sender.Send(context.Background(), []byte("test payload"), sub)
+	assert.NoError(t, err)
+	assert.Equal(t, "86400", gotTTL, "TTL header must be 24h, not the 0 default")
+	assert.Equal(t, "high", gotUrgency, "Urgency header must be high")
+}


### PR DESCRIPTION
## Why

The webpush `Sender.Send` set no `TTL`, so webpush-go sent the HTTP header `TTL: 0`. Per RFC 8030, a zero TTL tells the push service to deliver **only if the user agent is connected at that instant** and to drop the message otherwise — while still returning `201 Created`, so the drop is invisible (no error logged, message acked).

This was observed live: a `SALES_PHASE.discovered` announcement was delivered ~41 minutes late (when the browser reconnected) instead of promptly, and would be dropped entirely for a device offline past the push service's short grace window. For a "never miss a ticket sale" feature this is a real reliability defect.

## What

`internal/infrastructure/webpush/sender.go`:
- `TTL: 86400` (24h) — the push service stores and forwards across an offline window (e.g. overnight).
- `Urgency: wpush.UrgencyHigh` — prioritized delivery for time-sensitive sale alerts.

Added `TestSender_Send_DeliveryHeaders` asserting the outgoing request carries `TTL: 86400` and `Urgency: high`.

## Verification

- `make check` passes (lint + full test suite; new webpush test green).
- End-to-end already confirmed in prod: publish → consumer → audience → Web Push → device. This PR fixes the remaining delivery-timeliness gap.

Refs: #571