### PR TITLE
feat(analytics): emit ticket.journey.status.changed (task 14.1)

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -409,6 +409,60 @@ func (c *AnalyticsConsumer) HandleEntryZkProofRejected(msg *message.Message) err
 	return nil
 }
 
+// HandleTicketJourneyStatusChanged forwards the TICKET_JOURNEY.status_changed
+// NATS subject as the catalogue event
+// usecase.EventTicketJourneyStatusChanged. Properties: event_id,
+// from_status, to_status. from_status is "UNSPECIFIED" when no prior
+// journey existed (first-time SetStatus call for the (user, event) pair).
+func (c *AnalyticsConsumer) HandleTicketJourneyStatusChanged(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.TicketJourneyStatusChangedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse TICKET_JOURNEY.status_changed event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse TICKET_JOURNEY.status_changed event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventTicketJourneyStatusChanged)),
+			slog.String("user_id", data.UserID),
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "TICKET_JOURNEY.status_changed event missing user_id, skipping forward",
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"event_id":    data.EventID,
+		"from_status": data.FromStatus,
+		"to_status":   data.ToStatus,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventTicketJourneyStatusChanged, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventTicketJourneyStatusChanged)),
+			slog.String("user_id", data.UserID),
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
 // recordLag emits analytics_consumer_lag_seconds derived from the
 // CloudEvent's `ce_time` metadata. Missing or unparseable timestamps
 // are silently skipped — the metric is best-effort and downstream

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -813,6 +813,137 @@ func TestAnalyticsConsumer_HandleEntryZkProofRejected(t *testing.T) {
 	}
 }
 
