### PR TITLE
fix(notification): deep-link new-concert push to /dashboard

### DIFF
--- a/internal/usecase/push_notification_uc.go
+++ b/internal/usecase/push_notification_uc.go
@@ -300,7 +300,11 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 		payload := entity.NewNotificationPayload(
 			artist.Name,
 			concertNotificationBody(len(concerts), langByUser[userID]),
-			fmt.Sprintf("/concerts?artist=%s", artist.ID),
+			// Deep-link to the dashboard (the fan's home, which lists their
+			// followed-artist concerts). The former "/concerts?artist=<id>" had
+			// no matching frontend route and 404'd on tap; there is no per-artist
+			// concert list route yet, so land on the dashboard.
+			"/dashboard",
 			fmt.Sprintf("concert-%s", artist.ID),
 		)
 		if _, err := uc.notificationUC.Notify(ctx, userID, entity.NotificationTypeNewConcerts, payload); err != nil {


### PR DESCRIPTION
## Problem
Tapping a new-concert push notification showed a **404**. The payload deep-link was `/concerts?artist=<id>`, but the frontend has no such route (routes: `''`, `dashboard`, `concerts/:id`, `discovery`, `my-artists`). Found while verifying notification analytics in prod.

Pre-existing bug from the notification feature — unrelated to the analytics events (which only relocated the `url` into `data.url`; value unchanged).

## Fix
Point the deep-link to `/dashboard` — the fan's home, which lists their followed-artist concerts (and is the component `concerts/:id` also renders). Drops the non-functional `?artist=` filter; a dedicated per-artist concert view can be a future enhancement.

Refs #675