### PR TITLE
feat(analytics): emit sales_reminder.delivered (task 14.4)

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -614,6 +614,60 @@ func (c *AnalyticsConsumer) HandleTicketEmailParsed(msg *message.Message) error 
 	return nil
 }
 
+// HandleSalesReminderDelivered forwards the SALES_REMINDER.delivered NATS
+// subject as the catalogue event usecase.EventSalesReminderDelivered.
+// Properties: phase_stage, delivery_status. The distinct_id is the platform
+// UserID from the payload.
+func (c *AnalyticsConsumer) HandleSalesReminderDelivered(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.SalesReminderDeliveredData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse SALES_REMINDER.delivered event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse SALES_REMINDER.delivered event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventSalesReminderDelivered)),
+			slog.String("user_id", data.UserID),
+			slog.String("phase_stage", data.PhaseStage),
+			slog.String("delivery_status", data.DeliveryStatus),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "SALES_REMINDER.delivered event missing user_id, skipping forward",
+			slog.String("phase_stage", data.PhaseStage),
+			slog.String("delivery_status", data.DeliveryStatus),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"phase_stage":     data.PhaseStage,
+		"delivery_status": data.DeliveryStatus,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventSalesReminderDelivered, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventSalesReminderDelivered)),
+			slog.String("user_id", data.UserID),
+			slog.String("phase_stage", data.PhaseStage),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
 // recordLag emits analytics_consumer_lag_seconds derived from the
 // CloudEvent's `ce_time` metadata. Missing or unparseable timestamps
 // are silently skipped — the metric is best-effort and downstream

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -1290,6 +1290,122 @@ func TestAnalyticsConsumer_HandleTicketEmailParsed(t *testing.T) {
 	}
 }
 
