### PR TITLE
fix(messaging): add JetStream streams for ticket/sales-reminder subjects

### DIFF
--- a/internal/infrastructure/messaging/streams.go
+++ b/internal/infrastructure/messaging/streams.go
@@ -108,6 +108,54 @@ var streams = []nats.StreamConfig{
 		Duplicates: 2 * time.Minute,
 	},
 	{
+		// Carries SALES_REMINDER.delivered (sales-phase push reminder delivery
+		// outcomes), consumed by the analytics consumer.
+		Name:       "SALES_REMINDER",
+		Subjects:   []string{"SALES_REMINDER.*"},
+		Retention:  nats.LimitsPolicy,
+		MaxAge:     7 * 24 * time.Hour,
+		Storage:    nats.FileStorage,
+		Discard:    nats.DiscardOld,
+		Replicas:   1,
+		Duplicates: 2 * time.Minute,
+	},
+	{
+		// Carries TICKET.mint_completed (soulbound-ticket mint outcomes),
+		// consumed by the analytics consumer.
+		Name:       "TICKET",
+		Subjects:   []string{"TICKET.*"},
+		Retention:  nats.LimitsPolicy,
+		MaxAge:     7 * 24 * time.Hour,
+		Storage:    nats.FileStorage,
+		Discard:    nats.DiscardOld,
+		Replicas:   1,
+		Duplicates: 2 * time.Minute,
+	},
+	{
+		// Carries TICKET_JOURNEY.status_changed (fan interest-tier
+		// transitions), consumed by the analytics consumer.
+		Name:       "TICKET_JOURNEY",
+		Subjects:   []string{"TICKET_JOURNEY.*"},
+		Retention:  nats.LimitsPolicy,
+		MaxAge:     7 * 24 * time.Hour,
+		Storage:    nats.FileStorage,
+		Discard:    nats.DiscardOld,
+		Replicas:   1,
+		Duplicates: 2 * time.Minute,
+	},
+	{
+		// Carries TICKET_EMAIL.parsed (ticket-email ingestion outcomes),
+		// consumed by the analytics consumer.
+		Name:       "TICKET_EMAIL",
+		Subjects:   []string{"TICKET_EMAIL.*"},
+		Retention:  nats.LimitsPolicy,
+		MaxAge:     7 * 24 * time.Hour,
+		Storage:    nats.FileStorage,
+		Discard:    nats.DiscardOld,
+		Replicas:   1,
+		Duplicates: 2 * time.Minute,
+	},
+	{
 		Name:       "POISON",
 		Subjects:   []string{"POISON.*"},
 		Retention:  nats.LimitsPolicy,


### PR DESCRIPTION
## 🔗 Related Issue

Closes #355

## 📝 Summary of Changes

Fixes a prod consumer crashloop introduced when v1.14.0 became the first release to subscribe to the ticket/sales-reminder analytics subjects.

- The analytics-forwarding consumer (`internal/di/consumer.go`) subscribes to `TICKET_EMAIL.parsed`, `TICKET.mint_completed`, `TICKET_JOURNEY.status_changed`, and `SALES_REMINDER.delivered`, but `streams.go` defined no JetStream streams for those domains.
- `EnsureStreams` (run at consumer startup) only creates streams from the `streams` slice, so the subscribe failed with `nats: no stream matches subject` and the consumer crashlooped — the v1.14.0 rollout stalled with the old v1.13.0 pod still serving (ArgoCD backend = Degraded).
- Adds the four missing streams following the existing per-domain pattern (single-token suffixes → `.*`): `SALES_REMINDER`, `TICKET`, `TICKET_JOURNEY`, `TICKET_EMAIL`.

These subscriptions were added after v1.13.0 (analytics events batch #348/#316), so the gap only surfaced now. Target patch release: **v1.14.1**.

## 📋 Commit Log

- `fix(messaging): add JetStream streams for ticket/sales-reminder subjects`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes (messaging pkg tests pass; change is a stream-config addition matching the established pattern).
- [x] I have updated the relevant documentation (N/A).
- [x] I have run build / vet / messaging tests locally — all pass; `gofmt` clean.
- [x] My code follows the architecture and style guidelines of the project.

## 📸 Screenshots or Logs

Before (prod): `consumer router stopped with error: cannot subscribe topic TICKET_EMAIL.parsed: nats: no stream matches subject`
