### PR TITLE
fix(messaging): give each JetStream subject its own consumer group

### DIFF
--- a/internal/infrastructure/messaging/subscriber.go
+++ b/internal/infrastructure/messaging/subscriber.go
@@ -15,6 +15,20 @@ import (
 	"github.com/liverty-music/backend/pkg/config"
 )
 
+// consumerQueueGroupPrefix is the prefix for the per-topic JetStream deliver
+// (queue) group and durable name. Bumped from the historical bare "consumer"
+// group to segregate consumers per subject (see SubjectCalculator in
+// NewSubscriber for the collision this avoids).
+const consumerQueueGroupPrefix = "consumer"
+
+// consumerName derives a per-topic durable / deliver-group name from a subject,
+// e.g. "NOTIFICATION.delivered" -> "consumer_NOTIFICATION_delivered". Keeping
+// the durable and deliver group identical and unique per topic guarantees each
+// subject on a shared stream provisions its own JetStream consumer.
+func consumerName(topic string) string {
+	return consumerQueueGroupPrefix + "_" + strings.ReplaceAll(topic, ".", "_")
+}
+
 // NewSubscriber creates a Watermill Subscriber based on configuration.
 // When NATS_URL is set, it returns a NATS JetStream subscriber with durable consumers.
 // When NATS_URL is empty (local development), it returns a GoChannel subscriber
@@ -33,12 +47,28 @@ func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goCh
 			nats.MaxReconnects(-1),
 			nats.ReconnectWait(time.Second),
 		},
-		QueueGroupPrefix: "consumer",
+		QueueGroupPrefix: consumerQueueGroupPrefix,
 		CloseTimeout:     30 * time.Second,
 		AckWaitTimeout:   30 * time.Second,
+		// Derive BOTH the JetStream deliver (queue) group and the durable name
+		// per topic. This is required — not cosmetic — because several subjects
+		// share one stream (e.g. NOTIFICATION.subscribed/.unsubscribed/.delivered
+		// all live in the NOTIFICATION stream). nats.go's QueueSubscribe, when a
+		// durable does not yet exist, looks up an existing consumer on the stream
+		// by deliver group; with a single shared group it FINDS a sibling and
+		// binds to it instead of creating the new consumer — so the second and
+		// third subjects on a stream silently never get a consumer and their
+		// messages pile up unconsumed. A per-topic deliver group removes the
+		// collision so every subject provisions its own consumer.
+		SubjectCalculator: func(_, topic string) *watermillnats.SubjectDetail {
+			return &watermillnats.SubjectDetail{
+				Primary:    topic,
+				QueueGroup: consumerName(topic),
+			}
+		},
 		JetStream: watermillnats.JetStreamConfig{
 			DurableCalculator: func(_, topic string) string {
-				return strings.ReplaceAll(topic, ".", "_")
+				return consumerName(topic)
 			},
 			SubscribeOptions: []nats.SubOpt{
 				nats.AckExplicit(),


### PR DESCRIPTION
## Problem
`notification.delivered` (shipped in v1.17.0) is published to NATS but never reaches PostHog. Root cause: multiple subjects share one JetStream stream (`NOTIFICATION` carries `.subscribed`/`.unsubscribed`/`.delivered`), and the subscriber used a single deliver (queue) group `"consumer"` for every topic. When nats.go creates a not-yet-existing durable, it looks up an existing consumer on the stream **by deliver group**, finds a sibling sharing `"consumer"`, and binds to it instead of creating the new one. So the 2nd/3rd subjects on a stream silently never get a consumer.

Verified in prod: the `NOTIFICATION` stream had 3 messages but only the `NOTIFICATION_subscribed` consumer — `NOTIFICATION.delivered` / `.unsubscribed` messages sat unconsumed. Streams whose extra durables already existed from an earlier deploy (USER, ARTIST…) were unaffected, which masked this (pre-existing — `.unsubscribed` was already broken).

## Fix
Derive **both the durable name and the deliver group per topic** (`consumer_<TOPIC>`) so each subject always provisions its own consumer and the mis-bind cannot happen — including any future subject added to an existing stream.

## Rollout note
Consumers are recreated under the new per-topic names on deploy; the old shared-group durables become harmless orphans (optional cleanup later). One-time transition only.

Refs #675