+// TestAnalyticsConsumer_HandleSalesReminderDelivered covers
+// SALES_REMINDER.delivered → sales_reminder.delivered routing.
+// Properties: phase_stage, delivery_status. Distinct_id is the platform UserID.
+func TestAnalyticsConsumer_HandleSalesReminderDelivered(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validUserID = "11111111-2222-3333-4444-555555555555"
+		validStage  = "APPLY_OPEN"
+		validStatus = "delivered"
+	)
+
+	type args struct {
+		data entity.SalesReminderDeliveredData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards sales_reminder.delivered with phase_stage and delivery_status",
+			args: args{data: entity.SalesReminderDeliveredData{
+				UserID:         validUserID,
+				PhaseStage:     validStage,
+				DeliveryStatus: validStatus,
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil (local dev)",
+			args: args{data: entity.SalesReminderDeliveredData{
+				UserID:         validUserID,
+				PhaseStage:     validStage,
+				DeliveryStatus: "no_subscription",
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.SalesReminderDeliveredData{
+				UserID:         "",
+				PhaseStage:     validStage,
+				DeliveryStatus: "failed",
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.SalesReminderDeliveredData{
+				UserID:         validUserID,
+				PhaseStage:     validStage,
+				DeliveryStatus: validStatus,
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventSalesReminderDelivered,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["phase_stage"] == tt.args.data.PhaseStage &&
+									props["delivery_status"] == tt.args.data.DeliveryStatus
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleSalesReminderDelivered(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // TestAnalyticsConsumer_HandleUserCreated_BadPayload covers the
 // CloudEvent decode failure path separately because constructing an
 // invalid JSON payload with the same table shape would obscure the

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -175,6 +175,7 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		salesReminderRepo,
 		pushSubRepo,
 		webpushSender,
+		eventPublisher,
 		pushMetrics,
 		logger,
 	)
@@ -307,6 +308,13 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		entity.SubjectTicketEmailParsed,
 		subscriber,
 		analyticsConsumer.HandleTicketEmailParsed,
+	)
+
+	router.AddConsumerHandler(
+		"forward-sales-reminder-delivered-to-analytics",
+		entity.SubjectSalesReminderDelivered,
+		subscriber,
+		analyticsConsumer.HandleSalesReminderDelivered,
 	)
 
 	router.AddConsumerHandler(

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -36,6 +36,12 @@ const (
 	// ticket.mint.completed analytics event (SBT issuance / ticket-activation
 	// funnel).
 	SubjectTicketMintCompleted = "TICKET.mint_completed"
+	// SubjectSalesReminderDelivered is published by
+	// salesReminderDeliveryUseCase.DeliverReminder at every terminal delivery
+	// outcome (delivered, no_subscription, failed). It drives the
+	// sales_reminder.delivered analytics event so push-delivery reach and
+	// failure rates can be tracked per stage in PostHog.
+	SubjectSalesReminderDelivered = "SALES_REMINDER.delivered"
 	// SubjectTicketEmailParsed is published by TicketEmailUseCase.Create on
 	// both parse-success and parse-failure paths. It drives the
 	// ticket.email.parsed analytics event (email-ingestion data quality,
@@ -257,6 +263,24 @@ type TicketEmailParsedData struct {
 	// FieldCount is the number of non-nil optional fields extracted by the
 	// parser on success. Zero on failure.
 	FieldCount int `json:"field_count"`
+}
+
+// SalesReminderDeliveredData is the payload for SALES_REMINDER.delivered.
+// Mapped to the catalogue event sales_reminder.delivered by the
+// analytics-consumer. Published by salesReminderDeliveryUseCase.DeliverReminder
+// at every terminal delivery outcome so push-delivery reach and failure rates can
+// be tracked per stage in PostHog.
+type SalesReminderDeliveredData struct {
+	// UserID is the platform-internal user identifier of the reminder recipient.
+	// Used as the PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// PhaseStage is the string name of the ReminderStage (e.g. "APPLY_OPEN").
+	PhaseStage string `json:"phase_stage"`
+	// DeliveryStatus is one of "delivered", "no_subscription", or "failed".
+	// "delivered" means the push was accepted by at least one subscription.
+	// "no_subscription" means the user had no registered push subscriptions.
+	// "failed" means all send attempts were rejected (410 Gone or send error).
+	DeliveryStatus string `json:"delivery_status"`
 }
 
 // TicketJourneyStatusChangedData is the payload for TICKET_JOURNEY.status_changed.

--- a/internal/entity/sales_phase.go
+++ b/internal/entity/sales_phase.go
@@ -80,6 +80,24 @@ const (
 	ReminderStageResultDay ReminderStage = 4
 )
 
+// String returns the uppercase name of the stage for use in analytics event
+// properties (e.g. "APPLY_OPEN"). The zero value and any unrecognised int16
+// return "UNSPECIFIED".
+func (s ReminderStage) String() string {
+	switch s {
+	case ReminderStageApplyOpen:
+		return "APPLY_OPEN"
+	case ReminderStageApplyClose24H:
+		return "APPLY_CLOSE_24H"
+	case ReminderStageApplyClose1H:
+		return "APPLY_CLOSE_1H"
+	case ReminderStageResultDay:
+		return "RESULT_DAY"
+	default:
+		return "UNSPECIFIED"
+	}
+}
+
 // SalesPhase represents a single ticket-sales window for a series. A phase
 // belongs to a series and applies to it as a whole — there is no per-event
 // coverage subset.

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -105,6 +105,15 @@ const (
 	EventTicketEmailParsed AnalyticsEventName = "ticket.email.parsed"
 )
 
+// Sales reminder delivery events emitted from the backend.
+const (
+	// EventSalesReminderDelivered is recorded at every terminal delivery
+	// outcome of a sales-phase push reminder. It feeds reach and failure-rate
+	// dashboards per phase stage in PostHog.
+	// Properties: phase_stage, delivery_status.
+	EventSalesReminderDelivered AnalyticsEventName = "sales_reminder.delivered"
+)
+
 // Entry verification events emitted from the backend, including the
 // zero-knowledge-proof check at venue gates.
 const (
@@ -167,6 +176,7 @@ var knownBackendEvents = map[AnalyticsEventName]struct{}{
 	EventNotificationSubscribed:          {},
 	EventNotificationUnsubscribed:        {},
 	EventNotificationDelivered:           {},
+	EventSalesReminderDelivered:          {},
 }
 
 // IsKnownEvent reports whether name is registered in the backend event

--- a/internal/usecase/sales_reminder_delivery_uc.go
+++ b/internal/usecase/sales_reminder_delivery_uc.go
@@ -33,6 +33,7 @@ type salesReminderDeliveryUseCase struct {
 	reminderRepo entity.SalesPhaseReminderRepository
 	pushSubRepo  entity.PushSubscriptionRepository
 	sender       entity.PushNotificationSender
+	publisher    EventPublisher
 	metrics      PushMetrics
 	logger       *logging.Logger
 }
@@ -45,6 +46,7 @@ func NewSalesReminderDeliveryUseCase(
 	reminderRepo entity.SalesPhaseReminderRepository,
 	pushSubRepo entity.PushSubscriptionRepository,
 	sender entity.PushNotificationSender,
+	publisher EventPublisher,
 	metrics PushMetrics,
 	logger *logging.Logger,
 ) *salesReminderDeliveryUseCase {
@@ -52,8 +54,34 @@ func NewSalesReminderDeliveryUseCase(
 		reminderRepo: reminderRepo,
 		pushSubRepo:  pushSubRepo,
 		sender:       sender,
+		publisher:    publisher,
 		metrics:      metrics,
 		logger:       logger,
+	}
+}
+
+// publishDeliveryOutcome emits a sales_reminder.delivered analytics event for
+// the given terminal outcome. Failures are logged and never propagated — the
+// analytics publish must not affect DeliverReminder's return value or the
+// once-only RecordSent semantics.
+func (uc *salesReminderDeliveryUseCase) publishDeliveryOutcome(
+	ctx context.Context,
+	data entity.SalesPhaseReminderDueData,
+	stage entity.ReminderStage,
+	deliveryStatus string,
+) {
+	if err := uc.publisher.PublishEvent(ctx, entity.SubjectSalesReminderDelivered, entity.SalesReminderDeliveredData{
+		UserID:         data.UserID,
+		PhaseStage:     stage.String(),
+		DeliveryStatus: deliveryStatus,
+	}); err != nil {
+		uc.logger.Error(ctx, "failed to publish SALES_REMINDER.delivered event", err,
+			slog.String("user_id", data.UserID),
+			slog.String("phase_id", data.PhaseID),
+			slog.String("stage", stage.String()),
+			slog.String("delivery_status", deliveryStatus),
+		)
+		// Non-fatal: DeliverReminder's return value and RecordSent semantics are unchanged.
 	}
 }
 
@@ -67,7 +95,7 @@ func (uc *salesReminderDeliveryUseCase) DeliverReminder(ctx context.Context, dat
 	}
 
 	// Once-only guard: re-check AlreadySent to prevent double-send on
-	// at-least-once broker replay.
+	// at-least-once broker replay. Not a terminal delivery outcome — no analytics emit.
 	already, err := uc.reminderRepo.AlreadySent(ctx, data.UserID, data.PhaseID, stage)
 	if err != nil {
 		return fmt.Errorf("sales_reminder_delivery: AlreadySent check: %w", err)
@@ -84,9 +112,13 @@ func (uc *salesReminderDeliveryUseCase) DeliverReminder(ctx context.Context, dat
 	if len(subs) == 0 {
 		// No subscriptions — record sent so the next scan does not retry.
 		_ = uc.reminderRepo.RecordSent(ctx, data.UserID, data.PhaseID, stage)
+		// Terminal delivery outcome: user had no push subscriptions.
+		uc.publishDeliveryOutcome(ctx, data, stage, "no_subscription")
 		return nil
 	}
 
+	// nil Payload is a defensive skip — publisher should never emit this. Not
+	// a terminal delivery outcome because no send was attempted.
 	if data.Payload == nil {
 		uc.logger.Warn(ctx, "sales_reminder_delivery: nil payload, skipping", attrs...)
 		return nil
@@ -127,6 +159,11 @@ func (uc *salesReminderDeliveryUseCase) DeliverReminder(ctx context.Context, dat
 			uc.logger.Error(ctx, "sales_reminder_delivery: RecordSent failed", err, attrs...)
 			// Non-fatal: next scan will re-check via ListSentStages / AlreadySent.
 		}
+		// Terminal delivery outcome: at least one subscription accepted the push.
+		uc.publishDeliveryOutcome(ctx, data, stage, "delivered")
+	} else {
+		// Terminal delivery outcome: all send attempts were rejected (gone or error).
+		uc.publishDeliveryOutcome(ctx, data, stage, "failed")
 	}
 	return nil
 }

--- a/internal/usecase/sales_reminder_delivery_uc_test.go
+++ b/internal/usecase/sales_reminder_delivery_uc_test.go
@@ -1,0 +1,425 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liverty-music/backend/internal/entity"
+	entitymocks "github.com/liverty-music/backend/internal/entity/mocks"
+	"github.com/liverty-music/backend/internal/usecase"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
+)
+
+// noopDeliveryMetrics is a no-op PushMetrics for delivery use case tests that do
+// not assert on metric labels.
+type noopDeliveryMetrics struct{}
+
+func (noopDeliveryMetrics) RecordPushSend(_ context.Context, _ string) {}
+
+// buildDeliveryUC is a test helper that wires a salesReminderDeliveryUseCase
+// with caller-supplied mock dependencies.
+func buildDeliveryUC(
+	t *testing.T,
+	reminderRepo *entitymocks.MockSalesPhaseReminderRepository,
+	pushSubRepo *entitymocks.MockPushSubscriptionRepository,
+	sender *entitymocks.MockPushNotificationSender,
+	publisher *ucmocks.MockEventPublisher,
+) usecase.SalesReminderDeliveryUseCase {
+	t.Helper()
+	return usecase.NewSalesReminderDeliveryUseCase(
+		reminderRepo,
+		pushSubRepo,
+		sender,
+		publisher,
+		noopDeliveryMetrics{},
+		newTestLogger(t),
+	)
+}
+
+// validPayload returns a non-nil NotificationPayload for happy-path tests.
+func validPayload() *entity.NotificationPayload {
+	return &entity.NotificationPayload{Title: "Ticket Sales Open", Body: "Apply now."}
+}
+
+// validDueData builds a SalesPhaseReminderDueData for the given stage with a
+// non-nil payload.
+func validDueData(stage entity.ReminderStage) entity.SalesPhaseReminderDueData {
+	return entity.SalesPhaseReminderDueData{
+		UserID:  "user-001",
+		PhaseID: "phase-001",
+		Stage:   int16(stage),
+		Payload: validPayload(),
+	}
+}
+
+// ---- AlreadySent guard (no analytics emit expected) ----
+
+// TestDeliverReminder_AlreadySentSkipsWithoutEmit verifies that the AlreadySent
+// dedup guard returns nil without emitting an analytics event.
+func TestDeliverReminder_AlreadySentSkipsWithoutEmit(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
+		Return(true, nil)
+
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
+
+	require.NoError(t, err)
+	publisher.AssertNotCalled(t, "PublishEvent")
+}
+
+// ---- Infra-error returns (no analytics emit expected) ----
+
+// TestDeliverReminder_AlreadySentErrorReturnsErrWithoutEmit verifies that an
+// AlreadySent repository error propagates and does not emit analytics.
+func TestDeliverReminder_AlreadySentErrorReturnsErrWithoutEmit(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
+		Return(false, errors.New("db error"))
+
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
+
+	require.Error(t, err)
+	publisher.AssertNotCalled(t, "PublishEvent")
+}
+
+// TestDeliverReminder_ListByUserIDsErrorReturnsErrWithoutEmit verifies that a
+// push subscription list error propagates and does not emit analytics.
+func TestDeliverReminder_ListByUserIDsErrorReturnsErrWithoutEmit(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
+		Return(false, nil)
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-001"}).
+		Return(nil, errors.New("db error"))
+
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
+
+	require.Error(t, err)
+	publisher.AssertNotCalled(t, "PublishEvent")
+}
+
+// ---- nil-payload defensive skip (no analytics emit expected) ----
+
+// TestDeliverReminder_NilPayloadSkipsWithoutEmit verifies the nil-payload
+// defensive guard returns nil without emitting analytics — no send was attempted.
+func TestDeliverReminder_NilPayloadSkipsWithoutEmit(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	sub := &entity.PushSubscription{UserID: "user-001", Endpoint: "https://push.example.com/1"}
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
+		Return(false, nil)
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-001"}).
+		Return([]*entity.PushSubscription{sub}, nil)
+
+	data := entity.SalesPhaseReminderDueData{
+		UserID:  "user-001",
+		PhaseID: "phase-001",
+		Stage:   int16(entity.ReminderStageApplyOpen),
+		Payload: nil, // defensive skip
+	}
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), data)
+
+	require.NoError(t, err)
+	publisher.AssertNotCalled(t, "PublishEvent")
+}
+
+// ---- Terminal delivery outcome: no_subscription ----
+
+// TestDeliverReminder_NoSubscriptionEmitsNoSubscription verifies that
+// delivery_status="no_subscription" is emitted when the user has no push
+// subscriptions.
+func TestDeliverReminder_NoSubscriptionEmitsNoSubscription(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyClose24H).
+		Return(false, nil)
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-001"}).
+		Return([]*entity.PushSubscription{}, nil)
+	reminderRepo.EXPECT().
+		RecordSent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyClose24H).
+		Return(nil).
+		Maybe()
+
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
+			mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
+				return d.UserID == "user-001" &&
+					d.PhaseStage == "APPLY_CLOSE_24H" &&
+					d.DeliveryStatus == "no_subscription"
+			}),
+		).
+		Return(nil).
+		Once()
+
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyClose24H))
+
+	require.NoError(t, err)
+}
+
+// ---- Terminal delivery outcome: delivered ----
+
+// TestDeliverReminder_SuccessfulSendEmitsDelivered verifies that
+// delivery_status="delivered" is emitted after at least one successful push send.
+func TestDeliverReminder_SuccessfulSendEmitsDelivered(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	sub := &entity.PushSubscription{UserID: "user-001", Endpoint: "https://push.example.com/1"}
+
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
+		Return(false, nil)
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-001"}).
+		Return([]*entity.PushSubscription{sub}, nil)
+	sender.EXPECT().
+		Send(anyCtx, mock.Anything, sub).
+		Return(nil)
+	reminderRepo.EXPECT().
+		RecordSent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
+		Return(nil)
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
+			mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
+				return d.UserID == "user-001" &&
+					d.PhaseStage == "APPLY_OPEN" &&
+					d.DeliveryStatus == "delivered"
+			}),
+		).
+		Return(nil).
+		Once()
+
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
+
+	require.NoError(t, err)
+}
+
+// ---- Terminal delivery outcome: failed ----
+
+// TestDeliverReminder_AllSendFailEmitsFailed verifies that
+// delivery_status="failed" is emitted when all send attempts are rejected (non-410
+// errors, so no RecordSent).
+func TestDeliverReminder_AllSendFailEmitsFailed(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	sub := &entity.PushSubscription{UserID: "user-001", Endpoint: "https://push.example.com/1"}
+
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageResultDay).
+		Return(false, nil)
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-001"}).
+		Return([]*entity.PushSubscription{sub}, nil)
+	sender.EXPECT().
+		Send(anyCtx, mock.Anything, sub).
+		Return(errors.New("send error: 500 internal server error"))
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
+			mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
+				return d.UserID == "user-001" &&
+					d.PhaseStage == "RESULT_DAY" &&
+					d.DeliveryStatus == "failed"
+			}),
+		).
+		Return(nil).
+		Once()
+
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageResultDay))
+
+	// Total failure is not returned as an error — the next scan will retry.
+	require.NoError(t, err)
+}
+
+// TestDeliverReminder_AllGoneEmitsFailed verifies that delivery_status="failed"
+// is emitted when all subscriptions return 410 Gone (all gone, none succeeded).
+func TestDeliverReminder_AllGoneEmitsFailed(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	sub := &entity.PushSubscription{UserID: "user-001", Endpoint: "https://push.example.com/gone"}
+
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyClose1H).
+		Return(false, nil)
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-001"}).
+		Return([]*entity.PushSubscription{sub}, nil)
+	sender.EXPECT().
+		Send(anyCtx, mock.Anything, sub).
+		Return(apperr.ErrNotFound)
+	pushSubRepo.EXPECT().
+		Delete(anyCtx, "user-001", "https://push.example.com/gone").
+		Return(nil)
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
+			mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
+				return d.UserID == "user-001" &&
+					d.PhaseStage == "APPLY_CLOSE_1H" &&
+					d.DeliveryStatus == "failed"
+			}),
+		).
+		Return(nil).
+		Once()
+
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyClose1H))
+
+	require.NoError(t, err)
+}
+
+// ---- Publish non-fatal ----
+
+// TestDeliverReminder_PublishErrorIsNonFatal verifies that a PublishEvent
+// failure does not change DeliverReminder's return value or the once-only
+// RecordSent semantics.
+func TestDeliverReminder_PublishErrorIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+	publisher := ucmocks.NewMockEventPublisher(t)
+
+	sub := &entity.PushSubscription{UserID: "user-001", Endpoint: "https://push.example.com/1"}
+
+	reminderRepo.EXPECT().
+		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
+		Return(false, nil)
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-001"}).
+		Return([]*entity.PushSubscription{sub}, nil)
+	sender.EXPECT().
+		Send(anyCtx, mock.Anything, sub).
+		Return(nil)
+	reminderRepo.EXPECT().
+		RecordSent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
+		Return(nil)
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered, mock.Anything).
+		Return(errors.New("nats unavailable")).
+		Once()
+
+	uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
+
+	// Publish failure must NOT be returned — push delivered, RecordSent was called.
+	require.NoError(t, err)
+}
+
+// ---- phase_stage string form ----
+
+// TestDeliverReminder_PhaseStageStrings verifies that each ReminderStage value
+// serialises to the expected string in the published payload.
+func TestDeliverReminder_PhaseStageStrings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		stage     entity.ReminderStage
+		wantStage string
+	}{
+		{entity.ReminderStageApplyOpen, "APPLY_OPEN"},
+		{entity.ReminderStageApplyClose24H, "APPLY_CLOSE_24H"},
+		{entity.ReminderStageApplyClose1H, "APPLY_CLOSE_1H"},
+		{entity.ReminderStageResultDay, "RESULT_DAY"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.wantStage, func(t *testing.T) {
+			t.Parallel()
+
+			reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
+			pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+			sender := entitymocks.NewMockPushNotificationSender(t)
+			publisher := ucmocks.NewMockEventPublisher(t)
+
+			sub := &entity.PushSubscription{UserID: "user-001", Endpoint: "https://push.example.com/1"}
+
+			reminderRepo.EXPECT().
+				AlreadySent(anyCtx, "user-001", "phase-001", tt.stage).
+				Return(false, nil)
+			pushSubRepo.EXPECT().
+				ListByUserIDs(anyCtx, []string{"user-001"}).
+				Return([]*entity.PushSubscription{sub}, nil)
+			sender.EXPECT().
+				Send(anyCtx, mock.Anything, sub).
+				Return(nil)
+			reminderRepo.EXPECT().
+				RecordSent(anyCtx, "user-001", "phase-001", tt.stage).
+				Return(nil)
+			publisher.EXPECT().
+				PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
+					mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
+						assert.Equal(t, tt.wantStage, d.PhaseStage, "unexpected phase_stage")
+						return d.PhaseStage == tt.wantStage
+					}),
+				).
+				Return(nil).
+				Once()
+
+			uc := buildDeliveryUC(t, reminderRepo, pushSubRepo, sender, publisher)
+			err := uc.DeliverReminder(context.Background(), validDueData(tt.stage))
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/specification#532

