### PR TITLE
fix(analytics): verify login-event webhook via JSON+HMAC (Web Key issue)

### DIFF
--- a/internal/adapter/webhook/login_event_handler.go
+++ b/internal/adapter/webhook/login_event_handler.go
@@ -9,8 +9,9 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/zitadel/zitadel-go/v3/pkg/actions"
+
 	"github.com/liverty-music/backend/internal/entity"
-	"github.com/liverty-music/backend/internal/infrastructure/auth"
 	"github.com/pannpers/go-logging/logging"
 )
 
@@ -43,32 +44,38 @@ type eventPublisher interface {
 // the response, so it can never affect login. The handler emits `account.login`
 // once per interactive login.
 //
+// The Target is provisioned with PAYLOAD_TYPE_JSON (the Zitadel-recommended
+// default): the body is the raw event JSON, signed with an HMAC `ZITADEL-Signature`
+// header the handler verifies with the Target's signing key. (PAYLOAD_TYPE_JWT
+// is not used because an event-execution JWT target requires an active instance
+// web key, which this instance does not have — it fails with Errors.WebKey.NoActive.)
+//
 // The analytics path is best-effort and non-fatal: it resolves the login user
 // to the platform UserID and publishes an `ACCOUNT.login` domain event, but
 // ALWAYS returns 200 with an empty JSON body — a wrong event type, a missing
 // user identifier, a failed lookup, or a publish error is logged and skipped.
 type LoginEventHandler struct {
-	validator *auth.WebhookValidator
-	users     userResolver
-	publisher eventPublisher
-	logger    *logging.Logger
+	signingKey string
+	users      userResolver
+	publisher  eventPublisher
+	logger     *logging.Logger
 }
 
-// NewLoginEventHandler constructs a handler bound to the given validator, user
-// resolver, and event publisher. The validator's audience MUST be the
-// webhook-specific audience registered on the Zitadel login-event Target.
+// NewLoginEventHandler constructs a handler bound to the given Target signing
+// key, user resolver, and event publisher. The signing key MUST match the key
+// Zitadel generated for the login-event Target.
 func NewLoginEventHandler(
-	validator *auth.WebhookValidator,
+	signingKey string,
 	users userResolver,
 	publisher eventPublisher,
 	logger *logging.Logger,
 ) *LoginEventHandler {
-	return &LoginEventHandler{validator: validator, users: users, publisher: publisher, logger: logger}
+	return &LoginEventHandler{signingKey: signingKey, users: users, publisher: publisher, logger: logger}
 }
 
 // eventExecutionPayload captures the subset of the Actions v2 event-execution
-// payload this handler consumes. The top-level `userID` is the event EDITOR
-// (for session.user.checked, the Login-UI service user), NOT the person
+// JSON payload this handler consumes. The top-level `userID` is the event
+// EDITOR (for session.user.checked, the Login-UI service user), NOT the person
 // logging in — the login user lives inside `event_payload`, which is
 // base64-encoded. Unknown fields are ignored.
 type eventExecutionPayload struct {
@@ -104,28 +111,19 @@ func (h *LoginEventHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.validator.ValidateWebhookToken(ctx, string(body))
-	if err != nil {
-		h.logger.Warn(ctx, "login-event: webhook JWT validation failed",
+	// Verify the HMAC ZITADEL-Signature header against the raw JSON body using
+	// the Target's signing key. This is the security boundary alongside the
+	// private, internal-only webhook listener.
+	if err := actions.ValidateRequestPayload(body, &r.Header, h.signingKey); err != nil {
+		h.logger.Warn(ctx, "login-event: webhook signature validation failed",
 			slog.String("error", err.Error()),
 		)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	// Private claims carry the Actions v2 event payload. Round-trip through
-	// JSON so we can decode the nested, base64-encoded `event_payload` without
-	// walking the claim map manually.
-	rawClaims, err := json.Marshal(token.PrivateClaims())
-	if err != nil {
-		// A verified token whose claims cannot be re-marshalled is not worth
-		// failing login over; log and return success without emitting.
-		h.logger.Error(ctx, "login-event: failed to marshal private claims", err)
-		h.writeOK(ctx, w)
-		return
-	}
 	var payload eventExecutionPayload
-	if err := json.Unmarshal(rawClaims, &payload); err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		h.logger.Error(ctx, "login-event: failed to unmarshal payload", err)
 		h.writeOK(ctx, w)
 		return

--- a/internal/adapter/webhook/login_event_handler_test.go
+++ b/internal/adapter/webhook/login_event_handler_test.go
@@ -9,15 +9,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zitadel/zitadel-go/v3/pkg/actions"
 
 	"github.com/liverty-music/backend/internal/adapter/webhook"
 	"github.com/liverty-music/backend/internal/entity"
 )
 
-const testLoginEventAud = "urn:liverty-music:webhook:login-event"
+const testLoginEventSigningKey = "test-login-event-signing-key"
 
 // stubUserResolver records GetByExternalID calls and returns a canned result.
 type stubUserResolver struct {
@@ -48,47 +50,48 @@ func (s *stubPublisher) PublishEvent(_ context.Context, subject string, data any
 	return s.err
 }
 
-// loginEventBody builds a signed login-event webhook JWT whose claims model a
-// Zitadel Actions v2 event execution: an `event_type` plus a base64-encoded
+// loginEventBody builds a JSON login-event webhook body modelling a Zitadel
+// Actions v2 event execution: an `event_type` plus a base64-encoded
 // `event_payload`. For session.user.checked the login user lives in the decoded
 // payload's `userID` (the top-level userID would be the Login-UI editor). When
 // userID is empty the field is omitted so the "missing identifier" path can be
 // exercised.
-func loginEventBody(t *testing.T, f *jwksFixture, eventType, userID string) string {
+func loginEventBody(t *testing.T, eventType, userID string) []byte {
 	t.Helper()
 	inner := map[string]any{}
 	if userID != "" {
 		inner["userID"] = userID
 	}
-	encoded := encodeEventPayload(t, inner)
-	return f.signWebhookJWT(t, testIssuer, testLoginEventAud, map[string]any{
+	raw, err := json.Marshal(inner)
+	require.NoError(t, err)
+	body, err := json.Marshal(map[string]any{
 		"event_type": eventType,
 		// Top-level userID is the editor (Login-UI service user); the handler
 		// must ignore it and read the decoded event_payload instead.
 		"userID":        "login-ui-editor",
-		"event_payload": encoded,
+		"event_payload": base64.StdEncoding.EncodeToString(raw),
 	})
+	require.NoError(t, err)
+	return body
 }
 
-func encodeEventPayload(t *testing.T, payload map[string]any) string {
+// newSignedRequest builds a POST request with the ZITADEL-Signature header
+// computed from the body and the given signing key.
+func newSignedRequest(t *testing.T, body []byte, signingKey string) *http.Request {
 	t.Helper()
-	raw, err := json.Marshal(payload)
-	require.NoError(t, err)
-	return base64.StdEncoding.EncodeToString(raw)
+	req := httptest.NewRequest(http.MethodPost, "/account-login-event", bytes.NewReader(body))
+	req.Header.Set(actions.SigningHeader, actions.ComputeSignatureHeader(time.Now(), body, signingKey))
+	return req
 }
 
 func TestLoginEventHandler_UserInitiatedLogin_EmitsAccountLoginOnce(t *testing.T) {
-	fixture := newJWKSFixture(t)
 	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
 	pub := &stubPublisher{}
-	handler := webhook.NewLoginEventHandler(
-		fixture.newValidator(t, testLoginEventAud), users, pub, newLogger(t),
-	)
+	handler := webhook.NewLoginEventHandler(testLoginEventSigningKey, users, pub, newLogger(t))
 
-	body := loginEventBody(t, fixture, "session.user.checked", "zitadel-sub-123")
+	body := loginEventBody(t, "session.user.checked", "zitadel-sub-123")
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/account-login-event", bytes.NewBufferString(body))
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, newSignedRequest(t, body, testLoginEventSigningKey))
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	// The decoded event_payload userID was resolved to the platform UserID...
@@ -103,39 +106,44 @@ func TestLoginEventHandler_UserInitiatedLogin_EmitsAccountLoginOnce(t *testing.T
 }
 
 func TestLoginEventHandler_InvalidSignature_Rejected_NoPublish(t *testing.T) {
-	fixture := newJWKSFixture(t)
-	// A different fixture signs the token, so its signature does not verify
-	// against the handler's trusted JWKS.
-	forger := newJWKSFixture(t)
 	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
 	pub := &stubPublisher{}
-	handler := webhook.NewLoginEventHandler(
-		fixture.newValidator(t, testLoginEventAud), users, pub, newLogger(t),
-	)
+	handler := webhook.NewLoginEventHandler(testLoginEventSigningKey, users, pub, newLogger(t))
 
-	body := loginEventBody(t, forger, "session.user.checked", "zitadel-sub-123")
+	// Signed with a different key, so the signature does not verify.
+	body := loginEventBody(t, "session.user.checked", "zitadel-sub-123")
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/account-login-event", bytes.NewBufferString(body))
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, newSignedRequest(t, body, "wrong-signing-key"))
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Equal(t, 0, users.calls)
 	assert.Equal(t, 0, pub.calls)
 }
 
-func TestLoginEventHandler_WrongEventType_Skips_Returns200(t *testing.T) {
-	fixture := newJWKSFixture(t)
+func TestLoginEventHandler_MissingSignature_Rejected_NoPublish(t *testing.T) {
 	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
 	pub := &stubPublisher{}
-	handler := webhook.NewLoginEventHandler(
-		fixture.newValidator(t, testLoginEventAud), users, pub, newLogger(t),
-	)
+	handler := webhook.NewLoginEventHandler(testLoginEventSigningKey, users, pub, newLogger(t))
+
+	body := loginEventBody(t, "session.user.checked", "zitadel-sub-123")
+	rec := httptest.NewRecorder()
+	// No ZITADEL-Signature header set.
+	req := httptest.NewRequest(http.MethodPost, "/account-login-event", bytes.NewReader(body))
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, 0, pub.calls)
+}
+
+func TestLoginEventHandler_WrongEventType_Skips_Returns200(t *testing.T) {
+	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
+	pub := &stubPublisher{}
+	handler := webhook.NewLoginEventHandler(testLoginEventSigningKey, users, pub, newLogger(t))
 
 	// A different event type (e.g. a mis-bound Target) must not emit a login.
-	body := loginEventBody(t, fixture, "session.added", "zitadel-sub-123")
+	body := loginEventBody(t, "session.added", "zitadel-sub-123")
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/account-login-event", bytes.NewBufferString(body))
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, newSignedRequest(t, body, testLoginEventSigningKey))
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, 0, users.calls, "no lookup for a non-login event type")
@@ -143,18 +151,14 @@ func TestLoginEventHandler_WrongEventType_Skips_Returns200(t *testing.T) {
 }
 
 func TestLoginEventHandler_MissingUserID_Skips_Returns200(t *testing.T) {
-	fixture := newJWKSFixture(t)
 	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
 	pub := &stubPublisher{}
-	handler := webhook.NewLoginEventHandler(
-		fixture.newValidator(t, testLoginEventAud), users, pub, newLogger(t),
-	)
+	handler := webhook.NewLoginEventHandler(testLoginEventSigningKey, users, pub, newLogger(t))
 
 	// A session.user.checked whose decoded payload lacks userID: skip, never fail.
-	body := loginEventBody(t, fixture, "session.user.checked", "")
+	body := loginEventBody(t, "session.user.checked", "")
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/account-login-event", bytes.NewBufferString(body))
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, newSignedRequest(t, body, testLoginEventSigningKey))
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, 0, users.calls, "no lookup when identifier is absent")
@@ -162,17 +166,13 @@ func TestLoginEventHandler_MissingUserID_Skips_Returns200(t *testing.T) {
 }
 
 func TestLoginEventHandler_LookupMiss_Skips_Returns200(t *testing.T) {
-	fixture := newJWKSFixture(t)
 	users := &stubUserResolver{err: errors.New("user not found")}
 	pub := &stubPublisher{}
-	handler := webhook.NewLoginEventHandler(
-		fixture.newValidator(t, testLoginEventAud), users, pub, newLogger(t),
-	)
+	handler := webhook.NewLoginEventHandler(testLoginEventSigningKey, users, pub, newLogger(t))
 
-	body := loginEventBody(t, fixture, "session.user.checked", "zitadel-sub-unprovisioned")
+	body := loginEventBody(t, "session.user.checked", "zitadel-sub-unprovisioned")
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/account-login-event", bytes.NewBufferString(body))
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, newSignedRequest(t, body, testLoginEventSigningKey))
 
 	require.Equal(t, http.StatusOK, rec.Code, "a lookup miss must never fail login")
 	assert.Equal(t, 1, users.calls)
@@ -180,17 +180,13 @@ func TestLoginEventHandler_LookupMiss_Skips_Returns200(t *testing.T) {
 }
 
 func TestLoginEventHandler_PublishFailure_DoesNotAffectResponse(t *testing.T) {
-	fixture := newJWKSFixture(t)
 	users := &stubUserResolver{user: &entity.User{ID: "platform-uuid-1"}}
 	pub := &stubPublisher{err: errors.New("nats unavailable")}
-	handler := webhook.NewLoginEventHandler(
-		fixture.newValidator(t, testLoginEventAud), users, pub, newLogger(t),
-	)
+	handler := webhook.NewLoginEventHandler(testLoginEventSigningKey, users, pub, newLogger(t))
 
-	body := loginEventBody(t, fixture, "session.user.checked", "zitadel-sub-123")
+	body := loginEventBody(t, "session.user.checked", "zitadel-sub-123")
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/account-login-event", bytes.NewBufferString(body))
-	handler.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, newSignedRequest(t, body, testLoginEventSigningKey))
 
 	// The publish failed but login (the webhook response) still succeeds.
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -198,10 +194,8 @@ func TestLoginEventHandler_PublishFailure_DoesNotAffectResponse(t *testing.T) {
 }
 
 func TestLoginEventHandler_GET_ReturnsMethodNotAllowed(t *testing.T) {
-	fixture := newJWKSFixture(t)
 	handler := webhook.NewLoginEventHandler(
-		fixture.newValidator(t, testLoginEventAud),
-		&stubUserResolver{}, &stubPublisher{}, newLogger(t),
+		testLoginEventSigningKey, &stubUserResolver{}, &stubPublisher{}, newLogger(t),
 	)
 
 	rec := httptest.NewRecorder()

--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -395,10 +395,11 @@ func InitializeApp(ctx context.Context) (*App, error) {
 	)
 	// Login-event Actions v2 handler — bound to the event execution on
 	// session.user.checked; emits account.login once per interactive login,
-	// never on token refresh or a machine grant. Shares the JWKS cache;
-	// publishes a best-effort ACCOUNT.login event and never fails login.
+	// never on token refresh or a machine grant. The Target is PAYLOAD_TYPE_JSON,
+	// so the handler verifies the HMAC ZITADEL-Signature with the Target's signing
+	// key. Publishes a best-effort ACCOUNT.login event and never fails login.
 	loginEventHandler := webhook.NewLoginEventHandler(
-		jwtValidator.NewWebhookValidator(cfg.Webhook.LoginEventAudience),
+		cfg.Webhook.LoginEventSigningKey,
 		userUC,
 		eventPublisher,
 		logger,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -605,11 +605,14 @@ type WebhookSettings struct {
 	// registered on the corresponding Zitadel Target.
 	PreAccessTokenAudience string `envconfig:"WEBHOOK_PRE_ACCESS_TOKEN_AUDIENCE" default:"urn:liverty-music:webhook:pre-access-token"`
 
-	// LoginEventAudience is the expected `aud` claim for webhook JWTs delivered
-	// to `POST /account-login-event` (the account.login source). Must match the
-	// audience registered on the corresponding Zitadel login-event Target (the
-	// Actions v2 event execution on session.user.checked).
-	LoginEventAudience string `envconfig:"WEBHOOK_LOGIN_EVENT_AUDIENCE" default:"urn:liverty-music:webhook:login-event"`
+	// LoginEventSigningKey is the HMAC signing key for the login-event Target
+	// (`POST /account-login-event`, the account.login source). The Target uses
+	// PAYLOAD_TYPE_JSON; Zitadel signs each body with this key and the handler
+	// verifies the `ZITADEL-Signature` header against it. Sourced from a secret
+	// (Zitadel generates it at Target creation). Left un-validated/optional so a
+	// boot before the secret is synced degrades gracefully (the handler rejects
+	// unverifiable requests) rather than crash-looping.
+	LoginEventSigningKey string `envconfig:"WEBHOOK_LOGIN_EVENT_SIGNING_KEY"`
 }
 
 // Loadable constrains the config types that can be loaded from environment variables.
@@ -746,10 +749,6 @@ func (c *ServerConfig) Validate() error {
 
 	if c.Webhook.PreAccessTokenAudience == "" {
 		return fmt.Errorf("webhook pre-access-token audience is required")
-	}
-
-	if c.Webhook.LoginEventAudience == "" {
-		return fmt.Errorf("webhook login-event audience is required")
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,7 +15,6 @@ func validWebhookSettings() WebhookSettings {
 	return WebhookSettings{
 		Port:                   9090,
 		PreAccessTokenAudience: "urn:liverty-music:webhook:pre-access-token",
-		LoginEventAudience:     "urn:liverty-music:webhook:login-event",
 	}
 }
 
@@ -85,7 +84,6 @@ func TestLoad_ServerConfig(t *testing.T) {
 					ReadTimeout:            5 * time.Second,
 					IdleTimeout:            30 * time.Second,
 					PreAccessTokenAudience: "urn:liverty-music:webhook:pre-access-token",
-					LoginEventAudience:     "urn:liverty-music:webhook:login-event",
 				},
 				GCP: GCPConfig{
 					ProjectID:               "test-project",
@@ -181,7 +179,6 @@ func TestLoad_ServerConfig(t *testing.T) {
 					ReadTimeout:            5 * time.Second,
 					IdleTimeout:            30 * time.Second,
 					PreAccessTokenAudience: "urn:liverty-music:webhook:pre-access-token",
-					LoginEventAudience:     "urn:liverty-music:webhook:login-event",
 				},
 				GCP: GCPConfig{
 					ProjectID:               "custom-project",


### PR DESCRIPTION
The `account.login` event execution fired in prod but every target call failed with `Errors.WebKey.NoActive` (an event-execution `PAYLOAD_TYPE_JWT` target needs an active instance web key this Zitadel instance lacks). Switch to Zitadel's default `PAYLOAD_TYPE_JSON` + HMAC.

- `LoginEventHandler` verifies the `ZITADEL-Signature` header via `actions.ValidateRequestPayload` (zitadel-go SDK) and parses the raw JSON body; `event_type` guard + base64 `event_payload` decode unchanged.
- Config: `WEBHOOK_LOGIN_EVENT_AUDIENCE` → `WEBHOOK_LOGIN_EVENT_SIGNING_KEY` (secret, optional → graceful 401 before the key syncs).
- Tests sign with `actions.ComputeSignatureHeader`. `make check` passes.

Depends on cloud-provisioning `fix-login-event-hmac` (Target JSON + signingKey GSM secret). Release `v1.19.1` after merge.

Refs: #532