### PR TITLE
feat(analytics): emit account.login from Zitadel CreateSession webhook

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -110,6 +110,51 @@ func (c *AnalyticsConsumer) HandleUserCreated(msg *message.Message) error {
 	return nil
 }
 
+// HandleAccountLogin forwards the ACCOUNT.login NATS subject as the
+// catalogue event usecase.EventAccountLogin. The subject is published once
+// per user-initiated login (Zitadel CreateSession), never on a token
+// refresh, so this event is a returning/active-user signal. No properties
+// are attached: the distinct_id (platform UserID) is the whole payload, and
+// no PII (email, sub) is ever forwarded.
+func (c *AnalyticsConsumer) HandleAccountLogin(msg *message.Message) error {
+	ctx := msg.Context()
+	defer c.recordLag(ctx, msg)
+
+	var data entity.AccountLoginData
+	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
+		c.logger.Error(ctx, "failed to parse ACCOUNT.login event", err)
+		c.metrics.RecordMessage(ctx, statusSkippedParseError)
+		return apperr.Wrap(err, codes.Internal, "parse ACCOUNT.login event")
+	}
+
+	if c.client == nil {
+		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
+			slog.String("event", string(usecase.EventAccountLogin)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
+		return nil
+	}
+
+	if data.UserID == "" {
+		c.logger.Warn(ctx, "ACCOUNT.login event missing user_id, skipping forward")
+		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
+		return nil
+	}
+
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventAccountLogin, usecase.AnalyticsProperties{}); err != nil {
+		c.logger.Error(ctx, "failed to enqueue analytics event", err,
+			slog.String("event", string(usecase.EventAccountLogin)),
+			slog.String("user_id", data.UserID),
+		)
+		c.metrics.RecordMessage(ctx, statusEnqueueError)
+		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
+	}
+
+	c.metrics.RecordMessage(ctx, statusForwarded)
+	return nil
+}
+
 // HandleUserPreferredLanguageUpdated forwards the
 // USER.preferred_language_updated NATS subject as the catalogue event
 // usecase.EventAccountPreferredLanguageUpdated. Properties: from_locale,

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -145,6 +145,97 @@ func TestAnalyticsConsumer_HandleUserCreated(t *testing.T) {
 	}
 }
 
