### PR TITLE
feat(analytics): emit ticket.mint.completed + ticket.email.parsed (14.6, 14.2)

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -463,6 +463,108 @@ func (c *AnalyticsConsumer) HandleTicketJourneyStatusChanged(msg *message.Messag
 	return nil
 }
 
+// HandleTicketMintCompleted forwards the TICKET.mint_completed NATS subject
+// as the catalogue event usecase.EventTicketMintCompleted. Properties:
+// event_id. The distinct_id is the platform UserID from the payload.
+func (c *AnalyticsConsumer) HandleTicketMintCompleted(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.TicketMintCompletedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse TICKET.mint_completed event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse TICKET.mint_completed event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventTicketMintCompleted)),
+			slog.String("user_id", data.UserID),
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "TICKET.mint_completed event missing user_id, skipping forward",
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"event_id": data.EventID,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventTicketMintCompleted, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventTicketMintCompleted)),
+			slog.String("user_id", data.UserID),
+			slog.String("event_id", data.EventID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
+// HandleTicketEmailParsed forwards the TICKET_EMAIL.parsed NATS subject as
+// the catalogue event usecase.EventTicketEmailParsed. Properties: email_type,
+// parse_status, field_count. Emitted on both success and failure paths so
+// email-ingestion data quality and parser robustness are measurable in PostHog.
+func (c *AnalyticsConsumer) HandleTicketEmailParsed(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.TicketEmailParsedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse TICKET_EMAIL.parsed event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse TICKET_EMAIL.parsed event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventTicketEmailParsed)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "TICKET_EMAIL.parsed event missing user_id, skipping forward",
+			slog.String("email_type", data.EmailType),
+			slog.String("parse_status", data.ParseStatus),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"email_type":   data.EmailType,
+		"parse_status": data.ParseStatus,
+		"field_count":  data.FieldCount,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventTicketEmailParsed, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventTicketEmailParsed)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
 // recordLag emits analytics_consumer_lag_seconds derived from the
 // CloudEvent's `ce_time` metadata. Missing or unparseable timestamps
 // are silently skipped — the metric is best-effort and downstream

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -944,6 +944,244 @@ func TestAnalyticsConsumer_HandleTicketJourneyStatusChanged(t *testing.T) {
 	}
 }
 
