### PR TITLE
feat(analytics): emit notification.unsubscribed (task 14.3)

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -305,6 +305,55 @@ func (c *AnalyticsConsumer) HandleNotificationSubscribed(msg *message.Message) e
 	return nil
 }
 
+// HandleNotificationUnsubscribed forwards the NOTIFICATION.unsubscribed
+// NATS subject as the catalogue event
+// usecase.EventNotificationUnsubscribed. Properties: device_type
+// (classifier output from the endpoint host; the endpoint itself is
+// never forwarded). Only user-initiated unsubscriptions emit this event;
+// the auto-cleanup path on 410 Gone does not.
+func (c *AnalyticsConsumer) HandleNotificationUnsubscribed(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.NotificationUnsubscribedData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse NOTIFICATION.unsubscribed event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse NOTIFICATION.unsubscribed event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventNotificationUnsubscribed)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "NOTIFICATION.unsubscribed event missing user_id, skipping forward")
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"device_type": data.DeviceType,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventNotificationUnsubscribed, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventNotificationUnsubscribed)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
 // HandleEntryZkProofVerified forwards the ENTRY.zk_proof_verified
 // NATS subject as the catalogue event usecase.EventEntryZkProofVerified.
 // The distinct_id is the nullifier hash hex — anonymous-by-design per

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -589,6 +589,114 @@ func TestAnalyticsConsumer_HandleNotificationSubscribed(t *testing.T) {
 	}
 }
 