+// TestAnalyticsConsumer_HandleAccountLogin covers the routing/validation
+// surface of the ACCOUNT.login handler. account.login carries no properties —
+// the distinct_id (platform UserID) is the whole signal.
+func TestAnalyticsConsumer_HandleAccountLogin(t *testing.T) {
+	t.Parallel()
+
+	const validUserID = "11111111-2222-3333-4444-555555555555"
+
+	type want struct {
+		err              error
+		expectEnqueueErr error
+		expectEnqueue    bool
+		expectStatus     string
+	}
+	tests := []struct {
+		name      string
+		data      entity.AccountLoginData
+		want      want
+		nilClient bool
+	}{
+		{
+			name: "forwards account.login when client + UserID present",
+			data: entity.AccountLoginData{UserID: validUserID},
+			want: want{expectEnqueue: true, expectStatus: "forwarded"},
+		},
+		{
+			name:      "skips forward when client is nil (local dev)",
+			data:      entity.AccountLoginData{UserID: validUserID},
+			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
+			nilClient: true,
+		},
+		{
+			name: "skips forward when UserID is empty",
+			data: entity.AccountLoginData{UserID: ""},
+			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
+		},
+		{
+			name: "wraps Enqueue error as apperr.ErrInternal",
+			data: entity.AccountLoginData{UserID: validUserID},
+			want: want{
+				expectEnqueue:    true,
+				expectEnqueueErr: errors.New("queue full"),
+				err:              apperr.ErrInternal,
+				expectStatus:     "enqueue_error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var client usecase.AnalyticsClient
+			if !tt.nilClient {
+				clientMock := ucmocks.NewMockAnalyticsClient(t)
+				client = clientMock
+				if tt.want.expectEnqueue {
+					clientMock.EXPECT().
+						Enqueue(
+							mock.Anything,
+							tt.data.UserID,
+							usecase.EventAccountLogin,
+							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
+								return len(props) == 0
+							}),
+						).
+						Return(tt.want.expectEnqueueErr).
+						Once()
+				}
+			}
+
+			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
+			metricsMock.EXPECT().
+				RecordMessage(mock.Anything, tt.want.expectStatus).
+				Once()
+			metricsMock.EXPECT().
+				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
+				Once()
+
+			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
+			err := handler.HandleAccountLogin(makeAnalyticsMsg(t, tt.data))
+
+			if tt.want.err != nil {
+				assert.ErrorIs(t, err, tt.want.err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // TestAnalyticsConsumer_HandleUserPreferredLanguageUpdated covers
 // USER.preferred_language_updated → account.preferred_language.updated
 // routing. Properties from_locale and to_locale travel verbatim.

--- a/internal/adapter/webhook/create_session_handler.go
+++ b/internal/adapter/webhook/create_session_handler.go
@@ -1,0 +1,165 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/liverty-music/backend/internal/entity"
+	"github.com/liverty-music/backend/internal/infrastructure/auth"
+	"github.com/pannpers/go-logging/logging"
+)
+
+// userResolver resolves a Zitadel `sub` (identity-provider subject / external
+// ID) to the platform user. Satisfied by usecase.UserUseCase; declared here so
+// the handler depends only on the one method it needs.
+type userResolver interface {
+	GetByExternalID(ctx context.Context, externalID string) (*entity.User, error)
+}
+
+// eventPublisher publishes a domain event as a CloudEvent to a NATS subject.
+// Satisfied by usecase.EventPublisher.
+type eventPublisher interface {
+	PublishEvent(ctx context.Context, subject string, data any) error
+}
+
+// CreateSessionHandler serves `POST /create-session`. It is bound to a Zitadel
+// Actions v2 Execution on the RESPONSE side of
+// `/zitadel.session.v2.SessionService/CreateSession`: Zitadel invokes it once
+// per successful, user-initiated login (a session creation) and never on a
+// silent `refresh_token` grant, which reuses the existing session and does not
+// call CreateSession. The handler therefore emits `account.login` once per
+// login with no refresh over-count and nothing to discriminate.
+//
+// The analytics path is best-effort and non-fatal: the handler resolves the
+// login `sub` to the platform UserID and publishes an `ACCOUNT.login` domain
+// event, but ALWAYS returns 200 with an empty JSON body — a missing user
+// identifier, a failed lookup, or a publish error is logged and skipped so
+// session creation / login is never affected. (The Target is provisioned with
+// `interruptOnError: false`, so Zitadel also ignores our response, but
+// returning 200 keeps the contract explicit.)
+type CreateSessionHandler struct {
+	validator *auth.WebhookValidator
+	users     userResolver
+	publisher eventPublisher
+	logger    *logging.Logger
+}
+
+// NewCreateSessionHandler constructs a handler bound to the given validator,
+// user resolver, and event publisher. The validator's audience MUST be the
+// webhook-specific audience registered on the Zitadel CreateSession Target.
+func NewCreateSessionHandler(
+	validator *auth.WebhookValidator,
+	users userResolver,
+	publisher eventPublisher,
+	logger *logging.Logger,
+) *CreateSessionHandler {
+	return &CreateSessionHandler{validator: validator, users: users, publisher: publisher, logger: logger}
+}
+
+// createSessionPayload captures the subset of the Actions v2 method payload
+// this handler consumes. For a response-side Execution the payload carries
+// both `request` and `response`; the login user is the CreateSession request's
+// user check at `request.checks.user.userId`. Unknown fields are ignored.
+type createSessionPayload struct {
+	Request struct {
+		Checks struct {
+			User struct {
+				UserID string `json:"userId"`
+			} `json:"user"`
+		} `json:"checks"`
+	} `json:"request"`
+}
+
+// ServeHTTP implements http.Handler.
+func (h *CreateSessionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.logger.Warn(ctx, "create-session: failed to read body", slog.String("error", err.Error()))
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if len(body) == 0 {
+		h.logger.Warn(ctx, "create-session: empty body")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	token, err := h.validator.ValidateWebhookToken(ctx, string(body))
+	if err != nil {
+		h.logger.Warn(ctx, "create-session: webhook JWT validation failed",
+			slog.String("error", err.Error()),
+		)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Private claims carry the Actions v2 method payload. Round-trip through
+	// JSON so we can target nested `request.checks.user.userId` without walking
+	// the claim map manually.
+	rawClaims, err := json.Marshal(token.PrivateClaims())
+	if err != nil {
+		// A verified token whose claims cannot be re-marshalled is not worth
+		// failing login over; log and return success without emitting.
+		h.logger.Error(ctx, "create-session: failed to marshal private claims", err)
+		h.writeOK(ctx, w)
+		return
+	}
+	var payload createSessionPayload
+	if err := json.Unmarshal(rawClaims, &payload); err != nil {
+		h.logger.Error(ctx, "create-session: failed to unmarshal payload", err)
+		h.writeOK(ctx, w)
+		return
+	}
+
+	h.emitAccountLogin(ctx, payload.Request.Checks.User.UserID)
+	h.writeOK(ctx, w)
+}
+
+// emitAccountLogin resolves the Zitadel `sub` to the platform UserID and
+// publishes `ACCOUNT.login` best-effort. Every failure mode — an absent
+// identifier, a lookup miss/error, or a publish error — is logged and
+// swallowed; it never affects the HTTP response.
+func (h *CreateSessionHandler) emitAccountLogin(ctx context.Context, sub string) {
+	if sub == "" {
+		// The CreateSession `checks.user` is a oneof (userId | loginName), and
+		// some login flows attach the user via a later SetSession, so the
+		// identifier can legitimately be absent. Skip rather than guess.
+		h.logger.Warn(ctx, "create-session: payload missing request.checks.user.userId, skipping account.login")
+		return
+	}
+
+	user, err := h.users.GetByExternalID(ctx, sub)
+	if err != nil {
+		// User not yet provisioned, or a transient lookup error. Bounded
+		// under-count is acceptable; never fail login.
+		h.logger.Warn(ctx, "create-session: sub to UserID lookup failed, skipping account.login",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	if err := h.publisher.PublishEvent(ctx, entity.SubjectAccountLogin, entity.AccountLoginData{UserID: user.ID}); err != nil {
+		h.logger.Error(ctx, "create-session: failed to publish ACCOUNT.login", err)
+	}
+}
+
+// writeOK writes the 200 response Zitadel receives. The body is an empty JSON
+// object: a response-side analytics Execution manipulates nothing.
+func (h *CreateSessionHandler) writeOK(ctx context.Context, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write([]byte("{}")); err != nil && !errors.Is(err, http.ErrHandlerTimeout) {
+		h.logger.Error(ctx, "create-session: failed to write response", err)
+	}
+}

--- a/internal/adapter/webhook/create_session_handler_test.go
+++ b/internal/adapter/webhook/create_session_handler_test.go
@@ -1,0 +1,182 @@
+package webhook_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liverty-music/backend/internal/adapter/webhook"
+	"github.com/liverty-music/backend/internal/entity"
+)
+
+const testCreateSessionAud = "urn:liverty-music:webhook:create-session"
+
+// stubUserResolver records GetByExternalID calls and returns a canned result.
+type stubUserResolver struct {
+	user      *entity.User
+	err       error
+	calls     int
+	lastExtID string
+}
+
+func (s *stubUserResolver) GetByExternalID(_ context.Context, externalID string) (*entity.User, error) {
+	s.calls++
+	s.lastExtID = externalID
+	return s.user, s.err
+}
+
+// stubPublisher records PublishEvent calls and returns a canned error.
+type stubPublisher struct {
+	err     error
+	calls   int
+	subject string
+	data    any
+}
+
+func (s *stubPublisher) PublishEvent(_ context.Context, subject string, data any) error {
+	s.calls++
+	s.subject = subject
+	s.data = data
+	return s.err
+}
+
+// createSessionBody builds a signed CreateSession webhook JWT whose payload
+// carries request.checks.user.userId = sub. When sub is empty the userId field
+// is omitted so the "missing identifier" path can be exercised.
+func createSessionBody(t *testing.T, f *jwksFixture, sub string) string {
+	t.Helper()
+	user := map[string]any{}
+	if sub != "" {
+		user["userId"] = sub
+	}
+	return f.signWebhookJWT(t, testIssuer, testCreateSessionAud, map[string]any{
+		"request": map[string]any{
+			"checks": map[string]any{
+				"user": user,
+			},
+		},
+	})
+}
+
+func TestCreateSessionHandler_UserInitiatedLogin_EmitsAccountLoginOnce(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
+	pub := &stubPublisher{}
+	handler := webhook.NewCreateSessionHandler(
+		fixture.newValidator(t, testCreateSessionAud), users, pub, newLogger(t),
+	)
+
+	body := createSessionBody(t, fixture, "zitadel-sub-123")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/create-session", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	// sub was resolved to the platform UserID via the lookup...
+	assert.Equal(t, 1, users.calls)
+	assert.Equal(t, "zitadel-sub-123", users.lastExtID)
+	// ...and exactly one ACCOUNT.login was published carrying that UserID.
+	require.Equal(t, 1, pub.calls)
+	assert.Equal(t, entity.SubjectAccountLogin, pub.subject)
+	data, ok := pub.data.(entity.AccountLoginData)
+	require.True(t, ok, "published data must be entity.AccountLoginData")
+	assert.Equal(t, "platform-uuid-1", data.UserID)
+}
+
+func TestCreateSessionHandler_InvalidSignature_Rejected_NoPublish(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	// A different fixture signs the token, so its signature does not verify
+	// against the handler's trusted JWKS.
+	forger := newJWKSFixture(t)
+	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
+	pub := &stubPublisher{}
+	handler := webhook.NewCreateSessionHandler(
+		fixture.newValidator(t, testCreateSessionAud), users, pub, newLogger(t),
+	)
+
+	body := createSessionBody(t, forger, "zitadel-sub-123")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/create-session", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, 0, users.calls)
+	assert.Equal(t, 0, pub.calls)
+}
+
+func TestCreateSessionHandler_MissingUserID_Skips_Returns200(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
+	pub := &stubPublisher{}
+	handler := webhook.NewCreateSessionHandler(
+		fixture.newValidator(t, testCreateSessionAud), users, pub, newLogger(t),
+	)
+
+	// Login flow that attaches the user via loginName / a later SetSession:
+	// request.checks.user.userId is absent.
+	body := createSessionBody(t, fixture, "")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/create-session", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 0, users.calls, "no lookup when identifier is absent")
+	assert.Equal(t, 0, pub.calls, "no publish when identifier is absent")
+}
+
+func TestCreateSessionHandler_LookupMiss_Skips_Returns200(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	users := &stubUserResolver{err: errors.New("user not found")}
+	pub := &stubPublisher{}
+	handler := webhook.NewCreateSessionHandler(
+		fixture.newValidator(t, testCreateSessionAud), users, pub, newLogger(t),
+	)
+
+	body := createSessionBody(t, fixture, "zitadel-sub-unprovisioned")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/create-session", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "a lookup miss must never fail login")
+	assert.Equal(t, 1, users.calls)
+	assert.Equal(t, 0, pub.calls, "no publish when the sub cannot be resolved")
+}
+
+func TestCreateSessionHandler_PublishFailure_DoesNotAffectResponse(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
+	pub := &stubPublisher{err: errors.New("nats unavailable")}
+	handler := webhook.NewCreateSessionHandler(
+		fixture.newValidator(t, testCreateSessionAud), users, pub, newLogger(t),
+	)
+
+	body := createSessionBody(t, fixture, "zitadel-sub-123")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/create-session", bytes.NewBufferString(body))
+	handler.ServeHTTP(rec, req)
+
+	// The publish failed but login (the webhook response) still succeeds.
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, pub.calls)
+}
+
+func TestCreateSessionHandler_GET_ReturnsMethodNotAllowed(t *testing.T) {
+	fixture := newJWKSFixture(t)
+	handler := webhook.NewCreateSessionHandler(
+		fixture.newValidator(t, testCreateSessionAud),
+		&stubUserResolver{}, &stubPublisher{}, newLogger(t),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/create-session", nil)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	assert.Equal(t, http.MethodPost, rec.Header().Get("Allow"))
+}

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -244,6 +244,13 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	)
 
 	router.AddConsumerHandler(
+		"forward-account-login-to-analytics",
+		entity.SubjectAccountLogin,
+		subscriber,
+		analyticsConsumer.HandleAccountLogin,
+	)
+
+	router.AddConsumerHandler(
 		"forward-artist-followed-to-analytics",
 		entity.SubjectArtistFollowed,
 		subscriber,

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -393,8 +393,19 @@ func InitializeApp(ctx context.Context) (*App, error) {
 		jwtValidator.NewWebhookValidator(cfg.Webhook.PreAccessTokenAudience),
 		logger,
 	)
+	// CreateSession Actions v2 handler — emits account.login once per
+	// user-initiated login (session creation), never on token refresh. Shares
+	// the JWKS cache; publishes a best-effort ACCOUNT.login event and never
+	// fails login.
+	createSessionHandler := webhook.NewCreateSessionHandler(
+		jwtValidator.NewWebhookValidator(cfg.Webhook.CreateSessionAudience),
+		userUC,
+		eventPublisher,
+		logger,
+	)
 	webhookSrv := server.NewWebhookServer(cfg.Webhook, logger, map[string]http.Handler{
 		"/pre-access-token": preAccessTokenHandler,
+		"/create-session":   createSessionHandler,
 	})
 
 	// Register shutdown phases.

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -53,6 +53,14 @@ const (
 	// ticket.email.parsed analytics event (email-ingestion data quality,
 	// parser robustness).
 	SubjectTicketEmailParsed = "TICKET_EMAIL.parsed"
+	// SubjectAccountLogin is published by the CreateSession webhook handler
+	// once per user-initiated login (a Zitadel session creation). It drives
+	// the account.login analytics event (returning / active-user retention
+	// cohorts). The OIDC refresh_token grant reuses the existing session and
+	// never calls CreateSession, so this subject is never published on a
+	// silent token refresh — login-specific by construction. Uses a new
+	// ACCOUNT.* JetStream stream.
+	SubjectAccountLogin = "ACCOUNT.login"
 )
 
 // AllSubjects is the canonical catalogue of every domain-event NATS subject
@@ -81,6 +89,7 @@ var AllSubjects = []string{
 	SubjectTicketMintCompleted,
 	SubjectSalesReminderDelivered,
 	SubjectTicketEmailParsed,
+	SubjectAccountLogin,
 }
 
 // EntryRejectionReason enumerates the legitimate causes for a
@@ -123,6 +132,16 @@ type UserCreatedData struct {
 	ExternalID string `json:"external_id"`
 	// Email is the user's email address.
 	Email string `json:"email"`
+}
+
+// AccountLoginData is the payload for ACCOUNT.login events.
+// Mapped to the catalogue event account.login by the analytics-consumer.
+// Published by the CreateSession webhook handler once per user-initiated
+// login, after the Zitadel sub has been resolved to the platform UserID.
+type AccountLoginData struct {
+	// UserID is the platform-internal user identifier (UUID). Used as the
+	// PostHog distinct_id. Never the Zitadel sub, which Enqueue rejects.
+	UserID string `json:"user_id"`
 }
 
 // ArtistCreatedData is the payload for artist.created events.

--- a/internal/infrastructure/messaging/streams.go
+++ b/internal/infrastructure/messaging/streams.go
@@ -85,6 +85,16 @@ var streams = []nats.StreamConfig{
 		Duplicates: 2 * time.Minute,
 	},
 	{
+		Name:       "ACCOUNT",
+		Subjects:   []string{"ACCOUNT.*"},
+		Retention:  nats.LimitsPolicy,
+		MaxAge:     7 * 24 * time.Hour,
+		Storage:    nats.FileStorage,
+		Discard:    nats.DiscardOld,
+		Replicas:   1,
+		Duplicates: 2 * time.Minute,
+	},
+	{
 		Name:       "ENTRY",
 		Subjects:   []string{"ENTRY.*"},
 		Retention:  nats.LimitsPolicy,

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -17,8 +17,12 @@ type AnalyticsEventName string
 
 // Account lifecycle events emitted from the backend.
 const (
-	// EventAccountLogin is recorded when an existing user successfully
-	// completes the OIDC authentication callback.
+	// EventAccountLogin is recorded once per user-initiated login, sourced
+	// from the Zitadel CreateSession Actions v2 webhook. It is never recorded
+	// on a silent token refresh (the refresh_token grant does not create a
+	// session), so it is a returning/active-user retention signal. Signup is
+	// represented by EventUserCreated, not a separate account.signup.completed
+	// event.
 	EventAccountLogin AnalyticsEventName = "account.login"
 
 	// EventAccountPreferredLanguageUpdated is recorded when a user's

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -604,6 +604,12 @@ type WebhookSettings struct {
 	// delivered to `POST /pre-access-token`. Must match the audience
 	// registered on the corresponding Zitadel Target.
 	PreAccessTokenAudience string `envconfig:"WEBHOOK_PRE_ACCESS_TOKEN_AUDIENCE" default:"urn:liverty-music:webhook:pre-access-token"`
+
+	// CreateSessionAudience is the expected `aud` claim for webhook JWTs
+	// delivered to `POST /create-session` (the account.login source). Must
+	// match the audience registered on the corresponding Zitadel CreateSession
+	// Target.
+	CreateSessionAudience string `envconfig:"WEBHOOK_CREATE_SESSION_AUDIENCE" default:"urn:liverty-music:webhook:create-session"`
 }
 
 // Loadable constrains the config types that can be loaded from environment variables.
@@ -740,6 +746,10 @@ func (c *ServerConfig) Validate() error {
 
 	if c.Webhook.PreAccessTokenAudience == "" {
 		return fmt.Errorf("webhook pre-access-token audience is required")
+	}
+
+	if c.Webhook.CreateSessionAudience == "" {
+		return fmt.Errorf("webhook create-session audience is required")
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,6 +15,7 @@ func validWebhookSettings() WebhookSettings {
 	return WebhookSettings{
 		Port:                   9090,
 		PreAccessTokenAudience: "urn:liverty-music:webhook:pre-access-token",
+		CreateSessionAudience:  "urn:liverty-music:webhook:create-session",
 	}
 }
 
@@ -84,6 +85,7 @@ func TestLoad_ServerConfig(t *testing.T) {
 					ReadTimeout:            5 * time.Second,
 					IdleTimeout:            30 * time.Second,
 					PreAccessTokenAudience: "urn:liverty-music:webhook:pre-access-token",
+					CreateSessionAudience:  "urn:liverty-music:webhook:create-session",
 				},
 				GCP: GCPConfig{
 					ProjectID:               "test-project",
@@ -179,6 +181,7 @@ func TestLoad_ServerConfig(t *testing.T) {
 					ReadTimeout:            5 * time.Second,
 					IdleTimeout:            30 * time.Second,
 					PreAccessTokenAudience: "urn:liverty-music:webhook:pre-access-token",
+					CreateSessionAudience:  "urn:liverty-music:webhook:create-session",
 				},
 				GCP: GCPConfig{
 					ProjectID:               "custom-project",


### PR DESCRIPTION
## Summary

Implements the backend half of OpenSpec change **emit-auth-events-via-webhook**: a server-side `account.login` analytics event, emitted **once per user-initiated login**, so PostHog can build returning/active-user retention cohorts.

Login is sourced from a Zitadel Actions v2 **CreateSession** webhook — login-specific *by construction*: the OIDC `refresh_token` grant reuses the existing session and never calls `CreateSession`, so the event is **never emitted on a silent token refresh** (no over-count, nothing to discriminate).

## What's here

- **`/create-session` webhook handler** ([create_session_handler.go](internal/adapter/webhook/create_session_handler.go)): verifies the `PAYLOAD_TYPE_JWT` body against the Zitadel JWKS via the existing `WebhookValidator` (no HMAC secret — same pattern as `pre_access_token`), reads `request.checks.user.userId`, resolves that Zitadel `sub` → platform `UserID` via `GetByExternalID`, and publishes `ACCOUNT.login`.
  - **Best-effort / non-fatal:** a missing identifier, a lookup miss, or a publish failure is logged and skipped; the handler **always returns 200** so session creation / login is never affected.
- **Messaging:** new `ACCOUNT` JetStream stream + `SubjectAccountLogin` + `AccountLoginData` (added to `AllSubjects` so the stream-coverage test passes).
- **Consumer:** `AnalyticsConsumer.HandleAccountLogin` forwards `ACCOUNT.login` → `account.login` catalogue event (no PII in properties; platform `UserID` is the whole `distinct_id`), subscribed in `di/consumer.go`.
- **Config:** `WEBHOOK_CREATE_SESSION_AUDIENCE` (defaults to `urn:liverty-music:webhook:create-session`).
- **Signup:** unchanged — `user.created` stays canonical; no `account.signup.completed` (the constant was already removed upstream, so there is nothing to alias).

## Note on the webhook signature

The OpenSpec brief mentioned HMAC-SHA256, but the deployed `pre_access_token` Target uses `PAYLOAD_TYPE_JWT` + JWKS verification (cloud-provisioning: *"no shared HMAC secret needed"*). This handler reuses that exact JWKS pattern.

## Tests

- Handler: user-initiated login → exactly one `ACCOUNT.login` with resolved `UserID`; invalid signature → 401, no publish; missing `userId` → skip + 200; lookup miss → skip + 200; publish failure → still 200.
- Consumer: forwarded on valid payload; skipped on nil client / empty UserID; `Enqueue` error wrapped as `apperr.ErrInternal`.
- `make check` (lint + test) green.

## Rollout ordering

Deploy this **before** the cloud-provisioning Zitadel Execution so the webhook target is live when it starts firing (the Target is `interruptOnError: false`, so login is never blocked regardless). No proto change, no BSR gen.

Refs: liverty-music/specification#532