### PR TITLE
test(messaging): guard every event subject has a JetStream stream

### DIFF
--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -49,6 +49,33 @@ const (
 	SubjectTicketEmailParsed = "TICKET_EMAIL.parsed"
 )
 
+// AllSubjects is the canonical catalogue of every domain-event NATS subject
+// the system publishes and consumes. It is the single source of truth for
+// coverage checks: a subject added above MUST be added here too, and the
+// stream-coverage test then guarantees each one is captured by a configured
+// JetStream stream (see messaging.SubjectCoveredByStream). This closes the
+// recurring "added a publisher/subscription without its paired stream" gap
+// that fails a consumer at startup with "no stream matches subject".
+var AllSubjects = []string{
+	SubjectConcertDiscovered,
+	SubjectConcertCreated,
+	SubjectArtistCreated,
+	SubjectArtistFollowed,
+	SubjectArtistUnfollowed,
+	SubjectUserCreated,
+	SubjectUserPreferredLanguageUpdated,
+	SubjectNotificationSubscribed,
+	SubjectNotificationUnsubscribed,
+	SubjectEntryZkProofVerified,
+	SubjectEntryZkProofRejected,
+	SubjectSalesPhaseDiscovered,
+	SubjectSalesPhaseReminderDue,
+	SubjectTicketJourneyStatusChanged,
+	SubjectTicketMintCompleted,
+	SubjectSalesReminderDelivered,
+	SubjectTicketEmailParsed,
+}
+
 // EntryRejectionReason enumerates the legitimate causes for a
 // zk-proof entry rejection. Carried on the entry.zk_proof.rejected
 // analytics event so operations dashboards can break down

--- a/internal/infrastructure/messaging/streams.go
+++ b/internal/infrastructure/messaging/streams.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/liverty-music/backend/pkg/config"
@@ -165,6 +166,52 @@ var streams = []nats.StreamConfig{
 		Replicas:   1,
 		Duplicates: 2 * time.Minute,
 	},
+}
+
+// SubjectCoveredByStream reports whether the given concrete NATS subject is
+// captured by at least one configured JetStream stream. A JetStream consumer
+// can only bind to a subject that some stream's subject filter matches; a
+// subscription to an uncovered subject fails at startup with "no stream
+// matches subject" and crashloops the consumer. This is the recurring class of
+// bug that occurs when a new publisher/subscription is added for a fresh event
+// domain without adding its paired stream to the streams list above.
+//
+// Matching follows NATS token semantics: subjects are '.'-delimited; a '*'
+// token matches exactly one token, and a trailing '>' matches one or more
+// remaining tokens.
+func SubjectCoveredByStream(subject string) bool {
+	for _, s := range streams {
+		for _, filter := range s.Subjects {
+			if subjectMatches(filter, subject) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// subjectMatches implements NATS subject-filter matching for a single filter
+// against a concrete subject.
+func subjectMatches(filter, subject string) bool {
+	filterTokens := strings.Split(filter, ".")
+	subjectTokens := strings.Split(subject, ".")
+
+	for i, ft := range filterTokens {
+		// A trailing '>' matches all remaining subject tokens (at least one).
+		if ft == ">" {
+			return i < len(subjectTokens)
+		}
+		if i >= len(subjectTokens) {
+			return false
+		}
+		// '*' matches exactly one token; otherwise require an exact match.
+		if ft != "*" && ft != subjectTokens[i] {
+			return false
+		}
+	}
+
+	// No '>' wildcard consumed the tail, so token counts must match exactly.
+	return len(filterTokens) == len(subjectTokens)
 }
 
 // EnsureStreams connects to NATS and creates or updates the required

--- a/internal/infrastructure/messaging/streams_test.go
+++ b/internal/infrastructure/messaging/streams_test.go
@@ -1,0 +1,84 @@
+package messaging_test
+
+import (
+	"testing"
+
+	"github.com/liverty-music/backend/internal/entity"
+	"github.com/liverty-music/backend/internal/infrastructure/messaging"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAllSubjectsCoveredByStream is the regression guard for the recurring
+// "added a publisher/subscription without its paired JetStream stream" bug:
+// every domain-event subject in the entity catalogue MUST be captured by a
+// configured stream, otherwise a JetStream consumer that subscribes to it
+// fails at startup with "no stream matches subject" and crashloops in
+// production. This ran red for TICKET/TICKET_JOURNEY/TICKET_EMAIL/SALES_REMINDER
+// (and earlier SALES_PHASE) before their streams were added.
+func TestAllSubjectsCoveredByStream(t *testing.T) {
+	t.Parallel()
+
+	for _, subject := range entity.AllSubjects {
+		t.Run(subject, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Truef(t, messaging.SubjectCoveredByStream(subject),
+				"subject %q is not covered by any JetStream stream; add a stream "+
+					"whose Subjects match it to the streams list in streams.go, "+
+					"otherwise a consumer subscribing to it crashloops with "+
+					"\"no stream matches subject\"", subject)
+		})
+	}
+}
+
+// TestSubjectCoveredByStream exercises the NATS token-matching semantics
+// directly, including the '*' (single token) vs '>' (trailing tokens) nuance
+// that made SALES_PHASE.reminder.due require a '>' filter.
+func TestSubjectCoveredByStream(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		subject string
+		want    bool
+	}{
+		{
+			name:    "single-token subject matched by <domain>.* stream",
+			subject: "TICKET.mint_completed",
+			want:    true,
+		},
+		{
+			name:    "nested subject matched by <domain>.> stream",
+			subject: "SALES_PHASE.reminder.due",
+			want:    true,
+		},
+		{
+			name:    "single-token subject matched by <domain>.> stream",
+			subject: "SALES_PHASE.discovered",
+			want:    true,
+		},
+		{
+			name:    "unknown domain is not covered",
+			subject: "UNKNOWN.event",
+			want:    false,
+		},
+		{
+			name:    "nested subject is NOT covered by a single-token .* filter",
+			subject: "TICKET.mint.completed",
+			want:    false,
+		},
+		{
+			name:    "domain prefix alone (no event token) is not covered",
+			subject: "TICKET",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, messaging.SubjectCoveredByStream(tt.subject))
+		})
+	}
+}