+// TestAnalyticsConsumer_HandleNotificationUnsubscribed covers
+// NOTIFICATION.unsubscribed → notification.unsubscribed routing.
+// Property: device_type (the endpoint host classifier). Mirrors the
+// HandleNotificationSubscribed test for the unsubscribe case.
+func TestAnalyticsConsumer_HandleNotificationUnsubscribed(t *testing.T) {
+	t.Parallel()
+
+	const validUserID = "11111111-2222-3333-4444-555555555555"
+
+	type args struct {
+		data entity.NotificationUnsubscribedData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards with device_type when client + UserID present",
+			args: args{data: entity.NotificationUnsubscribedData{
+				UserID:     validUserID,
+				DeviceType: "android",
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil (local dev)",
+			args: args{data: entity.NotificationUnsubscribedData{
+				UserID:     validUserID,
+				DeviceType: "apple",
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.NotificationUnsubscribedData{
+				UserID:     "",
+				DeviceType: "android",
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.NotificationUnsubscribedData{
+				UserID:     validUserID,
+				DeviceType: "other",
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventNotificationUnsubscribed,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["device_type"] == tt.args.data.DeviceType
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleNotificationUnsubscribed(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // TestAnalyticsConsumer_HandleEntryZkProofVerified covers
 // ENTRY.zk_proof_verified routing. Distinct_id is the nullifier hash
 // hex (anonymous per ZK guarantee); event_id is a property.

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -268,6 +268,13 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	)
 
 	router.AddConsumerHandler(
+		"forward-notification-unsubscribed-to-analytics",
+		entity.SubjectNotificationUnsubscribed,
+		subscriber,
+		analyticsConsumer.HandleNotificationUnsubscribed,
+	)
+
+	router.AddConsumerHandler(
 		"forward-entry-zk-proof-verified-to-analytics",
 		entity.SubjectEntryZkProofVerified,
 		subscriber,

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -16,6 +16,7 @@ const (
 	SubjectUserCreated                  = "USER.created"
 	SubjectUserPreferredLanguageUpdated = "USER.preferred_language_updated"
 	SubjectNotificationSubscribed       = "NOTIFICATION.subscribed"
+	SubjectNotificationUnsubscribed     = "NOTIFICATION.unsubscribed"
 	SubjectEntryZkProofVerified         = "ENTRY.zk_proof_verified"
 	SubjectEntryZkProofRejected         = "ENTRY.zk_proof_rejected"
 	// SubjectSalesPhaseDiscovered is published when a brand-new sales phase row
@@ -177,6 +178,22 @@ type NotificationSubscribedData struct {
 	// (Mozilla autopush), "windows" (WNS), "other". The endpoint URL itself
 	// is sensitive and is NOT included in the payload — the host classifier
 	// is the only signal forwarded to PostHog.
+	DeviceType string `json:"device_type"`
+}
+
+// NotificationUnsubscribedData is the payload for NOTIFICATION.unsubscribed.
+// Mapped to the catalogue event notification.unsubscribed by the
+// analytics-consumer. Published by PushNotificationUseCase.Delete after the
+// repository removes a user-initiated Web Push subscription record. The
+// endpoint URL itself is sensitive and is NOT included; only the classifier
+// output is forwarded to PostHog.
+type NotificationUnsubscribedData struct {
+	// UserID is the platform-internal user identifier of the subscriber.
+	// Used as the PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// DeviceType is the browser/OS family derived from the push endpoint
+	// host. Values: "android" (FCM), "apple" (Web Push for Safari), "firefox"
+	// (Mozilla autopush), "windows" (WNS), "other". See DeviceTypeFromEndpoint.
 	DeviceType string `json:"device_type"`
 }
 

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -126,6 +126,12 @@ const (
 	// subscription has been persisted against the user record.
 	EventNotificationSubscribed AnalyticsEventName = "notification.subscribed"
 
+	// EventNotificationUnsubscribed is recorded after a user-initiated
+	// Web Push subscription has been removed via PushNotificationUseCase.Delete.
+	// Auto-cleanup on 410 Gone (send-loop expiry) intentionally does NOT
+	// emit this event — that is subscription expiry, not user churn.
+	EventNotificationUnsubscribed AnalyticsEventName = "notification.unsubscribed"
+
 	// EventNotificationDelivered is recorded when the push provider
 	// accepts a notification for delivery. The frontend records the
 	// downstream open/dismiss separately.
@@ -159,6 +165,7 @@ var knownBackendEvents = map[AnalyticsEventName]struct{}{
 	EventEntryZkProofVerified:            {},
 	EventEntryZkProofRejected:            {},
 	EventNotificationSubscribed:          {},
+	EventNotificationUnsubscribed:        {},
 	EventNotificationDelivered:           {},
 }
 

--- a/internal/usecase/push_notification_uc.go
+++ b/internal/usecase/push_notification_uc.go
@@ -130,10 +130,25 @@ func (uc *pushNotificationUseCase) Get(ctx context.Context, userID, endpoint str
 
 // Delete removes the push subscription matching the (userID, endpoint) pair.
 // Other browsers registered by the same user remain active. Idempotent.
+// On success, a notification.unsubscribed analytics event is published
+// non-fatally — a publish error is logged but does not change the return
+// behaviour. The auto-cleanup path inside NotifyNewConcerts (410 Gone) does
+// NOT call this method and therefore does NOT emit the analytics event.
 func (uc *pushNotificationUseCase) Delete(ctx context.Context, userID, endpoint string) error {
 	if err := uc.pushSubRepo.Delete(ctx, userID, endpoint); err != nil {
 		return fmt.Errorf("failed to delete push subscription: %w", err)
 	}
+
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectNotificationUnsubscribed, entity.NotificationUnsubscribedData{
+		UserID:     userID,
+		DeviceType: entity.DeviceTypeFromEndpoint(endpoint),
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish NOTIFICATION.unsubscribed event", err,
+			slog.String("user_id", userID),
+		)
+		// Non-fatal: the subscription is already deleted.
+	}
+
 	return nil
 }
 

--- a/internal/usecase/push_notification_uc_test.go
+++ b/internal/usecase/push_notification_uc_test.go
@@ -245,15 +245,40 @@ func TestPushNotificationUseCase_Delete(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "delete subscription successfully",
-			args: args{userID: "user-1", endpoint: "https://push.example.com/sub"},
+			name: "delete subscription successfully and publish analytics event",
+			args: args{userID: "user-1", endpoint: "https://fcm.googleapis.com/sub/abc"},
 			setup: func(t *testing.T, d *pushNotificationTestDeps) {
 				t.Helper()
 				d.pushSubRepo.EXPECT().
-					Delete(ctx, "user-1", "https://push.example.com/sub").
+					Delete(ctx, "user-1", "https://fcm.googleapis.com/sub/abc").
 					Return(nil).
 					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectNotificationUnsubscribed, entity.NotificationUnsubscribedData{
+						UserID:     "user-1",
+						DeviceType: "android",
+					}).
+					Return(nil).Once()
 			},
+			wantErr: nil,
+		},
+		{
+			name: "publish error is non-fatal when repository delete succeeds",
+			args: args{userID: "user-1", endpoint: "https://web.push.apple.com/sub/abc"},
+			setup: func(t *testing.T, d *pushNotificationTestDeps) {
+				t.Helper()
+				d.pushSubRepo.EXPECT().
+					Delete(ctx, "user-1", "https://web.push.apple.com/sub/abc").
+					Return(nil).
+					Once()
+				d.publisher.EXPECT().
+					PublishEvent(ctx, entity.SubjectNotificationUnsubscribed, entity.NotificationUnsubscribedData{
+						UserID:     "user-1",
+						DeviceType: "apple",
+					}).
+					Return(apperr.ErrInternal).Once()
+			},
+			// Publish error must not propagate — Delete returns nil.
 			wantErr: nil,
 		},
 		{
@@ -265,6 +290,7 @@ func TestPushNotificationUseCase_Delete(t *testing.T) {
 					Delete(ctx, "user-1", "https://push.example.com/sub").
 					Return(apperr.ErrInternal).
 					Once()
+				// No PublishEvent expected — repo failure prevents reaching the publish call.
 			},
 			wantErr: apperr.ErrInternal,
 		},
@@ -646,6 +672,27 @@ func notifySenderTestDeps(t *testing.T, subs []*entity.PushSubscription) *pushNo
 	d.followRepo.EXPECT().ListFollowers(ctx, "artist-1").Return(followers, nil).Once()
 	d.pushSubRepo.EXPECT().ListByUserIDs(ctx, []string{"user-1"}).Return(subs, nil).Once()
 	return d
+}
+
+// TestNotifyNewConcerts_SenderGone_DoesNotPublishUnsubscribedEvent asserts that
+// the 410 Gone auto-cleanup path inside NotifyNewConcerts does NOT emit
+// notification.unsubscribed. That event is user-churn signal and must only
+// come from the user-initiated Delete method.
+func TestNotifyNewConcerts_SenderGone_DoesNotPublishUnsubscribedEvent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	sub := &entity.PushSubscription{UserID: "user-1", Endpoint: "https://push.example.com/gone"}
+	d := notifySenderTestDeps(t, []*entity.PushSubscription{sub})
+	d.sender.sendFn = func(_ context.Context, _ []byte, _ *entity.PushSubscription) error {
+		return apperr.ErrNotFound
+	}
+	d.pushSubRepo.EXPECT().Delete(ctx, "user-1", "https://push.example.com/gone").Return(nil).Once()
+	// No d.publisher.EXPECT().PublishEvent(...) — the mock will fail the test
+	// if PublishEvent is called unexpectedly (testify/mock assertion on cleanup).
+
+	err := d.uc.NotifyNewConcerts(ctx, usecase.ConcertCreatedData{ArtistID: "artist-1", ConcertIDs: []string{"c1"}})
+	assert.NoError(t, err)
 }
 
 func TestNotifyNewConcerts_SenderGone_DeletesSubscription(t *testing.T) {


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/specification#532

## 📝 Summary of Changes

Implements OpenSpec task **14.3** `notification.unsubscribed` — the inverse of the existing `notification.subscribed` event.

- `PushNotificationUseCase.Delete` (the **user-initiated** unsubscribe) publishes `NOTIFICATION.unsubscribed` after the subscription is removed, reusing the same `DeviceTypeFromEndpoint` classifier as the subscribe path. The analytics-consumer forwards it to PostHog with `{device_type}`, attributed to the user.
- The **410-Gone send-loop auto-cleanup is deliberately NOT instrumented** (that's subscription expiry, not user churn) — a regression test enforces the expiry path never publishes the event.
- Publishing is non-fatal; consumer non-blocking. Constant already documented in the catalogue, so no spec change. `push_notification_uc` already had the publisher dep, so no constructor/`provider.go` change.

## Type of Change
- [x] feat: A new feature

## Verification
- [x] `make check` passed (lint + modernize + golangci-lint + docker integration tests).
- [x] Tests: Delete publish-on-success / non-fatal-on-publish-error / no-publish-on-repo-failure; expiry-path-does-not-publish regression; consumer handler forward / nil-client / empty-UserID / enqueue-error.

## Self-Checklist
- [x] Clean Architecture boundaries; `apperr`; publisher non-fatal; consumer non-blocking.
- [x] Reused the existing device-type classifier; mirrors `notification.subscribed`.