+// TestAnalyticsConsumer_HandleTicketJourneyStatusChanged covers
+// TICKET_JOURNEY.status_changed → ticket.journey.status.changed routing.
+// Properties: event_id, from_status, to_status. from_status is "UNSPECIFIED"
+// when no prior journey existed.
+func TestAnalyticsConsumer_HandleTicketJourneyStatusChanged(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validUserID  = "11111111-2222-3333-4444-555555555555"
+		validEventID = "550e8400-e29b-41d4-a716-446655440000"
+	)
+
+	type args struct {
+		data entity.TicketJourneyStatusChangedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards ticket.journey.status.changed with event_id + from_status + to_status",
+			args: args{data: entity.TicketJourneyStatusChangedData{
+				UserID:     validUserID,
+				EventID:    validEventID,
+				FromStatus: "UNSPECIFIED",
+				ToStatus:   "TRACKING",
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "forwards when from_status is a named status (non-first transition)",
+			args: args{data: entity.TicketJourneyStatusChangedData{
+				UserID:     validUserID,
+				EventID:    validEventID,
+				FromStatus: "TRACKING",
+				ToStatus:   "APPLIED",
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.TicketJourneyStatusChangedData{
+				UserID:     validUserID,
+				EventID:    validEventID,
+				FromStatus: "UNSPECIFIED",
+				ToStatus:   "TRACKING",
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.TicketJourneyStatusChangedData{
+				UserID:     "",
+				EventID:    validEventID,
+				FromStatus: "UNSPECIFIED",
+				ToStatus:   "TRACKING",
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.TicketJourneyStatusChangedData{
+				UserID:     validUserID,
+				EventID:    validEventID,
+				FromStatus: "UNPAID",
+				ToStatus:   "PAID",
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventTicketJourneyStatusChanged,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["event_id"] == tt.args.data.EventID &&
+									props["from_status"] == tt.args.data.FromStatus &&
+									props["to_status"] == tt.args.data.ToStatus
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleTicketJourneyStatusChanged(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // TestAnalyticsConsumer_HandleUserCreated_BadPayload covers the
 // CloudEvent decode failure path separately because constructing an
 // invalid JSON payload with the same table shape would obscure the

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -282,6 +282,13 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	)
 
 	router.AddConsumerHandler(
+		"forward-ticket-journey-status-changed-to-analytics",
+		entity.SubjectTicketJourneyStatusChanged,
+		subscriber,
+		analyticsConsumer.HandleTicketJourneyStatusChanged,
+	)
+
+	router.AddConsumerHandler(
 		"log-poison-queue",
 		messaging.PoisonQueueSubject,
 		subscriber,

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -196,7 +196,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	concertUC := usecase.NewConcertUseCase(artistRepo, concertRepo, venueRepo, seriesRepo, searchLogRepo, stagedConcertRepo, rejectedConcertRepo, geminiSearcher, centroidResolver, eventPublisher, businessMetrics, cfg.GCP.SearchCacheTTL(), cfg.GCP.SearchDiscoveryWindow(), logger)
 	artistUC := usecase.NewArtistUseCase(artistRepo, lastfmClient, musicbrainzClient, eventPublisher, artistCache, logger)
 	followUC := usecase.NewFollowUseCase(followRepo, artistRepo, musicbrainzClient, concertUC, searchLogRepo, eventPublisher, businessMetrics, logger)
-	ticketJourneyUC := usecase.NewTicketJourneyUseCase(ticketJourneyRepo, logger)
+	ticketJourneyUC := usecase.NewTicketJourneyUseCase(ticketJourneyRepo, eventPublisher, logger)
 	var ticketEmailUC usecase.TicketEmailUseCase
 	if emailParser != nil {
 		ticketEmailUC = usecase.NewTicketEmailUseCase(ticketEmailRepo, ticketJourneyRepo, emailParser, logger)

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -25,6 +25,11 @@ const (
 	// SubjectSalesPhaseReminderDue is published by the reminder scan for each
 	// (user, phase, stage) triple that became due and has not yet been sent.
 	SubjectSalesPhaseReminderDue = "SALES_PHASE.reminder.due"
+	// SubjectTicketJourneyStatusChanged is published by SetStatus after a
+	// successful upsert when the new status differs from the prior one (or
+	// when no prior journey existed). It drives the
+	// ticket.journey.status.changed analytics event.
+	SubjectTicketJourneyStatusChanged = "TICKET_JOURNEY.status_changed"
 )
 
 // EntryRejectionReason enumerates the legitimate causes for a
@@ -192,4 +197,23 @@ type SalesPhaseReminderDueData struct {
 	// Built per-recipient so times render in the user's timezone and copy
 	// is selected by preferred_language.
 	Payload *NotificationPayload `json:"payload"`
+}
+
+// TicketJourneyStatusChangedData is the payload for TICKET_JOURNEY.status_changed.
+// Mapped to the catalogue event ticket.journey.status.changed by the
+// analytics-consumer. Published by TicketJourneyUseCase.SetStatus after a
+// successful upsert when the incoming status differs from the stored one.
+// When no prior journey existed, FromStatus is "UNSPECIFIED" (the zero-value
+// sentinel of TicketJourneyStatus.String()).
+type TicketJourneyStatusChangedData struct {
+	// UserID is the platform-internal user identifier of the fan.
+	// Used as the PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// EventID is the internal UUID of the live event being tracked.
+	EventID string `json:"event_id"`
+	// FromStatus is the TicketJourneyStatus name before the change, or
+	// "UNSPECIFIED" when the journey did not exist prior to this call.
+	FromStatus string `json:"from_status"`
+	// ToStatus is the TicketJourneyStatus name after the successful upsert.
+	ToStatus string `json:"to_status"`
 }

--- a/internal/entity/mocks/mock_TicketJourneyRepository.go
+++ b/internal/entity/mocks/mock_TicketJourneyRepository.go
@@ -70,6 +70,66 @@ func (_c *MockTicketJourneyRepository_Delete_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// Get provides a mock function with given fields: ctx, userID, eventID
+func (_m *MockTicketJourneyRepository) Get(ctx context.Context, userID string, eventID string) (*entity.TicketJourney, error) {
+	ret := _m.Called(ctx, userID, eventID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
+
+	var r0 *entity.TicketJourney
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*entity.TicketJourney, error)); ok {
+		return rf(ctx, userID, eventID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *entity.TicketJourney); ok {
+		r0 = rf(ctx, userID, eventID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entity.TicketJourney)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, userID, eventID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTicketJourneyRepository_Get_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Get'
+type MockTicketJourneyRepository_Get_Call struct {
+	*mock.Call
+}
+
+// Get is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+//   - eventID string
+func (_e *MockTicketJourneyRepository_Expecter) Get(ctx interface{}, userID interface{}, eventID interface{}) *MockTicketJourneyRepository_Get_Call {
+	return &MockTicketJourneyRepository_Get_Call{Call: _e.mock.On("Get", ctx, userID, eventID)}
+}
+
+func (_c *MockTicketJourneyRepository_Get_Call) Run(run func(ctx context.Context, userID string, eventID string)) *MockTicketJourneyRepository_Get_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockTicketJourneyRepository_Get_Call) Return(_a0 *entity.TicketJourney, _a1 error) *MockTicketJourneyRepository_Get_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTicketJourneyRepository_Get_Call) RunAndReturn(run func(context.Context, string, string) (*entity.TicketJourney, error)) *MockTicketJourneyRepository_Get_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListByUser provides a mock function with given fields: ctx, userID
 func (_m *MockTicketJourneyRepository) ListByUser(ctx context.Context, userID string) ([]*entity.TicketJourney, error) {
 	ret := _m.Called(ctx, userID)

--- a/internal/entity/ticket_journey.go
+++ b/internal/entity/ticket_journey.go
@@ -18,6 +18,26 @@ const (
 	TicketJourneyStatusPaid TicketJourneyStatus = 5
 )
 
+// String returns the lowercase name of the status for use in analytics event
+// properties. The zero value (no prior journey) returns "UNSPECIFIED" as the
+// sentinel used by the ticket.journey.status.changed event's from_status field.
+func (s TicketJourneyStatus) String() string {
+	switch s {
+	case TicketJourneyStatusTracking:
+		return "TRACKING"
+	case TicketJourneyStatusApplied:
+		return "APPLIED"
+	case TicketJourneyStatusLost:
+		return "LOST"
+	case TicketJourneyStatusUnpaid:
+		return "UNPAID"
+	case TicketJourneyStatusPaid:
+		return "PAID"
+	default:
+		return "UNSPECIFIED"
+	}
+}
+
 // IsValid reports whether s is a recognized TicketJourneyStatus value.
 func (s TicketJourneyStatus) IsValid() bool {
 	return s >= TicketJourneyStatusTracking && s <= TicketJourneyStatusPaid
@@ -35,6 +55,14 @@ type TicketJourney struct {
 
 // TicketJourneyRepository defines the persistence layer operations for ticket journeys.
 type TicketJourneyRepository interface {
+	// Get retrieves the ticket journey for the given user and event.
+	//
+	// # Possible errors:
+	//
+	//   - NotFound: no journey exists for the (userID, eventID) pair.
+	//   - Internal: database query failure.
+	Get(ctx context.Context, userID, eventID string) (*TicketJourney, error)
+
 	// Upsert creates or updates a ticket journey for the given user and event.
 	//
 	// # Possible errors:

--- a/internal/infrastructure/analytics/posthog/posthog_feature_flags.go
+++ b/internal/infrastructure/analytics/posthog/posthog_feature_flags.go
@@ -27,7 +27,7 @@ const defaultFlagPollingInterval = 5 * time.Minute
 // implementing the full posthog.Client surface, mirroring the enqueuer
 // pattern in posthog_client.go.
 type flagEvaluator interface {
-	GetFeatureFlag(posthogsdk.FeatureFlagPayload) (interface{}, error)
+	GetFeatureFlag(posthogsdk.FeatureFlagPayload) (any, error)
 	Close() error
 }
 

--- a/internal/infrastructure/analytics/posthog/posthog_feature_flags_test.go
+++ b/internal/infrastructure/analytics/posthog/posthog_feature_flags_test.go
@@ -19,14 +19,14 @@ import (
 // the Close path. It satisfies posthog.FlagEvaluator.
 type fakeFlagEvaluator struct {
 	mu         sync.Mutex
-	result     interface{}
+	result     any
 	getErr     error
 	getCalls   int
 	closeErr   error
 	closeCalls int
 }
 
-func (f *fakeFlagEvaluator) GetFeatureFlag(posthogsdk.FeatureFlagPayload) (interface{}, error) {
+func (f *fakeFlagEvaluator) GetFeatureFlag(posthogsdk.FeatureFlagPayload) (any, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.getCalls++
@@ -141,7 +141,7 @@ func TestFeatureFlagEvaluator_IsEnabled(t *testing.T) {
 		key        string
 		distinctID string
 		def        bool
-		result     interface{}
+		result     any
 		getErr     error
 		want       bool
 		wantCalls  int
@@ -195,7 +195,7 @@ func TestFeatureFlagEvaluator_Variant(t *testing.T) {
 		key        string
 		distinctID string
 		def        string
-		result     interface{}
+		result     any
 		getErr     error
 		want       string
 		wantCalls  int

--- a/internal/infrastructure/database/rdb/ticket_journey_repo.go
+++ b/internal/infrastructure/database/rdb/ticket_journey_repo.go
@@ -18,6 +18,11 @@ type TicketJourneyRepository struct {
 var _ entity.TicketJourneyRepository = (*TicketJourneyRepository)(nil)
 
 const (
+	ticketJourneyGetQuery = `
+		SELECT event_id, status
+		FROM ticket_journeys
+		WHERE user_id = $1 AND event_id = $2
+	`
 	ticketJourneyUpsertQuery = `
 		INSERT INTO ticket_journeys (user_id, event_id, status)
 		VALUES ($1, $2, $3)
@@ -47,6 +52,25 @@ const (
 // NewTicketJourneyRepository creates a new ticket journey repository instance.
 func NewTicketJourneyRepository(db *Database) *TicketJourneyRepository {
 	return &TicketJourneyRepository{db: db}
+}
+
+// Get retrieves a single ticket journey by user and event IDs.
+// Returns apperr.ErrNotFound when no journey exists for the pair.
+func (r *TicketJourneyRepository) Get(ctx context.Context, userID, eventID string) (*entity.TicketJourney, error) {
+	row := r.db.Pool.QueryRow(ctx, ticketJourneyGetQuery, userID, eventID)
+	var gotEventID string
+	var status int16
+	if err := row.Scan(&gotEventID, &status); err != nil {
+		return nil, toAppErr(err, "failed to get ticket journey",
+			slog.String("user_id", userID),
+			slog.String("event_id", eventID),
+		)
+	}
+	return &entity.TicketJourney{
+		UserID:  userID,
+		EventID: gotEventID,
+		Status:  entity.TicketJourneyStatus(status),
+	}, nil
 }
 
 // Upsert creates or updates a ticket journey for the given user and event.

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -59,7 +59,7 @@ const (
 	EventConcertRecommendationServed AnalyticsEventName = "concert.recommendation.served"
 )
 
-// Ticket lottery and purchase events emitted from the backend.
+// Ticket journey and purchase events emitted from the backend.
 const (
 	// EventTicketLotteryEntryAccepted is recorded after a lottery entry
 	// passes validation and is persisted. Paired with the frontend
@@ -84,6 +84,13 @@ const (
 	// EventTicketPurchaseFailed is recorded when a purchase attempt is
 	// rejected by the payment provider or backend validation.
 	EventTicketPurchaseFailed AnalyticsEventName = "ticket.purchase.failed"
+
+	// EventTicketJourneyStatusChanged is recorded after a fan's ticket
+	// journey status is successfully updated via SetStatus. It is
+	// suppressed when the incoming status equals the stored status
+	// (no-op upsert) to avoid noise in downstream funnels.
+	// Properties: event_id, from_status, to_status.
+	EventTicketJourneyStatusChanged AnalyticsEventName = "ticket.journey.status.changed"
 )
 
 // Entry verification events emitted from the backend, including the
@@ -134,6 +141,7 @@ var knownBackendEvents = map[AnalyticsEventName]struct{}{
 	EventTicketLotteryResultAssigned:     {},
 	EventTicketPurchaseCompleted:         {},
 	EventTicketPurchaseFailed:            {},
+	EventTicketJourneyStatusChanged:      {},
 	EventEntryZkProofVerified:            {},
 	EventEntryZkProofRejected:            {},
 	EventNotificationSubscribed:          {},

--- a/internal/usecase/ticket_journey_uc.go
+++ b/internal/usecase/ticket_journey_uc.go
@@ -2,9 +2,13 @@ package usecase
 
 import (
 	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/pannpers/go-logging/logging"
 
 	"github.com/liverty-music/backend/internal/entity"
-	"github.com/pannpers/go-logging/logging"
 )
 
 // TicketJourneyUseCase defines the interface for ticket journey business logic.
@@ -34,28 +38,74 @@ type TicketJourneyUseCase interface {
 
 // ticketJourneyUseCase implements the TicketJourneyUseCase interface.
 type ticketJourneyUseCase struct {
-	repo   entity.TicketJourneyRepository
-	logger *logging.Logger
+	repo      entity.TicketJourneyRepository
+	publisher EventPublisher
+	logger    *logging.Logger
 }
+
+// Compile-time interface compliance check.
+var _ TicketJourneyUseCase = (*ticketJourneyUseCase)(nil)
 
 // NewTicketJourneyUseCase creates a new ticket journey use case.
 func NewTicketJourneyUseCase(
 	repo entity.TicketJourneyRepository,
+	publisher EventPublisher,
 	logger *logging.Logger,
 ) TicketJourneyUseCase {
 	return &ticketJourneyUseCase{
-		repo:   repo,
-		logger: logger,
+		repo:      repo,
+		publisher: publisher,
+		logger:    logger,
 	}
 }
 
 // SetStatus creates or updates a ticket journey.
+//
+// Before the upsert, it reads the current stored status to detect whether a
+// meaningful change is occurring. The TICKET_JOURNEY.status_changed analytics
+// event is published only when the new status differs from the prior one (or
+// when no prior journey existed). Publishing is non-fatal — a failure is
+// logged but does not roll back the already-persisted upsert.
 func (uc *ticketJourneyUseCase) SetStatus(ctx context.Context, userID, eventID string, status entity.TicketJourneyStatus) error {
-	return uc.repo.Upsert(ctx, &entity.TicketJourney{
+	// Capture the current status before the upsert so we can detect a change.
+	var fromStatus entity.TicketJourneyStatus // zero value = UNSPECIFIED sentinel
+	existing, err := uc.repo.Get(ctx, userID, eventID)
+	if err != nil && !errors.Is(err, apperr.ErrNotFound) {
+		return err
+	}
+	if existing != nil {
+		fromStatus = existing.Status
+	}
+
+	if err := uc.repo.Upsert(ctx, &entity.TicketJourney{
 		UserID:  userID,
 		EventID: eventID,
 		Status:  status,
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Publish only when status actually changed to avoid noise.
+	if fromStatus == status {
+		return nil
+	}
+
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectTicketJourneyStatusChanged, entity.TicketJourneyStatusChangedData{
+		UserID:     userID,
+		EventID:    eventID,
+		FromStatus: fromStatus.String(),
+		ToStatus:   status.String(),
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish TICKET_JOURNEY.status_changed event", err,
+			slog.String("user_id", userID),
+			slog.String("event_id", eventID),
+			slog.String("from_status", fromStatus.String()),
+			slog.String("to_status", status.String()),
+		)
+		// Non-fatal: the upsert is already persisted.
+	}
+
+	return nil
 }
 
 // Delete removes a ticket journey.

--- a/internal/usecase/ticket_journey_uc_test.go
+++ b/internal/usecase/ticket_journey_uc_test.go
@@ -2,26 +2,32 @@ package usecase_test
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/usecase"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 )
 
 type ticketJourneyTestDeps struct {
-	repo *mocks.MockTicketJourneyRepository
-	uc   usecase.TicketJourneyUseCase
+	repo      *mocks.MockTicketJourneyRepository
+	publisher *ucmocks.MockEventPublisher
+	uc        usecase.TicketJourneyUseCase
 }
 
 func newTicketJourneyTestDeps(t *testing.T) *ticketJourneyTestDeps {
 	t.Helper()
 	d := &ticketJourneyTestDeps{
-		repo: mocks.NewMockTicketJourneyRepository(t),
+		repo:      mocks.NewMockTicketJourneyRepository(t),
+		publisher: ucmocks.NewMockEventPublisher(t),
 	}
-	d.uc = usecase.NewTicketJourneyUseCase(d.repo, newTestLogger(t))
+	d.uc = usecase.NewTicketJourneyUseCase(d.repo, d.publisher, newTestLogger(t))
 	return d
 }
 
@@ -39,19 +45,138 @@ func TestTicketJourneyUseCase_SetStatus(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "successfully sets status",
+			name:    "publishes status_changed when no prior journey exists (new tracking)",
 			userID:  "user-1",
 			eventID: "event-1",
 			status:  entity.TicketJourneyStatusTracking,
 			setup: func(t *testing.T, d *ticketJourneyTestDeps) {
 				t.Helper()
 				d.repo.EXPECT().
+					Get(ctx, "user-1", "event-1").
+					Return(nil, apperr.ErrNotFound).
+					Once()
+				d.repo.EXPECT().
 					Upsert(ctx, mock.MatchedBy(func(j *entity.TicketJourney) bool {
 						return j.UserID == "user-1" && j.EventID == "event-1" && j.Status == entity.TicketJourneyStatusTracking
 					})).
 					Return(nil).
 					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectTicketJourneyStatusChanged, mock.MatchedBy(func(data entity.TicketJourneyStatusChangedData) bool {
+						return data.UserID == "user-1" &&
+							data.EventID == "event-1" &&
+							data.FromStatus == "UNSPECIFIED" &&
+							data.ToStatus == "TRACKING"
+					})).
+					Return(nil).
+					Once()
 			},
+		},
+		{
+			name:    "publishes status_changed when status transitions from tracking to applied",
+			userID:  "user-1",
+			eventID: "event-1",
+			status:  entity.TicketJourneyStatusApplied,
+			setup: func(t *testing.T, d *ticketJourneyTestDeps) {
+				t.Helper()
+				d.repo.EXPECT().
+					Get(ctx, "user-1", "event-1").
+					Return(&entity.TicketJourney{
+						UserID:  "user-1",
+						EventID: "event-1",
+						Status:  entity.TicketJourneyStatusTracking,
+					}, nil).
+					Once()
+				d.repo.EXPECT().
+					Upsert(ctx, mock.Anything).
+					Return(nil).
+					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectTicketJourneyStatusChanged, mock.MatchedBy(func(data entity.TicketJourneyStatusChangedData) bool {
+						return data.FromStatus == "TRACKING" && data.ToStatus == "APPLIED"
+					})).
+					Return(nil).
+					Once()
+			},
+		},
+		{
+			name:    "does not publish when status is unchanged (no-op upsert)",
+			userID:  "user-1",
+			eventID: "event-1",
+			status:  entity.TicketJourneyStatusTracking,
+			setup: func(t *testing.T, d *ticketJourneyTestDeps) {
+				t.Helper()
+				d.repo.EXPECT().
+					Get(ctx, "user-1", "event-1").
+					Return(&entity.TicketJourney{
+						UserID:  "user-1",
+						EventID: "event-1",
+						Status:  entity.TicketJourneyStatusTracking,
+					}, nil).
+					Once()
+				d.repo.EXPECT().
+					Upsert(ctx, mock.Anything).
+					Return(nil).
+					Once()
+				// publisher MUST NOT be called — no EXPECT() registered
+			},
+		},
+		{
+			name:    "publish error is non-fatal — SetStatus returns nil",
+			userID:  "user-2",
+			eventID: "event-2",
+			status:  entity.TicketJourneyStatusPaid,
+			setup: func(t *testing.T, d *ticketJourneyTestDeps) {
+				t.Helper()
+				d.repo.EXPECT().
+					Get(ctx, "user-2", "event-2").
+					Return(&entity.TicketJourney{
+						UserID:  "user-2",
+						EventID: "event-2",
+						Status:  entity.TicketJourneyStatusUnpaid,
+					}, nil).
+					Once()
+				d.repo.EXPECT().
+					Upsert(ctx, mock.Anything).
+					Return(nil).
+					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectTicketJourneyStatusChanged, mock.Anything).
+					Return(errors.New("nats unavailable")).
+					Once()
+			},
+		},
+		{
+			name:    "returns error when Get fails with non-NotFound error",
+			userID:  "user-3",
+			eventID: "event-3",
+			status:  entity.TicketJourneyStatusTracking,
+			setup: func(t *testing.T, d *ticketJourneyTestDeps) {
+				t.Helper()
+				d.repo.EXPECT().
+					Get(ctx, "user-3", "event-3").
+					Return(nil, apperr.ErrInternal).
+					Once()
+			},
+			wantErr: apperr.ErrInternal,
+		},
+		{
+			name:    "returns error when Upsert fails",
+			userID:  "user-4",
+			eventID: "event-4",
+			status:  entity.TicketJourneyStatusTracking,
+			setup: func(t *testing.T, d *ticketJourneyTestDeps) {
+				t.Helper()
+				d.repo.EXPECT().
+					Get(ctx, "user-4", "event-4").
+					Return(nil, apperr.ErrNotFound).
+					Once()
+				d.repo.EXPECT().
+					Upsert(ctx, mock.Anything).
+					Return(apperr.ErrInternal).
+					Once()
+			},
+			wantErr: apperr.ErrInternal,
 		},
 	}
 
@@ -135,5 +260,4 @@ func TestTicketJourneyUseCase_ListByUser(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, result)
 	})
-
 }


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/specification#532

## 📝 Summary of Changes

Implements OpenSpec task **14.1** of `introduce-analytics-tool`: emit `ticket.journey.status.changed` for the interest-tier engagement funnel.

- **Motivation**: the TicketJourney interest-tier progression (a user marking a concert TRACKING / APPLIED / PAID …) was a catalogued analytics event with **no publisher**, so the engagement-depth funnel had no signal.
- **Approach** (mirrors the existing artist-follow analytics path end-to-end):
  - `TicketJourneyUseCase.SetStatus` reads the prior status (new `TicketJourneyRepository.Get`), and **only when the status actually changes** publishes the `TICKET_JOURNEY.status_changed` NATS event. Publishing is **non-fatal** — a NATS/PostHog hiccup never rolls back the persisted journey.
  - The `analytics-consumer` forwards it to PostHog as `ticket.journey.status.changed` with `{event_id, from_status, to_status}`, attributed to the user's `UserId`; non-blocking, with the same metrics/error handling as the other handlers.
  - A newly-created journey reports `from_status = UNSPECIFIED`.
  - New `EventTicketJourneyStatusChanged` constant (+ `IsKnownEvent`); the catalogue already documented this event, so no spec change.
- Establishes the reusable **publisher + forwarder template** for the remaining backend event-coverage tasks (14.2–14.6).
- Drive-by: `interface{}` → `any` in the feature-flag adapter (`go fix`), which a newer `make check` `modernize` gate now requires.

## Type of Change
- [x] feat: A new feature

## Verification
- [x] `make check` passed locally (lint + `modernize` + golangci-lint + integration tests via docker postgres).
- [x] New tests: `SetStatus` publish-on-change / no-publish-on-noop / non-fatal-publish-error / Get-error-fatal; consumer `HandleTicketJourneyStatusChanged` forward + UID-validation + enqueue-error cases.

## Self-Checklist
- [x] Follows Clean Architecture layer boundaries (entity / usecase / infra / adapter / di).
- [x] `apperr` error handling; publisher non-fatal, consumer non-blocking.
- [x] Mocks regenerated via `mockery`; named-column SQL with `$1/$2` placeholders.