### PR DESCRIPTION
## 🔗 Related Issue

Refs #355

<!-- #355 was already fixed by #356 (the missing streams were added). This PR
adds the regression guard so the class of bug cannot recur, so it references
rather than re-closes the issue. -->

## 📝 Summary of Changes

**Motivation.** #355 was a production consumer crashloop: the analytics consumer subscribed to `TICKET.mint_completed`, `TICKET_JOURNEY.status_changed`, `TICKET_EMAIL.parsed`, and `SALES_REMINDER.delivered`, but `streams.go` defined no JetStream streams for those domains. `EnsureStreams` only creates streams from its list, so the subscribe failed at startup with `nats: no stream matches subject` and the consumer crashlooped (v1.14.0). The same "added a publisher/subscription without its paired stream" omission had hit `SALES_PHASE` earlier. **Nothing in CI caught it** — it compiles fine; the failure only surfaces at runtime when the consumer binds to NATS (and the dev-env smoke that could have booted the consumer is skipped because dev is stopped).

**Approach.** Move detection left from a prod crashloop to a failing unit test before merge, with no NATS required:

- **`entity.AllSubjects`** — single source of truth listing every domain-event subject. A newly added subject constant must be added here too.
- **`messaging.SubjectCoveredByStream`** — reports whether a subject is captured by a configured stream, using NATS token semantics (`*` = one token, `>` = trailing tokens) so the `SALES_PHASE.>` nesting is evaluated correctly.
- **`streams_test.go`** — asserts every `entity.AllSubjects` entry is covered by some stream, plus unit-tests for the matcher. This runs red in plain `make test`/CI the moment a subject is added without its stream.

No behavior change to `EnsureStreams`; production is already fixed (v1.16.0). This is a prevention-only, test + pure-helper addition — no OpenSpec change (no capability/requirement change).

## 📋 Commit Log

- `test(messaging): guard every event subject has a JetStream stream`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [ ] I have updated the relevant documentation (e.g., `README.md`, `CLAUDE.md`).
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.

## 📸 Screenshots or Logs

The bug this guards against, as it manifested in prod (2026-06-30):

```
consumer router stopped with error
  cannot subscribe topic TICKET.mint_completed:        nats: no stream matches subject
  cannot subscribe topic TICKET_JOURNEY.status_changed: nats: no stream matches subject
  cannot subscribe topic TICKET_EMAIL.parsed:           nats: no stream matches subject
  cannot subscribe topic SALES_REMINDER.delivered:      nats: no stream matches subject
```
