### PR TITLE
feat(notification): emit notification.delivered analytics event

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -354,6 +354,70 @@ func (c *AnalyticsConsumer) HandleNotificationUnsubscribed(msg *message.Message)
 	return nil
 }
 
+// HandleNotificationDelivered forwards the NOTIFICATION.delivered NATS
+// subject as the catalogue event usecase.EventNotificationDelivered.
+// Properties: notification_id, type. The distinct_id is the recipient's
+// platform UserID. Fired once per notification whose channel send reached
+// the delivered state, so push-delivery reach is measurable in PostHog.
+func (c *AnalyticsConsumer) HandleNotificationDelivered(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.NotificationDeliveredData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse NOTIFICATION.delivered event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse NOTIFICATION.delivered event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventNotificationDelivered)),
+			slog.String("user_id", data.UserID),
+			slog.String("notification_id", data.NotificationID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "NOTIFICATION.delivered event missing user_id, skipping forward",
+			slog.String("notification_id", data.NotificationID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	if data.NotificationID == "" {
+		c.logger.Warn(ctx, "NOTIFICATION.delivered event missing notification_id, skipping forward",
+			slog.String("user_id", data.UserID),
+		)
+		// Reuse the empty-user_id status label to keep the metric label set
+		// (and Prometheus cardinality) fixed: "missing correlation key" is the
+		// semantic match regardless of which key is absent.
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	properties := usecase.AnalyticsProperties{
+		"notification_id": data.NotificationID,
+		"type":            data.Type,
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventNotificationDelivered, properties); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventNotificationDelivered)),
+			slog.String("user_id", data.UserID),
+			slog.String("notification_id", data.NotificationID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
 // HandleEntryZkProofVerified forwards the ENTRY.zk_proof_verified
 // NATS subject as the catalogue event usecase.EventEntryZkProofVerified.
 // The distinct_id is the nullifier hash hex — anonymous-by-design per

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -697,6 +697,127 @@ func TestAnalyticsConsumer_HandleNotificationUnsubscribed(t *testing.T) {
 	}
 }
 
+// TestAnalyticsConsumer_HandleNotificationDelivered covers
+// NOTIFICATION.delivered → notification.delivered routing.
+// Distinct_id is the recipient UserID; properties: notification_id, type.
+func TestAnalyticsConsumer_HandleNotificationDelivered(t *testing.T) {
+	t.Parallel()
+
+	const validUserID = "11111111-2222-3333-4444-555555555555"
+
+	type args struct {
+		data entity.NotificationDeliveredData
+	}
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards with notification_id + type when client + UserID present",
+			args: args{data: entity.NotificationDeliveredData{
+				UserID:         validUserID,
+				NotificationID: "01890000-0000-7000-8000-000000000abc",
+				Type:           "new_concerts",
+			}},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name: "skips forward when client is nil",
+			args: args{data: entity.NotificationDeliveredData{
+				UserID:         validUserID,
+				NotificationID: "01890000-0000-7000-8000-000000000abc",
+				Type:           "new_concerts",
+			}},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			args: args{data: entity.NotificationDeliveredData{
+				UserID:         "",
+				NotificationID: "01890000-0000-7000-8000-000000000abc",
+				Type:           "new_concerts",
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "skips forward when notification_id is empty",
+			args: args{data: entity.NotificationDeliveredData{
+				UserID:         validUserID,
+				NotificationID: "",
+				Type:           "new_concerts",
+			}},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			args: args{data: entity.NotificationDeliveredData{
+				UserID:         validUserID,
+				NotificationID: "01890000-0000-7000-8000-000000000abc",
+				Type:           "sales_phase_announcement",
+			}},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			var clientMock *ucmocks.MockAnalyticsClient
+			if !tt.nilClient {
+				clientMock = ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.args.data.UserID,
+							usecase.EventNotificationDelivered,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return props["notification_id"] == tt.args.data.NotificationID &&
+									props["type"] == tt.args.data.Type
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleNotificationDelivered(makeAnalyticsMsg(t, tt.args.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // TestAnalyticsConsumer_HandleEntryZkProofVerified covers
 // ENTRY.zk_proof_verified routing. Distinct_id is the nullifier hash
 // hex (anonymous per ZK guarantee); event_id is a property.

--- a/internal/adapter/event/sales_consumers_test.go
+++ b/internal/adapter/event/sales_consumers_test.go
@@ -92,12 +92,7 @@ func TestSalesReminderConsumer_Handle(t *testing.T) {
 		UserID:  "user-001",
 		PhaseID: "phase-001",
 		Stage:   int16(entity.ReminderStageApplyOpen),
-		Payload: &entity.NotificationPayload{
-			Title: "Ticket Sales Open",
-			Body:  "Sales open now",
-			URL:   "/series/s1",
-			Tag:   "tag-1",
-		},
+		Payload: entity.NewNotificationPayload("Ticket Sales Open", "Sales open now", "/series/s1", "tag-1"),
 	}
 
 	t.Run("delegates to use case on success", func(t *testing.T) {

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -126,7 +126,7 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	webpushSender := infrawebpush.NewSender(cfg.VAPID.PublicKey, cfg.VAPID.PrivateKey, cfg.VAPID.Contact)
 	eventPublisher := messaging.NewEventPublisher(publisher)
 	notificationRepo := rdb.NewNotificationRepository(db)
-	notificationUC := usecase.NewNotificationUseCase(notificationRepo, pushSubRepo, webpushSender, infratelemetry.NewBusinessMetrics(), logger)
+	notificationUC := usecase.NewNotificationUseCase(notificationRepo, pushSubRepo, webpushSender, eventPublisher, infratelemetry.NewBusinessMetrics(), logger)
 	pushNotificationUC := usecase.NewPushNotificationUseCase(
 		artistRepo,
 		concertRepo,
@@ -269,6 +269,15 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		entity.SubjectNotificationUnsubscribed,
 		subscriber,
 		analyticsConsumer.HandleNotificationUnsubscribed,
+	)
+
+	// NOTIFICATION.delivered matches the existing NOTIFICATION.* stream
+	// (see messaging.streams) — no new JetStream stream is required.
+	router.AddConsumerHandler(
+		"forward-notification-delivered-to-analytics",
+		entity.SubjectNotificationDelivered,
+		subscriber,
+		analyticsConsumer.HandleNotificationDelivered,
 	)
 
 	router.AddConsumerHandler(

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -207,7 +207,7 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	}
 	webpushSender := infrawebpush.NewSender(cfg.VAPID.PublicKey, cfg.VAPID.PrivateKey, cfg.VAPID.Contact)
 	notificationRepo := rdb.NewNotificationRepository(db)
-	notificationUC := usecase.NewNotificationUseCase(notificationRepo, pushSubRepo, webpushSender, businessMetrics, logger)
+	notificationUC := usecase.NewNotificationUseCase(notificationRepo, pushSubRepo, webpushSender, eventPublisher, businessMetrics, logger)
 	pushNotificationUC := usecase.NewPushNotificationUseCase(
 		artistRepo,
 		concertRepo,

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -17,8 +17,14 @@ const (
 	SubjectUserPreferredLanguageUpdated = "USER.preferred_language_updated"
 	SubjectNotificationSubscribed       = "NOTIFICATION.subscribed"
 	SubjectNotificationUnsubscribed     = "NOTIFICATION.unsubscribed"
-	SubjectEntryZkProofVerified         = "ENTRY.zk_proof_verified"
-	SubjectEntryZkProofRejected         = "ENTRY.zk_proof_rejected"
+	// SubjectNotificationDelivered is published by NotificationUseCase once per
+	// notification whose channel send reached the delivered state. It drives the
+	// notification.delivered analytics event so push-delivery reach can be
+	// tracked in PostHog, keyed by notification_id. Matches the existing
+	// NOTIFICATION.* JetStream stream — no new stream required.
+	SubjectNotificationDelivered = "NOTIFICATION.delivered"
+	SubjectEntryZkProofVerified  = "ENTRY.zk_proof_verified"
+	SubjectEntryZkProofRejected  = "ENTRY.zk_proof_rejected"
 	// SubjectSalesPhaseDiscovered is published when a brand-new sales phase row
 	// is inserted. Re-discovery of an existing phase (UpsertOutcomeUpdated)
 	// must NOT publish this event.
@@ -66,6 +72,7 @@ var AllSubjects = []string{
 	SubjectUserPreferredLanguageUpdated,
 	SubjectNotificationSubscribed,
 	SubjectNotificationUnsubscribed,
+	SubjectNotificationDelivered,
 	SubjectEntryZkProofVerified,
 	SubjectEntryZkProofRejected,
 	SubjectSalesPhaseDiscovered,
@@ -228,6 +235,23 @@ type NotificationUnsubscribedData struct {
 	// host. Values: "android" (FCM), "apple" (Web Push for Safari), "firefox"
 	// (Mozilla autopush), "windows" (WNS), "other". See DeviceTypeFromEndpoint.
 	DeviceType string `json:"device_type"`
+}
+
+// NotificationDeliveredData is the payload for NOTIFICATION.delivered.
+// Mapped to the catalogue event notification.delivered by the
+// analytics-consumer. Published by NotificationUseCase once per notification
+// whose channel send reached the delivered state, so push-delivery reach is
+// measurable in PostHog keyed by notification_id. A failed delivery does NOT
+// publish this event.
+type NotificationDeliveredData struct {
+	// UserID is the platform-internal user identifier of the recipient.
+	// Used as the PostHog distinct_id.
+	UserID string `json:"user_id"`
+	// NotificationID is the stored notification record id, the end-to-end
+	// correlation key shared with the client open/dismiss events.
+	NotificationID string `json:"notification_id"`
+	// Type is the string name of the NotificationType (e.g. "new_concerts").
+	Type string `json:"type"`
 }
 
 // SalesPhaseDiscoveredData is the payload for SALES_PHASE.discovered events.

--- a/internal/entity/push_notification.go
+++ b/internal/entity/push_notification.go
@@ -10,13 +10,13 @@ type NotificationPayload struct {
 	Title string `json:"title"`
 	// Body is the human-readable notification text.
 	Body string `json:"body"`
-	// URL is the deep-link target opened when the user taps the notification.
-	URL string `json:"url"`
 	// Tag deduplicates notifications on the browser side; one active notification per tag.
 	Tag string `json:"tag"`
-	// Data carries key/value metadata delivered alongside the notification. The
-	// service worker reads it (e.g. data.notification_id) to correlate user
-	// interactions back to the stored notification record. Omitted when empty.
+	// Data carries the client-passthrough metadata delivered alongside the
+	// notification. The service worker maps it straight into showNotification's
+	// options.data, so notificationclick/close read it uniformly — the deep-link
+	// target (data.url) and the correlation key (data.notification_id). Omitted
+	// when empty.
 	Data map[string]string `json:"data,omitempty"`
 }
 
@@ -24,6 +24,25 @@ type NotificationPayload struct {
 // which the stored notification record's id is propagated to the client/service
 // worker, establishing the end-to-end correlation key.
 const NotificationDataKeyNotificationID = "notification_id"
+
+// NotificationDataKeyURL is the [NotificationPayload.Data] key under which the
+// deep-link target opened on notificationclick is propagated to the client.
+// Consolidated with notification_id under Data so the service worker maps the
+// whole payload.data into showNotification's options.data in one step.
+const NotificationDataKeyURL = "url"
+
+// NewNotificationPayload builds a payload with the deep-link url placed under
+// the client-passthrough Data map (data.url), where the service worker reads it
+// on notificationclick. Title, body, and tag stay top-level as native Web Push
+// notification fields.
+func NewNotificationPayload(title, body, url, tag string) *NotificationPayload {
+	return &NotificationPayload{
+		Title: title,
+		Body:  body,
+		Tag:   tag,
+		Data:  map[string]string{NotificationDataKeyURL: url},
+	}
+}
 
 // PushNotificationSender sends Web Push notifications to browser endpoints.
 // Implementations handle VAPID signing, encryption, and HTTP delivery.

--- a/internal/infrastructure/database/rdb/notification_repo_test.go
+++ b/internal/infrastructure/database/rdb/notification_repo_test.go
@@ -14,14 +14,9 @@ import (
 
 func newTestNotification(userID string, typ entity.NotificationType) *entity.Notification {
 	return &entity.Notification{
-		UserID: userID,
-		Type:   typ,
-		Payload: &entity.NotificationPayload{
-			Title: "Test Artist",
-			Body:  "1 new concert found",
-			URL:   "/concerts?artist=abc",
-			Tag:   "concert-abc",
-		},
+		UserID:  userID,
+		Type:    typ,
+		Payload: entity.NewNotificationPayload("Test Artist", "1 new concert found", "/concerts?artist=abc", "concert-abc"),
 	}
 }
 

--- a/internal/usecase/notification_uc.go
+++ b/internal/usecase/notification_uc.go
@@ -70,6 +70,7 @@ type notificationUseCase struct {
 	notificationRepo entity.NotificationRepository
 	pushSubRepo      entity.PushSubscriptionRepository
 	sender           entity.PushNotificationSender
+	publisher        EventPublisher
 	metrics          PushMetrics
 	logger           *logging.Logger
 }
@@ -77,11 +78,15 @@ type notificationUseCase struct {
 // Compile-time interface compliance check.
 var _ NotificationUseCase = (*notificationUseCase)(nil)
 
-// NewNotificationUseCase wires the notification use case.
+// NewNotificationUseCase wires the notification use case. publisher is used to
+// emit the non-fatal NOTIFICATION.delivered analytics event at the delivered
+// transition; analytics must never affect delivery, so publish failures are
+// logged and swallowed.
 func NewNotificationUseCase(
 	notificationRepo entity.NotificationRepository,
 	pushSubRepo entity.PushSubscriptionRepository,
 	sender entity.PushNotificationSender,
+	publisher EventPublisher,
 	metrics PushMetrics,
 	logger *logging.Logger,
 ) NotificationUseCase {
@@ -89,6 +94,7 @@ func NewNotificationUseCase(
 		notificationRepo: notificationRepo,
 		pushSubRepo:      pushSubRepo,
 		sender:           sender,
+		publisher:        publisher,
 		metrics:          metrics,
 		logger:           logger,
 	}
@@ -133,6 +139,24 @@ func (uc *notificationUseCase) Notify(ctx context.Context, userID string, typ en
 	n.DeliveryStatus = status
 	n.DeliverTime = deliveredAt
 	n.FailureReason = reason
+
+	// 5. Emit the delivered analytics event exactly once per notification, only
+	//    when the send actually reached the delivered state. Non-fatal by design:
+	//    analytics must never affect the delivery outcome, so a publish failure is
+	//    logged and swallowed (mirrors the notification.subscribed emit).
+	if status == entity.NotificationDeliveryStatusDelivered {
+		if err := uc.publisher.PublishEvent(ctx, entity.SubjectNotificationDelivered, entity.NotificationDeliveredData{
+			UserID:         userID,
+			NotificationID: n.ID,
+			Type:           string(typ),
+		}); err != nil {
+			uc.logger.Error(ctx, "failed to publish NOTIFICATION.delivered event", err,
+				slog.String("notification_id", n.ID),
+				slog.String("user_id", userID),
+			)
+		}
+	}
+
 	return n, nil
 }
 

--- a/internal/usecase/notification_uc_test.go
+++ b/internal/usecase/notification_uc_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/liverty-music/backend/internal/entity"
 	entitymocks "github.com/liverty-music/backend/internal/entity/mocks"
 	"github.com/liverty-music/backend/internal/usecase"
+	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 )
 
 func buildNotificationUC(
@@ -22,19 +23,21 @@ func buildNotificationUC(
 	notifRepo *entitymocks.MockNotificationRepository,
 	pushSubRepo *entitymocks.MockPushSubscriptionRepository,
 	sender *entitymocks.MockPushNotificationSender,
+	publisher *ucmocks.MockEventPublisher,
 ) usecase.NotificationUseCase {
 	t.Helper()
 	return usecase.NewNotificationUseCase(
 		notifRepo,
 		pushSubRepo,
 		sender,
+		publisher,
 		noopMetrics{},
 		newTestLogger(t),
 	)
 }
 
 func notifPayload() *entity.NotificationPayload {
-	return &entity.NotificationPayload{Title: "Artist", Body: "1 new concert found", URL: "/concerts", Tag: "concert-x"}
+	return entity.NewNotificationPayload("Artist", "1 new concert found", "/concerts", "concert-x")
 }
 
 func sub(userID, endpoint string) *entity.PushSubscription {
@@ -63,8 +66,18 @@ func TestNotify_Success(t *testing.T) {
 	notifRepo.EXPECT().
 		UpdateDelivery(anyCtx, "01890000-0000-7000-8000-000000000abc", entity.NotificationDeliveryStatusDelivered, mock.AnythingOfType("*time.Time"), "").
 		Return(nil)
+	// Delivered ⇒ exactly one NOTIFICATION.delivered emit, keyed by notification_id.
+	publisher := ucmocks.NewMockEventPublisher(t)
+	publisher.EXPECT().
+		PublishEvent(anyCtx, entity.SubjectNotificationDelivered, entity.NotificationDeliveredData{
+			UserID:         "user-1",
+			NotificationID: "01890000-0000-7000-8000-000000000abc",
+			Type:           string(entity.NotificationTypeNewConcerts),
+		}).
+		Return(nil).
+		Once()
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, publisher)
 	payload := notifPayload()
 	n, err := uc.Notify(context.Background(), "user-1", entity.NotificationTypeNewConcerts, payload)
 
@@ -97,7 +110,7 @@ func TestNotify_SendFailureRecordedAsFailed(t *testing.T) {
 		UpdateDelivery(anyCtx, "id-fail", entity.NotificationDeliveryStatusFailed, (*time.Time)(nil), mock.MatchedBy(func(s string) bool { return s != "" })).
 		Return(nil)
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	n, err := uc.Notify(context.Background(), "user-1", entity.NotificationTypeNewConcerts, notifPayload())
 
 	require.NoError(t, err)
@@ -130,7 +143,7 @@ func TestNotify_GoneSubscriptionCleanedUpAndFailed(t *testing.T) {
 		UpdateDelivery(anyCtx, "id-gone", entity.NotificationDeliveryStatusFailed, (*time.Time)(nil), mock.Anything).
 		Return(nil)
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	_, err := uc.Notify(context.Background(), "user-1", entity.NotificationTypeNewConcerts, notifPayload())
 	require.NoError(t, err)
 }
@@ -155,7 +168,7 @@ func TestNotify_NoSubscriptionRecordedAsFailed(t *testing.T) {
 		UpdateDelivery(anyCtx, "id-nosub", entity.NotificationDeliveryStatusFailed, (*time.Time)(nil), "no active push subscription").
 		Return(nil)
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	_, err := uc.Notify(context.Background(), "user-1", entity.NotificationTypeNewConcerts, notifPayload())
 	require.NoError(t, err)
 	sender.AssertNotCalled(t, "Send")
@@ -185,7 +198,7 @@ func TestNotify_ContextCancelledStopsDispatch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	n, err := uc.Notify(ctx, "user-1", entity.NotificationTypeNewConcerts, notifPayload())
 
 	require.NoError(t, err)
@@ -206,7 +219,7 @@ func TestNotify_RecordFailureDoesNotSend(t *testing.T) {
 		Create(anyCtx, mock.Anything).
 		Return(apperr.New(codes.Internal, "db down"))
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	_, err := uc.Notify(context.Background(), "user-1", entity.NotificationTypeNewConcerts, notifPayload())
 
 	require.Error(t, err)
@@ -223,7 +236,7 @@ func TestNotify_NilPayloadRejected(t *testing.T) {
 	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
 	sender := entitymocks.NewMockPushNotificationSender(t)
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	_, err := uc.Notify(context.Background(), "user-1", entity.NotificationTypeNewConcerts, nil)
 
 	require.ErrorIs(t, err, apperr.ErrInvalidArgument)
@@ -246,7 +259,7 @@ func TestMarkRead_OwnedDelegatesToRepo(t *testing.T) {
 		MarkRead(anyCtx, "user-1", "n-1").
 		Return(nil)
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	require.NoError(t, uc.MarkRead(context.Background(), "user-1", "n-1"))
 }
 
@@ -263,7 +276,7 @@ func TestMarkRead_CrossUserRejected(t *testing.T) {
 		Get(anyCtx, "n-1").
 		Return(&entity.Notification{ID: "n-1", UserID: "owner"}, nil)
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	err := uc.MarkRead(context.Background(), "attacker", "n-1")
 
 	require.ErrorIs(t, err, apperr.ErrPermissionDenied)
@@ -282,7 +295,7 @@ func TestMarkDismissed_CrossUserRejected(t *testing.T) {
 		Get(anyCtx, "n-1").
 		Return(&entity.Notification{ID: "n-1", UserID: "owner"}, nil)
 
-	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender)
+	uc := buildNotificationUC(t, notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t))
 	err := uc.MarkDismissed(context.Background(), "attacker", "n-1")
 
 	require.ErrorIs(t, err, apperr.ErrPermissionDenied)

--- a/internal/usecase/push_notification_uc.go
+++ b/internal/usecase/push_notification_uc.go
@@ -297,12 +297,12 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 		default:
 		}
 
-		payload := &entity.NotificationPayload{
-			Title: artist.Name,
-			Body:  concertNotificationBody(len(concerts), langByUser[userID]),
-			URL:   fmt.Sprintf("/concerts?artist=%s", artist.ID),
-			Tag:   fmt.Sprintf("concert-%s", artist.ID),
-		}
+		payload := entity.NewNotificationPayload(
+			artist.Name,
+			concertNotificationBody(len(concerts), langByUser[userID]),
+			fmt.Sprintf("/concerts?artist=%s", artist.ID),
+			fmt.Sprintf("concert-%s", artist.ID),
+		)
 		if _, err := uc.notificationUC.Notify(ctx, userID, entity.NotificationTypeNewConcerts, payload); err != nil {
 			// Record-create failure ("no record => no send"): surface so the
 			// consumer's at-least-once retry re-drives the batch. Repeat web

--- a/internal/usecase/sales_phase_announcement_uc.go
+++ b/internal/usecase/sales_phase_announcement_uc.go
@@ -93,12 +93,12 @@ func (uc *salesPhaseAnnouncementUseCase) AnnounceDiscoveredPhase(ctx context.Con
 		}
 
 		lang := langByUser[userID]
-		payload := &entity.NotificationPayload{
-			Title: announcementTitle(lang),
-			Body:  announcementBody(lang),
-			URL:   url,
-			Tag:   tag,
-		}
+		payload := entity.NewNotificationPayload(
+			announcementTitle(lang),
+			announcementBody(lang),
+			url,
+			tag,
+		)
 		if _, err := uc.notificationUC.Notify(ctx, userID, entity.NotificationTypeSalesPhaseAnnouncement, payload); err != nil {
 			// Record-create failure ("no record => no send"): surface so the
 			// consumer's at-least-once retry re-drives the batch. Repeat pushes

--- a/internal/usecase/sales_phase_announcement_uc_test.go
+++ b/internal/usecase/sales_phase_announcement_uc_test.go
@@ -66,7 +66,7 @@ func TestAnnounceDiscoveredPhase_LocalizesCopyPerRecipient(t *testing.T) {
 		Notify(anyCtx, "user-ja", entity.NotificationTypeSalesPhaseAnnouncement,
 			mock.MatchedBy(func(p *entity.NotificationPayload) bool {
 				return p.Title == "チケット販売情報の新着" &&
-					p.URL == "/series/series-1" &&
+					p.Data[entity.NotificationDataKeyURL] == "/series/series-1" &&
 					p.Tag == "sales-phase-phase-1"
 			})).
 		Return(deliveredNotif(), nil).
@@ -75,7 +75,7 @@ func TestAnnounceDiscoveredPhase_LocalizesCopyPerRecipient(t *testing.T) {
 		Notify(anyCtx, "user-en", entity.NotificationTypeSalesPhaseAnnouncement,
 			mock.MatchedBy(func(p *entity.NotificationPayload) bool {
 				return p.Title == "New Ticket Sales Phase" &&
-					p.URL == "/series/series-1" &&
+					p.Data[entity.NotificationDataKeyURL] == "/series/series-1" &&
 					p.Tag == "sales-phase-phase-1"
 			})).
 		Return(deliveredNotif(), nil).
@@ -85,7 +85,7 @@ func TestAnnounceDiscoveredPhase_LocalizesCopyPerRecipient(t *testing.T) {
 			mock.MatchedBy(func(p *entity.NotificationPayload) bool {
 				// Unset language falls back to English.
 				return p.Title == "New Ticket Sales Phase" &&
-					p.URL == "/series/series-1" &&
+					p.Data[entity.NotificationDataKeyURL] == "/series/series-1" &&
 					p.Tag == "sales-phase-phase-1"
 			})).
 		Return(deliveredNotif(), nil).

--- a/internal/usecase/sales_reminder_uc.go
+++ b/internal/usecase/sales_reminder_uc.go
@@ -359,38 +359,38 @@ func buildReminderPayload(phase *entity.SalesPhase, stage entity.ReminderStage, 
 	switch stage {
 	case entity.ReminderStageApplyOpen:
 		timeStr := formatLocalTime(phase.ApplyStartTime, tz, lang)
-		return &entity.NotificationPayload{
-			Title: stageTitle(lang, "apply_open"),
-			Body:  fmt.Sprintf(stageBody(lang, "apply_open"), channelLabel, timeStr),
-			URL:   url,
-			Tag:   tag,
-		}
+		return entity.NewNotificationPayload(
+			stageTitle(lang, "apply_open"),
+			fmt.Sprintf(stageBody(lang, "apply_open"), channelLabel, timeStr),
+			url,
+			tag,
+		)
 	case entity.ReminderStageApplyClose24H:
 		timeStr := formatLocalTime(phase.ApplyEndTime, tz, lang)
-		return &entity.NotificationPayload{
-			Title: stageTitle(lang, "apply_close_24h"),
-			Body:  fmt.Sprintf(stageBody(lang, "apply_close_24h"), channelLabel, timeStr),
-			URL:   url,
-			Tag:   tag,
-		}
+		return entity.NewNotificationPayload(
+			stageTitle(lang, "apply_close_24h"),
+			fmt.Sprintf(stageBody(lang, "apply_close_24h"), channelLabel, timeStr),
+			url,
+			tag,
+		)
 	case entity.ReminderStageApplyClose1H:
 		timeStr := formatLocalTime(phase.ApplyEndTime, tz, lang)
-		return &entity.NotificationPayload{
-			Title: stageTitle(lang, "apply_close_1h"),
-			Body:  fmt.Sprintf(stageBody(lang, "apply_close_1h"), channelLabel, timeStr),
-			URL:   url,
-			Tag:   tag,
-		}
+		return entity.NewNotificationPayload(
+			stageTitle(lang, "apply_close_1h"),
+			fmt.Sprintf(stageBody(lang, "apply_close_1h"), channelLabel, timeStr),
+			url,
+			tag,
+		)
 	case entity.ReminderStageResultDay:
 		timeStr := formatLocalTime(phase.LotteryResultTime, tz, lang)
-		return &entity.NotificationPayload{
-			Title: stageTitle(lang, "result_day"),
-			Body:  fmt.Sprintf(stageBody(lang, "result_day"), channelLabel, timeStr),
-			URL:   url,
-			Tag:   tag,
-		}
+		return entity.NewNotificationPayload(
+			stageTitle(lang, "result_day"),
+			fmt.Sprintf(stageBody(lang, "result_day"), channelLabel, timeStr),
+			url,
+			tag,
+		)
 	default:
-		return &entity.NotificationPayload{URL: url, Tag: tag}
+		return entity.NewNotificationPayload("", "", url, tag)
 	}
 }
 

--- a/internal/usecase/sales_reminder_uc_test.go
+++ b/internal/usecase/sales_reminder_uc_test.go
@@ -343,7 +343,7 @@ func TestBuildReminderPayload(t *testing.T) {
 		p := usecase.ExportedBuildReminderPayload(phase, entity.ReminderStageApplyOpen, userEN)
 		assert.Equal(t, "Ticket Sales Open", p.Title)
 		assert.Contains(t, p.Body, "Fan Club")
-		assert.Equal(t, "https://eplus.jp/example", p.URL)
+		assert.Equal(t, "https://eplus.jp/example", p.Data[entity.NotificationDataKeyURL])
 		assert.Equal(t, "sales-phase-phase-001-stage-1", p.Tag)
 	})
 	t.Run("APPLY_OPEN ja", func(t *testing.T) {
@@ -366,7 +366,7 @@ func TestBuildReminderPayload(t *testing.T) {
 		t.Parallel()
 		noURL := &entity.SalesPhase{ID: "p2", SeriesID: "s2", Channel: entity.SalesChannelGeneral}
 		p := usecase.ExportedBuildReminderPayload(noURL, entity.ReminderStageApplyOpen, userEN)
-		assert.Equal(t, "/series/s2", p.URL)
+		assert.Equal(t, "/series/s2", p.Data[entity.NotificationDataKeyURL])
 	})
 }
 


### PR DESCRIPTION
## What
Emit a `notification.delivered` product-analytics event, keyed by `notification_id`, when a notification's channel send reaches the delivered state.

- `SubjectNotificationDelivered` + `NotificationDeliveredData{UserID, NotificationID, Type}` — reuses the existing `NOTIFICATION.*` JetStream stream (no new stream → no consumer-crashloop risk).
- `analytics_consumer.HandleNotificationDelivered` forwards to PostHog (`notification_id`, `type` properties); wired in `di/consumer.go`.
- `NotificationUseCase` publishes it **once per notification** at the delivered transition, **non-fatally** (mirrors `notification.subscribed` — analytics never affects delivery).
- Reshape `NotificationPayload`: move `URL` into `data.url` alongside `data.notification_id` (via `NewNotificationPayload`), so the SW maps `payload.data` straight into `showNotification` `options.data`. Wire JSON becomes `{ title, body, tag, data: { url, notification_id } }`.

## Testing
- Consumer handler: forward / nil-client / empty-user_id / empty-notification_id / enqueue-error paths.
- UseCase: delivered ⇒ one emit; failed / no-subscription / cancelled ⇒ no emit.
- `make check` passes (lint + unit + integration).

## Why
Closes the delivery-audit loop from `introduce-notification-service` (its deferred Decision 5); satisfies the descoped `introduce-analytics-tool` task 13.2.

Refs #675