+// TestAnalyticsConsumer_HandleTicketMintCompleted covers
+// TICKET.mint_completed → ticket.mint.completed routing.
+// Property: event_id. Distinct_id is the platform UserID.
+func TestAnalyticsConsumer_HandleTicketMintCompleted(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validUserID  = "11111111-2222-3333-4444-555555555555"
+		validEventID = "550e8400-e29b-41d4-a716-446655440000"
+	)
+
+	type args struct {
+		data entity.TicketMintCompletedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards ticket.mint.completed with event_id property",
+			args: args{data: entity.TicketMintCompletedData{
+				UserID:  validUserID,
+				EventID: validEventID,
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.TicketMintCompletedData{
+				UserID:  validUserID,
+				EventID: validEventID,
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.TicketMintCompletedData{
+				UserID:  "",
+				EventID: validEventID,
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.TicketMintCompletedData{
+				UserID:  validUserID,
+				EventID: validEventID,
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventTicketMintCompleted,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["event_id"] == tt.args.data.EventID
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleTicketMintCompleted(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestAnalyticsConsumer_HandleTicketEmailParsed covers
+// TICKET_EMAIL.parsed → ticket.email.parsed routing.
+// Properties: email_type, parse_status, field_count.
+// Emitted on both success and failure parser outcomes.
+func TestAnalyticsConsumer_HandleTicketEmailParsed(t *testing.T) {
+	t.Parallel()
+
+	const validUserID = "11111111-2222-3333-4444-555555555555"
+
+	type args struct {
+		data entity.TicketEmailParsedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards ticket.email.parsed with all three properties on success",
+			args: args{data: entity.TicketEmailParsedData{
+				UserID:      validUserID,
+				EmailType:   "LOTTERY_INFO",
+				ParseStatus: "success",
+				FieldCount:  4,
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "forwards ticket.email.parsed with field_count=0 on failure",
+			args: args{data: entity.TicketEmailParsedData{
+				UserID:      validUserID,
+				EmailType:   "LOTTERY_RESULT",
+				ParseStatus: "failure",
+				FieldCount:  0,
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.TicketEmailParsedData{
+				UserID:      validUserID,
+				EmailType:   "LOTTERY_INFO",
+				ParseStatus: "success",
+				FieldCount:  2,
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.TicketEmailParsedData{
+				UserID:      "",
+				EmailType:   "LOTTERY_INFO",
+				ParseStatus: "success",
+				FieldCount:  1,
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.TicketEmailParsedData{
+				UserID:      validUserID,
+				EmailType:   "LOTTERY_INFO",
+				ParseStatus: "success",
+				FieldCount:  3,
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventTicketEmailParsed,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["email_type"] == tt.args.data.EmailType &&
+									props["parse_status"] == tt.args.data.ParseStatus &&
+									props["field_count"] == tt.args.data.FieldCount
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleTicketEmailParsed(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // TestAnalyticsConsumer_HandleUserCreated_BadPayload covers the
 // CloudEvent decode failure path separately because constructing an
 // invalid JSON payload with the same table shape would obscure the

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -289,6 +289,20 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	)
 
 	router.AddConsumerHandler(
+		"forward-ticket-mint-completed-to-analytics",
+		entity.SubjectTicketMintCompleted,
+		subscriber,
+		analyticsConsumer.HandleTicketMintCompleted,
+	)
+
+	router.AddConsumerHandler(
+		"forward-ticket-email-parsed-to-analytics",
+		entity.SubjectTicketEmailParsed,
+		subscriber,
+		analyticsConsumer.HandleTicketEmailParsed,
+	)
+
+	router.AddConsumerHandler(
 		"log-poison-queue",
 		messaging.PoisonQueueSubject,
 		subscriber,

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -137,28 +137,6 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	// Initialize the shutdown package for phased resource teardown.
 	shutdown.Init(logger)
 
-	// Infrastructure - Blockchain (optional; skipped when config is absent)
-	var ticketUC usecase.TicketUseCase
-	var sbtCloser io.Closer
-	if cfg.Blockchain.RPCURL != "" && cfg.Blockchain.DeployerPrivateKey != "" && cfg.Blockchain.TicketSBTAddress != "" {
-		sbtClient, err := ticketsbt.NewClient(
-			ctx,
-			cfg.Blockchain.RPCURL,
-			cfg.Blockchain.DeployerPrivateKey,
-			cfg.Blockchain.TicketSBTAddress,
-			cfg.Blockchain.ChainID,
-			logger,
-		)
-		if err != nil {
-			return nil, err
-		}
-		sbtCloser = sbtClient
-		ticketUC = usecase.NewTicketUseCase(ticketRepo, sbtClient, infratelemetry.NewOTelMintMetrics(), logger)
-	} else {
-		logger.Warn(ctx, "⚠️  Blockchain config absent, ticket minting is disabled")
-		_ = ticketRepo // referenced when blockchain is enabled; suppress unused warning
-	}
-
 	// Infrastructure - Messaging Publisher
 	if err := messaging.EnsureStreams(ctx, cfg.NATS); err != nil {
 		return nil, fmt.Errorf("ensure NATS streams: %w", err)
@@ -191,6 +169,29 @@ func InitializeApp(ctx context.Context) (*App, error) {
 
 	// Use Cases
 	eventPublisher := messaging.NewEventPublisher(publisher)
+
+	// Infrastructure - Blockchain (optional; skipped when config is absent)
+	var ticketUC usecase.TicketUseCase
+	var sbtCloser io.Closer
+	if cfg.Blockchain.RPCURL != "" && cfg.Blockchain.DeployerPrivateKey != "" && cfg.Blockchain.TicketSBTAddress != "" {
+		sbtClient, err := ticketsbt.NewClient(
+			ctx,
+			cfg.Blockchain.RPCURL,
+			cfg.Blockchain.DeployerPrivateKey,
+			cfg.Blockchain.TicketSBTAddress,
+			cfg.Blockchain.ChainID,
+			logger,
+		)
+		if err != nil {
+			return nil, err
+		}
+		sbtCloser = sbtClient
+		ticketUC = usecase.NewTicketUseCase(ticketRepo, sbtClient, infratelemetry.NewOTelMintMetrics(), eventPublisher, logger)
+	} else {
+		logger.Warn(ctx, "⚠️  Blockchain config absent, ticket minting is disabled")
+		_ = ticketRepo // referenced when blockchain is enabled; suppress unused warning
+	}
+
 	userUC := usecase.NewUserUseCase(userRepo, eventPublisher, logger)
 	centroidResolver := geo.NewCentroidResolver()
 	concertUC := usecase.NewConcertUseCase(artistRepo, concertRepo, venueRepo, seriesRepo, searchLogRepo, stagedConcertRepo, rejectedConcertRepo, geminiSearcher, centroidResolver, eventPublisher, businessMetrics, cfg.GCP.SearchCacheTTL(), cfg.GCP.SearchDiscoveryWindow(), logger)
@@ -199,7 +200,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	ticketJourneyUC := usecase.NewTicketJourneyUseCase(ticketJourneyRepo, eventPublisher, logger)
 	var ticketEmailUC usecase.TicketEmailUseCase
 	if emailParser != nil {
-		ticketEmailUC = usecase.NewTicketEmailUseCase(ticketEmailRepo, ticketJourneyRepo, emailParser, logger)
+		ticketEmailUC = usecase.NewTicketEmailUseCase(ticketEmailRepo, ticketJourneyRepo, emailParser, eventPublisher, logger)
 	} else {
 		_ = ticketEmailRepo // referenced when email parser is enabled; suppress unused warning
 	}

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -30,6 +30,16 @@ const (
 	// when no prior journey existed). It drives the
 	// ticket.journey.status.changed analytics event.
 	SubjectTicketJourneyStatusChanged = "TICKET_JOURNEY.status_changed"
+	// SubjectTicketMintCompleted is published by TicketUseCase.MintTicket after
+	// a ticket is successfully minted and persisted. It drives the
+	// ticket.mint.completed analytics event (SBT issuance / ticket-activation
+	// funnel).
+	SubjectTicketMintCompleted = "TICKET.mint_completed"
+	// SubjectTicketEmailParsed is published by TicketEmailUseCase.Create on
+	// both parse-success and parse-failure paths. It drives the
+	// ticket.email.parsed analytics event (email-ingestion data quality,
+	// parser robustness).
+	SubjectTicketEmailParsed = "TICKET_EMAIL.parsed"
 )
 
 // EntryRejectionReason enumerates the legitimate causes for a
@@ -197,6 +207,39 @@ type SalesPhaseReminderDueData struct {
 	// Built per-recipient so times render in the user's timezone and copy
 	// is selected by preferred_language.
 	Payload *NotificationPayload `json:"payload"`
+}
+
+// TicketMintCompletedData is the payload for TICKET.mint_completed.
+// Mapped to the catalogue event ticket.mint.completed by the
+// analytics-consumer. Published by TicketUseCase.MintTicket after a ticket is
+// successfully minted and persisted. Drives the SBT issuance /
+// ticket-activation funnel in PostHog.
+type TicketMintCompletedData struct {
+	// UserID is the platform-internal user identifier of the ticket recipient.
+	// Used as the PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// EventID is the internal UUID of the live event for which the ticket was minted.
+	EventID string `json:"event_id"`
+}
+
+// TicketEmailParsedData is the payload for TICKET_EMAIL.parsed.
+// Mapped to the catalogue event ticket.email.parsed by the
+// analytics-consumer. Published by TicketEmailUseCase.Create on both
+// parse-success and parse-failure paths so email-ingestion data quality and
+// parser robustness can be measured in PostHog.
+type TicketEmailParsedData struct {
+	// UserID is the platform-internal user identifier of the fan who imported
+	// the email. Used as the PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// EmailType is the string name of the TicketEmailType enum value (e.g.
+	// "LOTTERY_INFO", "LOTTERY_RESULT").
+	EmailType string `json:"email_type"`
+	// ParseStatus is "success" when the parser returned no error, "failure"
+	// otherwise.
+	ParseStatus string `json:"parse_status"`
+	// FieldCount is the number of non-nil optional fields extracted by the
+	// parser on success. Zero on failure.
+	FieldCount int `json:"field_count"`
 }
 
 // TicketJourneyStatusChangedData is the payload for TICKET_JOURNEY.status_changed.

--- a/internal/entity/ticket_email.go
+++ b/internal/entity/ticket_email.go
@@ -21,6 +21,19 @@ func (t TicketEmailType) IsValid() bool {
 	return t >= TicketEmailTypeLotteryInfo && t <= TicketEmailTypeLotteryResult
 }
 
+// String returns the uppercase enum-name of the type for use in analytics
+// event properties. The zero value returns "UNSPECIFIED".
+func (t TicketEmailType) String() string {
+	switch t {
+	case TicketEmailTypeLotteryInfo:
+		return "LOTTERY_INFO"
+	case TicketEmailTypeLotteryResult:
+		return "LOTTERY_RESULT"
+	default:
+		return "UNSPECIFIED"
+	}
+}
+
 // TicketEmail represents an imported ticket-related email parsed by Gemini Flash.
 type TicketEmail struct {
 	// ID is the unique identifier (UUIDv7).

--- a/internal/entity/ticket_email_parser.go
+++ b/internal/entity/ticket_email_parser.go
@@ -18,6 +18,32 @@ type ParsedEmailData struct {
 	PaymentDeadline *string `json:"payment_deadline,omitempty"`
 }
 
+// FieldCount returns the number of non-nil optional fields that the parser
+// successfully extracted. Used as the field_count property on the
+// ticket.email.parsed analytics event to quantify parse yield.
+func (p *ParsedEmailData) FieldCount() int {
+	n := 0
+	if p.LotteryStart != nil {
+		n++
+	}
+	if p.LotteryEnd != nil {
+		n++
+	}
+	if p.ApplicationURL != nil {
+		n++
+	}
+	if p.LotteryResult != nil {
+		n++
+	}
+	if p.PaymentStatus != nil {
+		n++
+	}
+	if p.PaymentDeadline != nil {
+		n++
+	}
+	return n
+}
+
 // JourneyStatus maps the parsed email data to a TicketJourneyStatus based on
 // the email type and the raw values returned by the AI parser.
 //

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -91,6 +91,18 @@ const (
 	// (no-op upsert) to avoid noise in downstream funnels.
 	// Properties: event_id, from_status, to_status.
 	EventTicketJourneyStatusChanged AnalyticsEventName = "ticket.journey.status.changed"
+
+	// EventTicketMintCompleted is recorded after a soulbound ticket is
+	// successfully minted on-chain and persisted in the database. Feeds the
+	// SBT issuance / ticket-activation funnel in PostHog.
+	// Properties: event_id.
+	EventTicketMintCompleted AnalyticsEventName = "ticket.mint.completed"
+
+	// EventTicketEmailParsed is recorded by TicketEmailUseCase.Create on
+	// both parse-success and parse-failure paths. Feeds the email-ingestion
+	// data quality and parser robustness dashboards in PostHog.
+	// Properties: email_type, parse_status, field_count.
+	EventTicketEmailParsed AnalyticsEventName = "ticket.email.parsed"
 )
 
 // Entry verification events emitted from the backend, including the
@@ -142,6 +154,8 @@ var knownBackendEvents = map[AnalyticsEventName]struct{}{
 	EventTicketPurchaseCompleted:         {},
 	EventTicketPurchaseFailed:            {},
 	EventTicketJourneyStatusChanged:      {},
+	EventTicketMintCompleted:             {},
+	EventTicketEmailParsed:               {},
 	EventEntryZkProofVerified:            {},
 	EventEntryZkProofRejected:            {},
 	EventNotificationSubscribed:          {},

--- a/internal/usecase/ticket_email_uc.go
+++ b/internal/usecase/ticket_email_uc.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"time"
 
 	"github.com/liverty-music/backend/internal/entity"
@@ -35,6 +36,7 @@ type ticketEmailUseCase struct {
 	emailRepo   entity.TicketEmailRepository
 	journeyRepo entity.TicketJourneyRepository
 	parser      entity.TicketEmailParser
+	publisher   EventPublisher
 	logger      *logging.Logger
 }
 
@@ -43,13 +45,34 @@ func NewTicketEmailUseCase(
 	emailRepo entity.TicketEmailRepository,
 	journeyRepo entity.TicketJourneyRepository,
 	parser entity.TicketEmailParser,
+	publisher EventPublisher,
 	logger *logging.Logger,
 ) TicketEmailUseCase {
 	return &ticketEmailUseCase{
 		emailRepo:   emailRepo,
 		journeyRepo: journeyRepo,
 		parser:      parser,
+		publisher:   publisher,
 		logger:      logger,
+	}
+}
+
+// publishEmailParsed emits the ticket.email.parsed analytics event. It is
+// non-fatal: publish failures are logged and do not alter the caller's return
+// value.
+func (uc *ticketEmailUseCase) publishEmailParsed(ctx context.Context, userID string, emailType entity.TicketEmailType, parseStatus string, fieldCount int) {
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectTicketEmailParsed, entity.TicketEmailParsedData{
+		UserID:      userID,
+		EmailType:   emailType.String(),
+		ParseStatus: parseStatus,
+		FieldCount:  fieldCount,
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish TICKET_EMAIL.parsed event", err,
+			slog.String("user_id", userID),
+			slog.String("email_type", emailType.String()),
+			slog.String("parse_status", parseStatus),
+		)
+		// Non-fatal: the operation result is unaffected.
 	}
 }
 
@@ -57,6 +80,7 @@ func NewTicketEmailUseCase(
 func (uc *ticketEmailUseCase) Create(ctx context.Context, userID string, eventIDs []string, emailType entity.TicketEmailType, rawBody string) ([]*entity.TicketEmail, error) {
 	parsed, err := uc.parser.Parse(ctx, rawBody, emailType)
 	if err != nil {
+		uc.publishEmailParsed(ctx, userID, emailType, "failure", 0)
 		return nil, err
 	}
 
@@ -76,6 +100,8 @@ func (uc *ticketEmailUseCase) Create(ctx context.Context, userID string, eventID
 		}
 		results = append(results, created)
 	}
+
+	uc.publishEmailParsed(ctx, userID, emailType, "success", parsed.FieldCount())
 
 	return results, nil
 }

--- a/internal/usecase/ticket_email_uc_test.go
+++ b/internal/usecase/ticket_email_uc_test.go
@@ -3,12 +3,14 @@ package usecase_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/usecase"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/pannpers/go-apperr/apperr/codes"
 	"github.com/stretchr/testify/assert"
@@ -21,6 +23,7 @@ type ticketEmailTestDeps struct {
 	emailRepo   *mocks.MockTicketEmailRepository
 	journeyRepo *mocks.MockTicketJourneyRepository
 	parser      *mocks.MockTicketEmailParser
+	publisher   *ucmocks.MockEventPublisher
 	uc          usecase.TicketEmailUseCase
 }
 
@@ -30,8 +33,9 @@ func newTicketEmailTestDeps(t *testing.T) *ticketEmailTestDeps {
 		emailRepo:   mocks.NewMockTicketEmailRepository(t),
 		journeyRepo: mocks.NewMockTicketJourneyRepository(t),
 		parser:      mocks.NewMockTicketEmailParser(t),
+		publisher:   ucmocks.NewMockEventPublisher(t),
 	}
-	d.uc = usecase.NewTicketEmailUseCase(d.emailRepo, d.journeyRepo, d.parser, newTestLogger(t))
+	d.uc = usecase.NewTicketEmailUseCase(d.emailRepo, d.journeyRepo, d.parser, d.publisher, newTestLogger(t))
 	return d
 }
 
@@ -102,6 +106,15 @@ func TestTicketEmailUseCase_Create(t *testing.T) {
 					Create(ctx, mock.AnythingOfType("*entity.NewTicketEmail")).
 					Return(sampleTicketEmail("te-2", userID, eventID2, entity.TicketEmailTypeLotteryInfo), nil).
 					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectTicketEmailParsed, mock.MatchedBy(func(data entity.TicketEmailParsedData) bool {
+						return data.UserID == userID &&
+							data.EmailType == "LOTTERY_INFO" &&
+							data.ParseStatus == "success" &&
+							data.FieldCount == parsed.FieldCount()
+					})).
+					Return(nil).
+					Once()
 			},
 			wantCount: 2,
 		},
@@ -113,19 +126,28 @@ func TestTicketEmailUseCase_Create(t *testing.T) {
 			rawBody:   rawBody,
 			setup: func(t *testing.T, d *ticketEmailTestDeps) {
 				t.Helper()
+				parsed := sampleParsedData()
 				d.parser.EXPECT().
 					Parse(ctx, rawBody, entity.TicketEmailTypeLotteryResult).
-					Return(sampleParsedData(), nil).
+					Return(parsed, nil).
 					Once()
 				d.emailRepo.EXPECT().
 					Create(ctx, mock.AnythingOfType("*entity.NewTicketEmail")).
 					Return(sampleTicketEmail("te-3", userID, eventID1, entity.TicketEmailTypeLotteryResult), nil).
 					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectTicketEmailParsed, mock.MatchedBy(func(data entity.TicketEmailParsedData) bool {
+						return data.UserID == userID &&
+							data.EmailType == "LOTTERY_RESULT" &&
+							data.ParseStatus == "success"
+					})).
+					Return(nil).
+					Once()
 			},
 			wantCount: 1,
 		},
 		{
-			name:      "propagates parser error without persisting",
+			name:      "propagates parser error without persisting, publishes failure event",
 			userID:    userID,
 			eventIDs:  []string{eventID1},
 			emailType: entity.TicketEmailTypeLotteryInfo,
@@ -135,6 +157,15 @@ func TestTicketEmailUseCase_Create(t *testing.T) {
 				d.parser.EXPECT().
 					Parse(ctx, rawBody, entity.TicketEmailTypeLotteryInfo).
 					Return(nil, apperr.New(codes.Internal, "gemini error")).
+					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectTicketEmailParsed, mock.MatchedBy(func(data entity.TicketEmailParsedData) bool {
+						return data.UserID == userID &&
+							data.EmailType == "LOTTERY_INFO" &&
+							data.ParseStatus == "failure" &&
+							data.FieldCount == 0
+					})).
+					Return(nil).
 					Once()
 			},
 			wantErr: apperr.ErrInternal,
@@ -154,6 +185,50 @@ func TestTicketEmailUseCase_Create(t *testing.T) {
 				d.emailRepo.EXPECT().
 					Create(ctx, mock.AnythingOfType("*entity.NewTicketEmail")).
 					Return(nil, apperr.New(codes.Internal, "db error")).
+					Once()
+				// publish is not reached when the repo Create fails mid-loop
+			},
+			wantErr: apperr.ErrInternal,
+		},
+		{
+			name:      "publish error is non-fatal on success path",
+			userID:    userID,
+			eventIDs:  []string{eventID1},
+			emailType: entity.TicketEmailTypeLotteryInfo,
+			rawBody:   rawBody,
+			setup: func(t *testing.T, d *ticketEmailTestDeps) {
+				t.Helper()
+				parsed := sampleParsedData()
+				d.parser.EXPECT().
+					Parse(ctx, rawBody, entity.TicketEmailTypeLotteryInfo).
+					Return(parsed, nil).
+					Once()
+				d.emailRepo.EXPECT().
+					Create(ctx, mock.AnythingOfType("*entity.NewTicketEmail")).
+					Return(sampleTicketEmail("te-4", userID, eventID1, entity.TicketEmailTypeLotteryInfo), nil).
+					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectTicketEmailParsed, mock.Anything).
+					Return(errors.New("nats unavailable")).
+					Once()
+			},
+			wantCount: 1,
+		},
+		{
+			name:      "publish error on parse failure is non-fatal",
+			userID:    userID,
+			eventIDs:  []string{eventID1},
+			emailType: entity.TicketEmailTypeLotteryInfo,
+			rawBody:   rawBody,
+			setup: func(t *testing.T, d *ticketEmailTestDeps) {
+				t.Helper()
+				d.parser.EXPECT().
+					Parse(ctx, rawBody, entity.TicketEmailTypeLotteryInfo).
+					Return(nil, apperr.New(codes.Internal, "gemini error")).
+					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectTicketEmailParsed, mock.Anything).
+					Return(errors.New("nats unavailable")).
 					Once()
 			},
 			wantErr: apperr.ErrInternal,

--- a/internal/usecase/ticket_mint_uc_test.go
+++ b/internal/usecase/ticket_mint_uc_test.go
@@ -33,7 +33,7 @@ func validMintParams() *usecase.MintTicketParams {
 
 func newTicketUC(t *testing.T, repo *mocks.MockTicketRepository, minter *mocks.MockTicketMinter) usecase.TicketUseCase {
 	t.Helper()
-	return usecase.NewTicketUseCase(repo, minter, noopMintMetrics{}, newTestLogger(t))
+	return usecase.NewTicketUseCase(repo, minter, noopMintMetrics{}, nil, newTestLogger(t))
 }
 
 // --- validateMintParams ---
@@ -61,7 +61,7 @@ func TestTicketUseCase_ValidateMintParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			uc := usecase.NewTicketUseCase(nil, nil, noopMintMetrics{}, newTestLogger(t))
+			uc := usecase.NewTicketUseCase(nil, nil, noopMintMetrics{}, nil, newTestLogger(t))
 
 			err := usecase.ExportedValidateMintParams(uc, tt.params)
 

--- a/internal/usecase/ticket_uc.go
+++ b/internal/usecase/ticket_uc.go
@@ -57,6 +57,7 @@ type MintTicketParams struct {
 type ticketUseCase struct {
 	ticketRepo  entity.TicketRepository
 	minter      entity.TicketMinter
+	publisher   EventPublisher
 	logger      *logging.Logger
 	mintMetrics MintMetrics
 }
@@ -69,11 +70,13 @@ func NewTicketUseCase(
 	ticketRepo entity.TicketRepository,
 	minter entity.TicketMinter,
 	mintMetrics MintMetrics,
+	publisher EventPublisher,
 	logger *logging.Logger,
 ) TicketUseCase {
 	return &ticketUseCase{
 		ticketRepo:  ticketRepo,
 		minter:      minter,
+		publisher:   publisher,
 		logger:      logger,
 		mintMetrics: mintMetrics,
 	}
@@ -230,7 +233,25 @@ func (uc *ticketUseCase) MintTicket(ctx context.Context, params *MintTicketParam
 	uc.mintMetrics.RecordDuration(ctx, mintElapsed, "success")
 	uc.mintMetrics.RecordTotal(ctx, "success")
 
-	return uc.persistTicket(ctx, params, tokenID, txHash)
+	ticket, err := uc.persistTicket(ctx, params, tokenID, txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	// Publish non-fatally: the ticket is already persisted so an analytics
+	// failure must not roll back or surface as an error to the caller.
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectTicketMintCompleted, entity.TicketMintCompletedData{
+		UserID:  params.UserID,
+		EventID: params.EventID,
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish TICKET.mint_completed event", err,
+			slog.String("user_id", params.UserID),
+			slog.String("event_id", params.EventID),
+		)
+		// Non-fatal: the ticket is already persisted.
+	}
+
+	return ticket, nil
 }
 
 // GetTicket retrieves a ticket by ID.

--- a/internal/usecase/ticket_uc_test.go
+++ b/internal/usecase/ticket_uc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/usecase"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -19,10 +20,21 @@ type noopMintMetrics struct{}
 func (noopMintMetrics) RecordDuration(context.Context, float64, string) {}
 func (noopMintMetrics) RecordTotal(context.Context, string)             {}
 
+// newTestTicketUC builds a TicketUseCase for tests that do NOT reach the
+// publish path (validation, error, idempotency-by-existing-DB-record, etc.).
+// Pass nil for publisher when the test never reaches a successful persist.
 func newTestTicketUC(t *testing.T, repo *mocks.MockTicketRepository, minter *mocks.MockTicketMinter) usecase.TicketUseCase {
 	t.Helper()
 	logger := newTestLogger(t)
-	return usecase.NewTicketUseCase(repo, minter, noopMintMetrics{}, logger)
+	return usecase.NewTicketUseCase(repo, minter, noopMintMetrics{}, nil, logger)
+}
+
+// newTestTicketUCWithPublisher builds a TicketUseCase for tests that reach a
+// successful persist — the publisher mock must have an expectation set up by
+// the caller.
+func newTestTicketUCWithPublisher(t *testing.T, repo *mocks.MockTicketRepository, minter *mocks.MockTicketMinter, publisher *ucmocks.MockEventPublisher) usecase.TicketUseCase {
+	t.Helper()
+	return usecase.NewTicketUseCase(repo, minter, noopMintMetrics{}, publisher, newTestLogger(t))
 }
 
 func TestMintTicket_Validation(t *testing.T) {
@@ -40,7 +52,7 @@ func TestMintTicket_Validation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			uc := usecase.NewTicketUseCase(nil, nil, noopMintMetrics{}, logger)
+			uc := usecase.NewTicketUseCase(nil, nil, noopMintMetrics{}, nil, logger)
 			_, err := uc.MintTicket(context.Background(), tc.params)
 			assert.Error(t, err)
 			assert.True(t, errors.Is(err, apperr.ErrInvalidArgument), "expected InvalidArgument, got %v", err)
@@ -52,6 +64,7 @@ func TestMintTicket_IdempotencyDB(t *testing.T) {
 	t.Parallel()
 
 	// When a ticket already exists in the DB, return it without minting.
+	// The early-return path does not publish — publisher is nil.
 	repo := mocks.NewMockTicketRepository(t)
 	minter := mocks.NewMockTicketMinter(t)
 	uc := newTestTicketUC(t, repo, minter)
@@ -76,7 +89,8 @@ func TestMintTicket_HappyPath(t *testing.T) {
 
 	repo := mocks.NewMockTicketRepository(t)
 	minter := mocks.NewMockTicketMinter(t)
-	uc := newTestTicketUC(t, repo, minter)
+	publisher := ucmocks.NewMockEventPublisher(t)
+	uc := newTestTicketUCWithPublisher(t, repo, minter, publisher)
 
 	created := &entity.Ticket{ID: "ticket-2", EventID: "event-1", UserID: "user-1", TokenID: 99}
 
@@ -87,6 +101,12 @@ func TestMintTicket_HappyPath(t *testing.T) {
 	repo.EXPECT().Create(anyCtx, mock.MatchedBy(func(p *entity.NewTicket) bool {
 		return p.EventID == "event-1" && p.UserID == "user-1" && p.TxHash == "0xdeadbeef"
 	})).Return(created, nil)
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectTicketMintCompleted, mock.MatchedBy(func(data entity.TicketMintCompletedData) bool {
+			return data.UserID == "user-1" && data.EventID == "event-1"
+		})).
+		Return(nil).
+		Once()
 
 	got, err := uc.MintTicket(context.Background(), &usecase.MintTicketParams{
 		EventID:          "event-1",
@@ -102,6 +122,7 @@ func TestMintTicket_EventNotFound(t *testing.T) {
 	t.Parallel()
 
 	// When the event does not exist, return NotFound before on-chain mint.
+	// Never reaches persist, so publisher is nil.
 	repo := mocks.NewMockTicketRepository(t)
 	minter := mocks.NewMockTicketMinter(t)
 	uc := newTestTicketUC(t, repo, minter)
@@ -127,7 +148,8 @@ func TestMintTicket_AlreadyMintedOwnerMatches(t *testing.T) {
 	// Token is on-chain but no DB record — owner matches → reconcile and save.
 	repo := mocks.NewMockTicketRepository(t)
 	minter := mocks.NewMockTicketMinter(t)
-	uc := newTestTicketUC(t, repo, minter)
+	publisher := ucmocks.NewMockEventPublisher(t)
+	uc := newTestTicketUCWithPublisher(t, repo, minter, publisher)
 
 	recipient := "0xaAbBcCdDeEfF0011223344556677889900aAbBcC"
 	created := &entity.Ticket{ID: "ticket-3", EventID: "event-1", UserID: "user-1"}
@@ -140,6 +162,12 @@ func TestMintTicket_AlreadyMintedOwnerMatches(t *testing.T) {
 	repo.EXPECT().Create(anyCtx, mock.MatchedBy(func(p *entity.NewTicket) bool {
 		return p.EventID == "event-1" && p.UserID == "user-1"
 	})).Return(created, nil)
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectTicketMintCompleted, mock.MatchedBy(func(data entity.TicketMintCompletedData) bool {
+			return data.UserID == "user-1" && data.EventID == "event-1"
+		})).
+		Return(nil).
+		Once()
 
 	got, err := uc.MintTicket(context.Background(), &usecase.MintTicketParams{
 		EventID:          "event-1",
@@ -156,6 +184,7 @@ func TestMintTicket_AlreadyMintedOwnerMismatch(t *testing.T) {
 	t.Parallel()
 
 	// Token is on-chain but owned by a different address → PermissionDenied.
+	// Never reaches persist, so publisher is nil.
 	repo := mocks.NewMockTicketRepository(t)
 	minter := mocks.NewMockTicketMinter(t)
 	uc := newTestTicketUC(t, repo, minter)
@@ -178,10 +207,13 @@ func TestMintTicket_AlreadyMintedOwnerMismatch(t *testing.T) {
 func TestMintTicket_ConcurrentMintIdempotency(t *testing.T) {
 	t.Parallel()
 
-	// If Create returns AlreadyExists (concurrent mint), fetch and return the existing record.
+	// If Create returns AlreadyExists (concurrent mint), fetch and return the
+	// existing record. persistTicket returns the existing ticket, so publish
+	// is still invoked.
 	repo := mocks.NewMockTicketRepository(t)
 	minter := mocks.NewMockTicketMinter(t)
-	uc := newTestTicketUC(t, repo, minter)
+	publisher := ucmocks.NewMockEventPublisher(t)
+	uc := newTestTicketUCWithPublisher(t, repo, minter, publisher)
 
 	existing := &entity.Ticket{ID: "ticket-4", EventID: "event-1", UserID: "user-1"}
 
@@ -191,6 +223,12 @@ func TestMintTicket_ConcurrentMintIdempotency(t *testing.T) {
 	minter.EXPECT().Mint(anyCtx, mock.Anything, mock.AnythingOfType("uint64")).Return("0xdeadbeef", nil)
 	repo.EXPECT().Create(anyCtx, mock.Anything).Return(nil, apperr.ErrAlreadyExists)
 	repo.EXPECT().GetByEventAndUser(anyCtx, "event-1", "user-1").Return(existing, nil).Once()
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectTicketMintCompleted, mock.MatchedBy(func(data entity.TicketMintCompletedData) bool {
+			return data.UserID == "user-1" && data.EventID == "event-1"
+		})).
+		Return(nil).
+		Once()
 
 	got, err := uc.MintTicket(context.Background(), &usecase.MintTicketParams{
 		EventID:          "event-1",
@@ -206,6 +244,7 @@ func TestMintTicket_IsTokenMintedError(t *testing.T) {
 	t.Parallel()
 
 	// RPC error from IsTokenMinted should be propagated as Internal.
+	// Never reaches persist, so publisher is nil.
 	repo := mocks.NewMockTicketRepository(t)
 	minter := mocks.NewMockTicketMinter(t)
 	uc := newTestTicketUC(t, repo, minter)
@@ -222,4 +261,37 @@ func TestMintTicket_IsTokenMintedError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, apperr.ErrInternal), "expected Internal, got %v", err)
+}
+
+// TestMintTicket_PublishNonFatal verifies that a publish failure does not
+// cause MintTicket to return an error — the ticket is already persisted and
+// must be returned to the caller.
+func TestMintTicket_PublishNonFatal(t *testing.T) {
+	t.Parallel()
+
+	repo := mocks.NewMockTicketRepository(t)
+	minter := mocks.NewMockTicketMinter(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+	uc := newTestTicketUCWithPublisher(t, repo, minter, publisher)
+
+	created := &entity.Ticket{ID: "ticket-5", EventID: "event-1", UserID: "user-1", TokenID: 77}
+
+	repo.EXPECT().GetByEventAndUser(anyCtx, "event-1", "user-1").Return(nil, apperr.ErrNotFound)
+	repo.EXPECT().EventExists(anyCtx, "event-1").Return(true, nil)
+	minter.EXPECT().IsTokenMinted(anyCtx, mock.AnythingOfType("uint64")).Return(false, nil)
+	minter.EXPECT().Mint(anyCtx, "0xaAbBcCdDeEfF0011223344556677889900aAbBcC", mock.AnythingOfType("uint64")).Return("0xdeadbeef", nil)
+	repo.EXPECT().Create(anyCtx, mock.Anything).Return(created, nil)
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectTicketMintCompleted, mock.Anything).
+		Return(errors.New("nats unavailable")).
+		Once()
+
+	got, err := uc.MintTicket(context.Background(), &usecase.MintTicketParams{
+		EventID:          "event-1",
+		UserID:           "user-1",
+		RecipientAddress: "0xaAbBcCdDeEfF0011223344556677889900aAbBcC",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, created, got)
 }


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/specification#532

## 📝 Summary of Changes

Implements OpenSpec tasks **14.6** and **14.2** on the proven **14.1** publisher+forwarder template — two catalogued BE analytics events that previously had no publisher.

- **`ticket.mint.completed` (14.6)** — `TicketUseCase.MintTicket` publishes `TICKET.mint_completed` after a ticket is persisted (fresh-mint and concurrent-reconcile paths; not the no-op already-minted early return). Forwarded with `{event_id}`, attributed to the user. Signal: SBT issuance / ticket-activation funnel.
- **`ticket.email.parsed` (14.2)** — `TicketEmailUseCase.Create` publishes `TICKET_EMAIL.parsed` on **both** parse success and failure (so parser robustness is measurable). Forwarded with `{email_type, parse_status, field_count}`; `field_count` counts the parsed non-nil fields, `parse_status` is success/failure. The method's error-return behaviour is unchanged.

Both publishes are **non-fatal** (a NATS/PostHog hiccup never affects the mint or the parse result); the consumer stays non-blocking. Constants are already documented in the catalogue, so no spec change. `provider.go` relocates the messaging-publisher block so the `EventPublisher` is in scope for both usecases.

## Type of Change
- [x] feat: A new feature

## Verification
- [x] `make check` passed (lint + modernize + golangci-lint + docker integration tests).
- [x] New/updated tests: mint publish-on-success + non-fatal; email publish-on-success/failure + non-fatal; two new consumer handler tests (forward / nil-client / empty-UserID / enqueue-error).

## Self-Checklist
- [x] Clean Architecture boundaries; `apperr`; publisher non-fatal; consumer non-blocking.
- [x] Mocks regenerated; tests updated for the new constructor deps.