## 📝 Summary of Changes

Implements OpenSpec task **14.4** `sales_reminder.delivered` — the sales-phase-timeline reach KPI.

- `SalesReminderDeliveryUseCase.DeliverReminder` publishes `SALES_REMINDER.delivered` at its terminal delivery outcomes, forwarded to PostHog with `{phase_stage, delivery_status}`, attributed to the user. `delivery_status`:
  - `"delivered"` — at least one push send succeeded
  - `"no_subscription"` — user has no push subscriptions
  - `"failed"` — all sends rejected (410 Gone / error)
- Deliberately **does NOT** emit on: already-sent dedup skip, nil-payload defensive skip, or pre-delivery infra-error returns (`AlreadySent`/`ListByUserIDs`/`Marshal`).
- Publishing is **non-fatal** and never alters the once-only `RecordSent` semantics; consumer non-blocking. Adds `ReminderStage.String()` for `phase_stage`. Constant already in the catalogue, so no spec change. Publisher dep added to the delivery uc + wired in `di/consumer.go`.

## Type of Change
- [x] feat: A new feature

## Verification
- [x] `make check` passed (lint + modernize + golangci-lint + docker integration tests).
- [x] Tests: emit-per-outcome (delivered/no_subscription/failed incl. all-410), no-emit on dedup + infra errors, publish-error non-fatal, all stage strings; consumer handler forward / nil-client / empty-UserID / enqueue-error.

## Self-Checklist
- [x] Clean Architecture; `apperr`; publisher non-fatal; consumer non-blocking.
- [x] Mocks refreshed; follows the §14 template (14.1/14.6).
