### PR TITLE
refactor(analytics): prune backend analytics events and rename login

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -111,8 +111,8 @@ func (c *AnalyticsConsumer) HandleUserCreated(msg *message.Message) error {
 }
 
 // HandleAccountLogin forwards the ACCOUNT.login NATS subject as the
-// catalogue event usecase.EventAccountLogin. The subject is published once
-// per user-initiated login (Zitadel session.user.checked), never on a token
+// catalogue event usecase.EventAccountSignin. The subject is published once
+// per user-initiated sign-in (Zitadel session.user.checked), never on a token
 // refresh, so this event is a returning/active-user signal. No properties
 // are attached: the distinct_id (platform UserID) is the whole payload, and
 // no PII (email, sub) is ever forwarded.
@@ -129,7 +129,7 @@ func (c *AnalyticsConsumer) HandleAccountLogin(msg *message.Message) error {
 
 	if c.client == nil {
 		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
-			slog.String("event", string(usecase.EventAccountLogin)),
+			slog.String("event", string(usecase.EventAccountSignin)),
 			slog.String("user_id", data.UserID),
 		)
 		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
@@ -142,57 +142,9 @@ func (c *AnalyticsConsumer) HandleAccountLogin(msg *message.Message) error {
 		return nil
 	}
 
-	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventAccountLogin, usecase.AnalyticsProperties{}); err != nil {
+	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventAccountSignin, usecase.AnalyticsProperties{}); err != nil {
 		c.logger.Error(ctx, "failed to enqueue analytics event", err,
-			slog.String("event", string(usecase.EventAccountLogin)),
-			slog.String("user_id", data.UserID),
-		)
-		c.metrics.RecordMessage(ctx, statusEnqueueError)
-		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
-	}
-
-	c.metrics.RecordMessage(ctx, statusForwarded)
-	return nil
-}
-
-// HandleUserPreferredLanguageUpdated forwards the
-// USER.preferred_language_updated NATS subject as the catalogue event
-// usecase.EventAccountPreferredLanguageUpdated. Properties: from_locale,
-// to_locale (per specification/docs/analytics/event-catalog.md).
-func (c *AnalyticsConsumer) HandleUserPreferredLanguageUpdated(msg *message.Message) error {
-	ctx := msg.Context()
-	defer c.recordLag(ctx, msg)
-
-	var data entity.UserPreferredLanguageUpdatedData
-	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
-		c.logger.Error(ctx, "failed to parse USER.preferred_language_updated event", err)
-		c.metrics.RecordMessage(ctx, statusSkippedParseError)
-		return apperr.Wrap(err, codes.Internal, "parse USER.preferred_language_updated event")
-	}
-
-	if c.client == nil {
-		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
-			slog.String("event", string(usecase.EventAccountPreferredLanguageUpdated)),
-			slog.String("user_id", data.UserID),
-		)
-		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
-		return nil
-	}
-
-	if data.UserID == "" {
-		c.logger.Warn(ctx, "USER.preferred_language_updated event missing user_id, skipping forward")
-		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
-		return nil
-	}
-
-	properties := usecase.AnalyticsProperties{
-		"from_locale": data.FromLocale,
-		"to_locale":   data.ToLocale,
-	}
-
-	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventAccountPreferredLanguageUpdated, properties); err != nil {
-		c.logger.Error(ctx, "failed to enqueue analytics event", err,
-			slog.String("event", string(usecase.EventAccountPreferredLanguageUpdated)),
+			slog.String("event", string(usecase.EventAccountSignin)),
 			slog.String("user_id", data.UserID),
 		)
 		c.metrics.RecordMessage(ctx, statusEnqueueError)
@@ -714,60 +666,6 @@ func (c *AnalyticsConsumer) HandleTicketEmailParsed(msg *message.Message) error 
 		c.logger.Error(ctx, "failed to enqueue analytics event", err,
 			slog.String("event", string(usecase.EventTicketEmailParsed)),
 			slog.String("user_id", data.UserID),
-		)
-		c.metrics.RecordMessage(ctx, statusEnqueueError)
-		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")
-	}
-
-	c.metrics.RecordMessage(ctx, statusForwarded)
-	return nil
-}
-
-// HandleSalesReminderDelivered forwards the SALES_REMINDER.delivered NATS
-// subject as the catalogue event usecase.EventSalesReminderDelivered.
-// Properties: phase_stage, delivery_status. The distinct_id is the platform
-// UserID from the payload.
-func (c *AnalyticsConsumer) HandleSalesReminderDelivered(msg *message.Message) error {
-	ctx := msg.Context()
-	defer c.recordLag(ctx, msg)
-
-	var data entity.SalesReminderDeliveredData
-	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
-		c.logger.Error(ctx, "failed to parse SALES_REMINDER.delivered event", err)
-		c.metrics.RecordMessage(ctx, statusSkippedParseError)
-		return apperr.Wrap(err, codes.Internal, "parse SALES_REMINDER.delivered event")
-	}
-
-	if c.client == nil {
-		c.logger.Warn(ctx, "analytics client not configured, skipping forward",
-			slog.String("event", string(usecase.EventSalesReminderDelivered)),
-			slog.String("user_id", data.UserID),
-			slog.String("phase_stage", data.PhaseStage),
-			slog.String("delivery_status", data.DeliveryStatus),
-		)
-		c.metrics.RecordMessage(ctx, statusSkippedNilClient)
-		return nil
-	}
-
-	if data.UserID == "" {
-		c.logger.Warn(ctx, "SALES_REMINDER.delivered event missing user_id, skipping forward",
-			slog.String("phase_stage", data.PhaseStage),
-			slog.String("delivery_status", data.DeliveryStatus),
-		)
-		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
-		return nil
-	}
-
-	properties := usecase.AnalyticsProperties{
-		"phase_stage":     data.PhaseStage,
-		"delivery_status": data.DeliveryStatus,
-	}
-
-	if err := c.client.Enqueue(ctx, data.UserID, usecase.EventSalesReminderDelivered, properties); err != nil {
-		c.logger.Error(ctx, "failed to enqueue analytics event", err,
-			slog.String("event", string(usecase.EventSalesReminderDelivered)),
-			slog.String("user_id", data.UserID),
-			slog.String("phase_stage", data.PhaseStage),
 		)
 		c.metrics.RecordMessage(ctx, statusEnqueueError)
 		return apperr.Wrap(err, codes.Internal, "enqueue analytics event")

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -146,7 +146,7 @@ func TestAnalyticsConsumer_HandleUserCreated(t *testing.T) {
 }
 
 // TestAnalyticsConsumer_HandleAccountLogin covers the routing/validation
-// surface of the ACCOUNT.login handler. account.login carries no properties —
+// surface of the ACCOUNT.login handler. account.signin carries no properties —
 // the distinct_id (platform UserID) is the whole signal.
 func TestAnalyticsConsumer_HandleAccountLogin(t *testing.T) {
 	t.Parallel()
@@ -166,7 +166,7 @@ func TestAnalyticsConsumer_HandleAccountLogin(t *testing.T) {
 		nilClient bool
 	}{
 		{
-			name: "forwards account.login when client + UserID present",
+			name: "forwards account.signin when client + UserID present",
 			data: entity.AccountLoginData{UserID: validUserID},
 			want: want{expectEnqueue: true, expectStatus: "forwarded"},
 		},
@@ -206,7 +206,7 @@ func TestAnalyticsConsumer_HandleAccountLogin(t *testing.T) {
 						Enqueue(
 							mock.Anything,
 							tt.data.UserID,
-							usecase.EventAccountLogin,
+							usecase.EventAccountSignin,
 							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
 								return len(props) == 0
 							}),
@@ -226,124 +226,6 @@ func TestAnalyticsConsumer_HandleAccountLogin(t *testing.T) {
 
 			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
 			err := handler.HandleAccountLogin(makeAnalyticsMsg(t, tt.data))
-
-			if tt.want.err != nil {
-				assert.ErrorIs(t, err, tt.want.err)
-				return
-			}
-			assert.NoError(t, err)
-		})
-	}
-}
-
-// TestAnalyticsConsumer_HandleUserPreferredLanguageUpdated covers
-// USER.preferred_language_updated → account.preferred_language.updated
-// routing. Properties from_locale and to_locale travel verbatim.
-func TestAnalyticsConsumer_HandleUserPreferredLanguageUpdated(t *testing.T) {
-	t.Parallel()
-
-	const validUserID = "11111111-2222-3333-4444-555555555555"
-
-	type args struct {
-		data entity.UserPreferredLanguageUpdatedData
-	}
-	type want struct {
-		err              error
-		expectEnqueueErr error
-		expectEnqueue    bool
-		expectStatus     string
-	}
-	tests := []struct {
-		name      string
-		args      args
-		want      want
-		nilClient bool
-	}{
-		{
-			name: "forwards with both locales when client + UserID present",
-			args: args{data: entity.UserPreferredLanguageUpdatedData{
-				UserID:     validUserID,
-				FromLocale: "ja",
-				ToLocale:   "en",
-			}},
-			want: want{expectEnqueue: true, expectStatus: "forwarded"},
-		},
-		{
-			name: "forwards with empty from_locale when prior was unset",
-			args: args{data: entity.UserPreferredLanguageUpdatedData{
-				UserID:     validUserID,
-				FromLocale: "",
-				ToLocale:   "ja",
-			}},
-			want: want{expectEnqueue: true, expectStatus: "forwarded"},
-		},
-		{
-			name: "skips forward when client is nil",
-			args: args{data: entity.UserPreferredLanguageUpdatedData{
-				UserID:   validUserID,
-				ToLocale: "ja",
-			}},
-			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
-			nilClient: true,
-		},
-		{
-			name: "skips forward when UserID is empty",
-			args: args{data: entity.UserPreferredLanguageUpdatedData{
-				UserID:   "",
-				ToLocale: "ja",
-			}},
-			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
-		},
-		{
-			name: "wraps Enqueue error as apperr.ErrInternal",
-			args: args{data: entity.UserPreferredLanguageUpdatedData{
-				UserID:   validUserID,
-				ToLocale: "ja",
-			}},
-			want: want{
-				expectEnqueue:    true,
-				expectEnqueueErr: errors.New("queue full"),
-				err:              apperr.ErrInternal,
-				expectStatus:     "enqueue_error",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var client usecase.AnalyticsClient
-			var clientMock *ucmocks.MockAnalyticsClient
-			if !tt.nilClient {
-				clientMock = ucmocks.NewMockAnalyticsClient(t)
-				client = clientMock
-				if tt.want.expectEnqueue {
-					clientMock.EXPECT().
-						Enqueue(
-							mock.Anything,
-							tt.args.data.UserID,
-							usecase.EventAccountPreferredLanguageUpdated,
-							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
-								return props["from_locale"] == tt.args.data.FromLocale &&
-									props["to_locale"] == tt.args.data.ToLocale
-							}),
-						).
-						Return(tt.want.expectEnqueueErr).
-						Once()
-				}
-			}
-
-			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
-			metricsMock.EXPECT().
-				RecordMessage(mock.Anything, tt.want.expectStatus).
-				Once()
-			metricsMock.EXPECT().
-				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
-				Once()
-
-			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
-			err := handler.HandleUserPreferredLanguageUpdated(makeAnalyticsMsg(t, tt.args.data))
 
 			if tt.want.err != nil {
 				assert.ErrorIs(t, err, tt.want.err)
@@ -1492,122 +1374,6 @@ func TestAnalyticsConsumer_HandleTicketEmailParsed(t *testing.T) {
 
 			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
 			err := handler.HandleTicketEmailParsed(makeAnalyticsMsg(t, tt.args.data))
-
-			if tt.want.err != nil {
-				assert.ErrorIs(t, err, tt.want.err)
-				return
-			}
-			assert.NoError(t, err)
-		})
-	}
-}
-
-// TestAnalyticsConsumer_HandleSalesReminderDelivered covers
-// SALES_REMINDER.delivered → sales_reminder.delivered routing.
-// Properties: phase_stage, delivery_status. Distinct_id is the platform UserID.
-func TestAnalyticsConsumer_HandleSalesReminderDelivered(t *testing.T) {
-	t.Parallel()
-
-	const (
-		validUserID = "11111111-2222-3333-4444-555555555555"
-		validStage  = "APPLY_OPEN"
-		validStatus = "delivered"
-	)
-
-	type args struct {
-		data entity.SalesReminderDeliveredData
-	}
-	type want struct {
-		err              error
-		expectEnqueueErr error
-		expectEnqueue    bool
-		expectStatus     string
-	}
-	tests := []struct {
-		name      string
-		args      args
-		want      want
-		nilClient bool
-	}{
-		{
-			name: "forwards sales_reminder.delivered with phase_stage and delivery_status",
-			args: args{data: entity.SalesReminderDeliveredData{
-				UserID:         validUserID,
-				PhaseStage:     validStage,
-				DeliveryStatus: validStatus,
-			}},
-			want: want{expectEnqueue: true, expectStatus: "forwarded"},
-		},
-		{
-			name: "skips forward when client is nil (local dev)",
-			args: args{data: entity.SalesReminderDeliveredData{
-				UserID:         validUserID,
-				PhaseStage:     validStage,
-				DeliveryStatus: "no_subscription",
-			}},
-			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
-			nilClient: true,
-		},
-		{
-			name: "skips forward when UserID is empty",
-			args: args{data: entity.SalesReminderDeliveredData{
-				UserID:         "",
-				PhaseStage:     validStage,
-				DeliveryStatus: "failed",
-			}},
-			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
-		},
-		{
-			name: "wraps Enqueue error as apperr.ErrInternal",
-			args: args{data: entity.SalesReminderDeliveredData{
-				UserID:         validUserID,
-				PhaseStage:     validStage,
-				DeliveryStatus: validStatus,
-			}},
-			want: want{
-				expectEnqueue:    true,
-				expectEnqueueErr: errors.New("queue full"),
-				err:              apperr.ErrInternal,
-				expectStatus:     "enqueue_error",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var client usecase.AnalyticsClient
-			var clientMock *ucmocks.MockAnalyticsClient
-			if !tt.nilClient {
-				clientMock = ucmocks.NewMockAnalyticsClient(t)
-				client = clientMock
-				if tt.want.expectEnqueue {
-					clientMock.EXPECT().
-						Enqueue(
-							mock.Anything,
-							tt.args.data.UserID,
-							usecase.EventSalesReminderDelivered,
-							mock.MatchedBy(func(props usecase.AnalyticsProperties) bool {
-								return props["phase_stage"] == tt.args.data.PhaseStage &&
-									props["delivery_status"] == tt.args.data.DeliveryStatus
-							}),
-						).
-						Return(tt.want.expectEnqueueErr).
-						Once()
-				}
-			}
-
-			metricsMock := ucmocks.NewMockAnalyticsConsumerMetrics(t)
-			metricsMock.EXPECT().
-				RecordMessage(mock.Anything, tt.want.expectStatus).
-				Once()
-			metricsMock.EXPECT().
-				RecordLag(mock.Anything, mock.MatchedBy(func(s float64) bool { return s >= 0 })).
-				Once()
-
-			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
-			err := handler.HandleSalesReminderDelivered(makeAnalyticsMsg(t, tt.args.data))
 
 			if tt.want.err != nil {
 				assert.ErrorIs(t, err, tt.want.err)

--- a/internal/adapter/webhook/login_event_handler.go
+++ b/internal/adapter/webhook/login_event_handler.go
@@ -41,8 +41,9 @@ type eventPublisher interface {
 // Unlike a request/response (method) execution — whose webhook return REPLACES
 // the API payload and previously broke sign-in — an event execution is
 // fire-and-forget: it fires after the event is persisted and Zitadel ignores
-// the response, so it can never affect login. The handler emits `account.login`
-// once per interactive login.
+// the response, so it can never affect login. The handler publishes the
+// `ACCOUNT.login` subject once per interactive login, which the analytics
+// consumer forwards as the `account.signin` event.
 //
 // The Target is provisioned with PAYLOAD_TYPE_JSON (the Zitadel-recommended
 // default): the body is the raw event JSON, signed with an HMAC `ZITADEL-Signature`

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -172,7 +172,6 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	salesReminderDeliveryUC := usecase.NewSalesReminderDeliveryUseCase(
 		salesReminderRepo,
 		notificationUC,
-		eventPublisher,
 		logger,
 	)
 
@@ -234,13 +233,6 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		entity.SubjectUserCreated,
 		subscriber,
 		analyticsConsumer.HandleUserCreated,
-	)
-
-	router.AddConsumerHandler(
-		"forward-user-preferred-language-updated-to-analytics",
-		entity.SubjectUserPreferredLanguageUpdated,
-		subscriber,
-		analyticsConsumer.HandleUserPreferredLanguageUpdated,
 	)
 
 	router.AddConsumerHandler(
@@ -320,13 +312,6 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		entity.SubjectTicketEmailParsed,
 		subscriber,
 		analyticsConsumer.HandleTicketEmailParsed,
-	)
-
-	router.AddConsumerHandler(
-		"forward-sales-reminder-delivered-to-analytics",
-		entity.SubjectSalesReminderDelivered,
-		subscriber,
-		analyticsConsumer.HandleSalesReminderDelivered,
 	)
 
 	router.AddConsumerHandler(

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -8,15 +8,14 @@ package entity
 // lowercase catalogue event name (see specification/docs/analytics/
 // event-catalog.md) at the Handle method that subscribes to it.
 const (
-	SubjectConcertDiscovered            = "CONCERT.discovered"
-	SubjectConcertCreated               = "CONCERT.created"
-	SubjectArtistCreated                = "ARTIST.created"
-	SubjectArtistFollowed               = "ARTIST.followed"
-	SubjectArtistUnfollowed             = "ARTIST.unfollowed"
-	SubjectUserCreated                  = "USER.created"
-	SubjectUserPreferredLanguageUpdated = "USER.preferred_language_updated"
-	SubjectNotificationSubscribed       = "NOTIFICATION.subscribed"
-	SubjectNotificationUnsubscribed     = "NOTIFICATION.unsubscribed"
+	SubjectConcertDiscovered        = "CONCERT.discovered"
+	SubjectConcertCreated           = "CONCERT.created"
+	SubjectArtistCreated            = "ARTIST.created"
+	SubjectArtistFollowed           = "ARTIST.followed"
+	SubjectArtistUnfollowed         = "ARTIST.unfollowed"
+	SubjectUserCreated              = "USER.created"
+	SubjectNotificationSubscribed   = "NOTIFICATION.subscribed"
+	SubjectNotificationUnsubscribed = "NOTIFICATION.unsubscribed"
 	// SubjectNotificationDelivered is published by NotificationUseCase once per
 	// notification whose channel send reached the delivered state. It drives the
 	// notification.delivered analytics event so push-delivery reach can be
@@ -42,12 +41,6 @@ const (
 	// ticket.mint.completed analytics event (SBT issuance / ticket-activation
 	// funnel).
 	SubjectTicketMintCompleted = "TICKET.mint_completed"
-	// SubjectSalesReminderDelivered is published by
-	// salesReminderDeliveryUseCase.DeliverReminder at every terminal delivery
-	// outcome (delivered, no_subscription, failed). It drives the
-	// sales_reminder.delivered analytics event so push-delivery reach and
-	// failure rates can be tracked per stage in PostHog.
-	SubjectSalesReminderDelivered = "SALES_REMINDER.delivered"
 	// SubjectTicketEmailParsed is published by TicketEmailUseCase.Create on
 	// both parse-success and parse-failure paths. It drives the
 	// ticket.email.parsed analytics event (email-ingestion data quality,
@@ -55,7 +48,7 @@ const (
 	SubjectTicketEmailParsed = "TICKET_EMAIL.parsed"
 	// SubjectAccountLogin is published by the login-event webhook handler once
 	// per user-initiated login, bound to the Zitadel session.user.checked
-	// event. It drives the account.login analytics event (returning /
+	// event. It drives the account.signin analytics event (returning /
 	// active-user retention cohorts). The OIDC refresh_token grant touches only
 	// the oidc_session aggregate and never emits session.user.checked, so this
 	// subject is never published on a silent token refresh — login-specific by
@@ -77,7 +70,6 @@ var AllSubjects = []string{
 	SubjectArtistFollowed,
 	SubjectArtistUnfollowed,
 	SubjectUserCreated,
-	SubjectUserPreferredLanguageUpdated,
 	SubjectNotificationSubscribed,
 	SubjectNotificationUnsubscribed,
 	SubjectNotificationDelivered,
@@ -87,7 +79,6 @@ var AllSubjects = []string{
 	SubjectSalesPhaseReminderDue,
 	SubjectTicketJourneyStatusChanged,
 	SubjectTicketMintCompleted,
-	SubjectSalesReminderDelivered,
 	SubjectTicketEmailParsed,
 	SubjectAccountLogin,
 }
@@ -135,9 +126,10 @@ type UserCreatedData struct {
 }
 
 // AccountLoginData is the payload for ACCOUNT.login events.
-// Mapped to the catalogue event account.login by the analytics-consumer.
-// Published by the login-event webhook handler once per user-initiated
-// login, after the Zitadel sub has been resolved to the platform UserID.
+// Mapped to the catalogue event account.signin by the analytics-consumer
+// (the NATS transport subject stays ACCOUNT.login). Published by the
+// login-event webhook handler once per user-initiated sign-in, after the
+// Zitadel sub has been resolved to the platform UserID.
 type AccountLoginData struct {
 	// UserID is the platform-internal user identifier (UUID). Used as the
 	// PostHog distinct_id. Never the Zitadel sub, which Enqueue rejects.
@@ -153,22 +145,6 @@ type ArtistCreatedData struct {
 	ArtistName string `json:"artist_name"`
 	// MBID is the MusicBrainz identifier for canonical identity.
 	MBID string `json:"mbid"`
-}
-
-// UserPreferredLanguageUpdatedData is the payload for USER.preferred_language_updated.
-// Mapped to the catalogue event account.preferred_language.updated by the
-// analytics-consumer. Published by UserUseCase.UpdatePreferredLanguage after
-// the repository confirms the change.
-type UserPreferredLanguageUpdatedData struct {
-	// UserID is the platform-internal user identifier (UUID). Used as the
-	// PostHog distinct_id.
-	UserID string `json:"user_id"`
-	// FromLocale is the ISO 639-1 language code before the change. Empty
-	// when the user had no preferred language set previously (legacy rows
-	// pending backfill — see entity.User.PreferredLanguage docstring).
-	FromLocale string `json:"from_locale"`
-	// ToLocale is the ISO 639-1 language code after the change.
-	ToLocale string `json:"to_locale"`
 }
 
 // ArtistFollowedData is the payload for ARTIST.followed.
@@ -333,24 +309,6 @@ type TicketEmailParsedData struct {
 	// FieldCount is the number of non-nil optional fields extracted by the
 	// parser on success. Zero on failure.
 	FieldCount int `json:"field_count"`
-}
-
-// SalesReminderDeliveredData is the payload for SALES_REMINDER.delivered.
-// Mapped to the catalogue event sales_reminder.delivered by the
-// analytics-consumer. Published by salesReminderDeliveryUseCase.DeliverReminder
-// at every terminal delivery outcome so push-delivery reach and failure rates can
-// be tracked per stage in PostHog.
-type SalesReminderDeliveredData struct {
-	// UserID is the platform-internal user identifier of the reminder recipient.
-	// Used as the PostHog distinct_id.
-	UserID string `json:"user_id"`
-	// PhaseStage is the string name of the ReminderStage (e.g. "APPLY_OPEN").
-	PhaseStage string `json:"phase_stage"`
-	// DeliveryStatus is one of "delivered", "no_subscription", or "failed".
-	// "delivered" means the push was accepted by at least one subscription.
-	// "no_subscription" means the user had no registered push subscriptions.
-	// "failed" means all send attempts were rejected (410 Gone or send error).
-	DeliveryStatus string `json:"delivery_status"`
 }
 
 // TicketJourneyStatusChangedData is the payload for TICKET_JOURNEY.status_changed.

--- a/internal/infrastructure/analytics/posthog/posthog_client_test.go
+++ b/internal/infrastructure/analytics/posthog/posthog_client_test.go
@@ -198,7 +198,7 @@ func TestAnalyticsClient_Enqueue(t *testing.T) {
 			name: "forwards a known event with properties",
 			args: args{
 				distinctID: validUUID,
-				eventName:  usecase.EventTicketPurchaseCompleted,
+				eventName:  usecase.EventTicketMintCompleted,
 				properties: usecase.AnalyticsProperties{
 					"ticket_id":    "ticket-42",
 					"concert_id":   "concert-7",
@@ -211,7 +211,7 @@ func TestAnalyticsClient_Enqueue(t *testing.T) {
 				captured := fake.Captured()
 				require.Len(t, captured, 1)
 				assert.Equal(t, validUUID, captured[0].DistinctId)
-				assert.Equal(t, string(usecase.EventTicketPurchaseCompleted), captured[0].Event)
+				assert.Equal(t, string(usecase.EventTicketMintCompleted), captured[0].Event)
 				assert.Equal(t, "ticket-42", captured[0].Properties["ticket_id"])
 				assert.Equal(t, "concert-7", captured[0].Properties["concert_id"])
 				assert.Equal(t, "3000-4999", captured[0].Properties["price_bucket"])

--- a/internal/infrastructure/messaging/streams.go
+++ b/internal/infrastructure/messaging/streams.go
@@ -119,18 +119,6 @@ var streams = []nats.StreamConfig{
 		Duplicates: 2 * time.Minute,
 	},
 	{
-		// Carries SALES_REMINDER.delivered (sales-phase push reminder delivery
-		// outcomes), consumed by the analytics consumer.
-		Name:       "SALES_REMINDER",
-		Subjects:   []string{"SALES_REMINDER.*"},
-		Retention:  nats.LimitsPolicy,
-		MaxAge:     7 * 24 * time.Hour,
-		Storage:    nats.FileStorage,
-		Discard:    nats.DiscardOld,
-		Replicas:   1,
-		Duplicates: 2 * time.Minute,
-	},
-	{
 		// Carries TICKET.mint_completed (soulbound-ticket mint outcomes),
 		// consumed by the analytics consumer.
 		Name:       "TICKET",

--- a/internal/usecase/analytics_events.go
+++ b/internal/usecase/analytics_events.go
@@ -17,26 +17,20 @@ type AnalyticsEventName string
 
 // Account lifecycle events emitted from the backend.
 const (
-	// EventAccountLogin is recorded once per user-initiated login, sourced
-	// from the Zitadel session.user.checked Actions v2 event webhook. It is
-	// never recorded on a silent token refresh (which touches only the
-	// oidc_session aggregate), so it is a returning/active-user retention
-	// signal. Signup is
-	// represented by EventUserCreated, not a separate account.signup.completed
-	// event.
-	EventAccountLogin AnalyticsEventName = "account.login"
-
-	// EventAccountPreferredLanguageUpdated is recorded when a user's
-	// preferred display language is changed via UpdatePreferredLanguage.
-	EventAccountPreferredLanguageUpdated AnalyticsEventName = "account.preferred_language.updated"
+	// EventAccountSignin is recorded once per user-initiated sign-in, sourced
+	// from the Zitadel session.user.checked Actions v2 event webhook (NATS
+	// transport subject ACCOUNT.login). It is never recorded on a silent token
+	// refresh (which touches only the oidc_session aggregate), so it is a
+	// returning/active-user retention signal. Signup is represented by
+	// EventUserCreated, not a separate account.signup.completed event.
+	//
+	// Named account.signin (renamed from account.login while it had zero
+	// production history) for vocabulary consistency with the account.* namespace.
+	EventAccountSignin AnalyticsEventName = "account.signin"
 
 	// EventUserCreated is recorded when the backend creates a User record
 	// for the first time, either through self-signup or admin provisioning.
 	EventUserCreated AnalyticsEventName = "user.created"
-
-	// EventUserDeleted is recorded when a User record is permanently
-	// removed from the platform.
-	EventUserDeleted AnalyticsEventName = "user.deleted"
 )
 
 // Artist engagement events emitted from the backend after persistence.
@@ -53,30 +47,6 @@ const (
 
 // Ticket journey and purchase events emitted from the backend.
 const (
-	// EventTicketLotteryEntryAccepted is recorded after a lottery entry
-	// passes validation and is persisted. Paired with the frontend
-	// ticket.lottery.entry.submitted to measure the intent-to-acceptance gap.
-	EventTicketLotteryEntryAccepted AnalyticsEventName = "ticket.lottery.entry.accepted"
-
-	// EventTicketLotteryEntryRejected is recorded when a lottery entry
-	// fails validation (duplicate, closed window, etc.). Paired with
-	// ticket.lottery.entry.submitted.
-	EventTicketLotteryEntryRejected AnalyticsEventName = "ticket.lottery.entry.rejected"
-
-	// EventTicketLotteryResultAssigned is recorded when the lottery draw
-	// completes and a result (WON or LOST) is recorded against the entry.
-	EventTicketLotteryResultAssigned AnalyticsEventName = "ticket.lottery.result.assigned"
-
-	// EventTicketPurchaseCompleted is the trust-critical event recorded
-	// when a payment provider confirms a successful ticket purchase. The
-	// frontend emits a paired ticket.purchase.initiated at the moment the
-	// user starts the purchase flow.
-	EventTicketPurchaseCompleted AnalyticsEventName = "ticket.purchase.completed"
-
-	// EventTicketPurchaseFailed is recorded when a purchase attempt is
-	// rejected by the payment provider or backend validation.
-	EventTicketPurchaseFailed AnalyticsEventName = "ticket.purchase.failed"
-
 	// EventTicketJourneyStatusChanged is recorded after a fan's ticket
 	// journey status is successfully updated via SetStatus. It is
 	// suppressed when the incoming status equals the stored status
@@ -95,15 +65,6 @@ const (
 	// data quality and parser robustness dashboards in PostHog.
 	// Properties: email_type, parse_status, field_count.
 	EventTicketEmailParsed AnalyticsEventName = "ticket.email.parsed"
-)
-
-// Sales reminder delivery events emitted from the backend.
-const (
-	// EventSalesReminderDelivered is recorded at every terminal delivery
-	// outcome of a sales-phase push reminder. It feeds reach and failure-rate
-	// dashboards per phase stage in PostHog.
-	// Properties: phase_stage, delivery_status.
-	EventSalesReminderDelivered AnalyticsEventName = "sales_reminder.delivered"
 )
 
 // Entry verification events emitted from the backend, including the
@@ -147,26 +108,18 @@ const (
 // The map is populated lazily-once at package init via the const groups
 // above; every new constant MUST be added here in the same commit.
 var knownBackendEvents = map[AnalyticsEventName]struct{}{
-	EventAccountLogin:                    {},
-	EventAccountPreferredLanguageUpdated: {},
-	EventUserCreated:                     {},
-	EventUserDeleted:                     {},
-	EventArtistFollowCompleted:           {},
-	EventArtistUnfollowCompleted:         {},
-	EventTicketLotteryEntryAccepted:      {},
-	EventTicketLotteryEntryRejected:      {},
-	EventTicketLotteryResultAssigned:     {},
-	EventTicketPurchaseCompleted:         {},
-	EventTicketPurchaseFailed:            {},
-	EventTicketJourneyStatusChanged:      {},
-	EventTicketMintCompleted:             {},
-	EventTicketEmailParsed:               {},
-	EventEntryZkProofVerified:            {},
-	EventEntryZkProofRejected:            {},
-	EventNotificationSubscribed:          {},
-	EventNotificationUnsubscribed:        {},
-	EventNotificationDelivered:           {},
-	EventSalesReminderDelivered:          {},
+	EventAccountSignin:              {},
+	EventUserCreated:                {},
+	EventArtistFollowCompleted:      {},
+	EventArtistUnfollowCompleted:    {},
+	EventTicketJourneyStatusChanged: {},
+	EventTicketMintCompleted:        {},
+	EventTicketEmailParsed:          {},
+	EventEntryZkProofVerified:       {},
+	EventEntryZkProofRejected:       {},
+	EventNotificationSubscribed:     {},
+	EventNotificationUnsubscribed:   {},
+	EventNotificationDelivered:      {},
 }
 
 // IsKnownEvent reports whether name is registered in the backend event

--- a/internal/usecase/sales_reminder_delivery_uc.go
+++ b/internal/usecase/sales_reminder_delivery_uc.go
@@ -30,7 +30,6 @@ type SalesReminderDeliveryUseCase interface {
 type salesReminderDeliveryUseCase struct {
 	reminderRepo   entity.SalesPhaseReminderRepository
 	notificationUC NotificationUseCase
-	publisher      EventPublisher
 	logger         *logging.Logger
 }
 
@@ -41,40 +40,41 @@ var _ SalesReminderDeliveryUseCase = (*salesReminderDeliveryUseCase)(nil)
 func NewSalesReminderDeliveryUseCase(
 	reminderRepo entity.SalesPhaseReminderRepository,
 	notificationUC NotificationUseCase,
-	publisher EventPublisher,
 	logger *logging.Logger,
 ) *salesReminderDeliveryUseCase {
 	return &salesReminderDeliveryUseCase{
 		reminderRepo:   reminderRepo,
 		notificationUC: notificationUC,
-		publisher:      publisher,
 		logger:         logger,
 	}
 }
 
-// publishDeliveryOutcome emits a sales_reminder.delivered analytics event for
-// the given terminal outcome. Failures are logged and never propagated — the
-// analytics publish must not affect DeliverReminder's return value or the
-// once-only RecordSent semantics.
-func (uc *salesReminderDeliveryUseCase) publishDeliveryOutcome(
+// logDeliveryOutcome records a structured log line for a terminal reminder
+// delivery outcome. Reach is now tracked in product analytics via
+// notification.delivered (type = "sales_reminder"); this log preserves the
+// delivery-reliability visibility (no_subscription / failed per phase stage)
+// that operational telemetry needs, replacing the removed
+// sales_reminder.delivered analytics event. A log-based metric keys on the
+// stable message "sales_reminder delivery outcome" and the `outcome` /
+// `phase_stage` fields. Non-success outcomes are logged at Warn so they
+// surface without a metric; the success case stays at Info.
+func (uc *salesReminderDeliveryUseCase) logDeliveryOutcome(
 	ctx context.Context,
 	data entity.SalesPhaseReminderDueData,
 	stage entity.ReminderStage,
-	deliveryStatus string,
+	outcome string,
 ) {
-	if err := uc.publisher.PublishEvent(ctx, entity.SubjectSalesReminderDelivered, entity.SalesReminderDeliveredData{
-		UserID:         data.UserID,
-		PhaseStage:     stage.String(),
-		DeliveryStatus: deliveryStatus,
-	}); err != nil {
-		uc.logger.Error(ctx, "failed to publish SALES_REMINDER.delivered event", err,
-			slog.String("user_id", data.UserID),
-			slog.String("phase_id", data.PhaseID),
-			slog.String("stage", stage.String()),
-			slog.String("delivery_status", deliveryStatus),
-		)
-		// Non-fatal: DeliverReminder's return value and RecordSent semantics are unchanged.
+	attrs := []slog.Attr{
+		slog.String("outcome", outcome),
+		slog.String("phase_stage", stage.String()),
+		slog.String("user_id", data.UserID),
+		slog.String("phase_id", data.PhaseID),
 	}
+	if outcome == "delivered" {
+		uc.logger.Info(ctx, "sales_reminder delivery outcome", attrs...)
+		return
+	}
+	uc.logger.Warn(ctx, "sales_reminder delivery outcome", attrs...)
 }
 
 // DeliverReminder implements [SalesReminderDeliveryUseCase].
@@ -117,23 +117,23 @@ func (uc *salesReminderDeliveryUseCase) DeliverReminder(ctx context.Context, dat
 	switch {
 	case n.DeliveryStatus == entity.NotificationDeliveryStatusDelivered:
 		// At least one subscription accepted the push. Record sent so the next
-		// scan does not re-deliver, then emit the terminal delivered outcome.
+		// scan does not re-deliver, then log the terminal delivered outcome.
 		if err := uc.reminderRepo.RecordSent(ctx, data.UserID, data.PhaseID, stage); err != nil {
 			uc.logger.Error(ctx, "sales_reminder_delivery: RecordSent failed", err, attrs...)
 			// Non-fatal: next scan will re-check via ListSentStages / AlreadySent.
 		}
-		uc.publishDeliveryOutcome(ctx, data, stage, "delivered")
+		uc.logDeliveryOutcome(ctx, data, stage, "delivered")
 	case n.FailureReason == NotificationFailureReasonNoSubscription:
 		// The user has no push device to deliver to — nothing to retry. Record
-		// sent to suppress future re-delivery and emit the no_subscription outcome.
+		// sent to suppress future re-delivery and log the no_subscription outcome.
 		if err := uc.reminderRepo.RecordSent(ctx, data.UserID, data.PhaseID, stage); err != nil {
 			uc.logger.Error(ctx, "sales_reminder_delivery: RecordSent failed", err, attrs...)
 		}
-		uc.publishDeliveryOutcome(ctx, data, stage, "no_subscription")
+		uc.logDeliveryOutcome(ctx, data, stage, "no_subscription")
 	default:
 		// Transient send failure — leave the sent-log empty so the next scan
-		// retries, and emit the terminal failed outcome.
-		uc.publishDeliveryOutcome(ctx, data, stage, "failed")
+		// retries, and log the terminal failed outcome.
+		uc.logDeliveryOutcome(ctx, data, stage, "failed")
 	}
 	return nil
 }

--- a/internal/usecase/sales_reminder_delivery_uc_test.go
+++ b/internal/usecase/sales_reminder_delivery_uc_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -21,13 +20,11 @@ func buildDeliveryUC(
 	t *testing.T,
 	reminderRepo *entitymocks.MockSalesPhaseReminderRepository,
 	notificationUC *ucmocks.MockNotificationUseCase,
-	publisher *ucmocks.MockEventPublisher,
 ) usecase.SalesReminderDeliveryUseCase {
 	t.Helper()
 	return usecase.NewSalesReminderDeliveryUseCase(
 		reminderRepo,
 		notificationUC,
-		publisher,
 		newTestLogger(t),
 	)
 }
@@ -48,60 +45,55 @@ func validDueData(stage entity.ReminderStage) entity.SalesPhaseReminderDueData {
 	}
 }
 
-// ---- AlreadySent guard (no analytics emit expected) ----
+// ---- AlreadySent guard (no send expected) ----
 
-// TestDeliverReminder_AlreadySentSkipsWithoutEmit verifies that the AlreadySent
-// dedup guard returns nil without emitting an analytics event.
-func TestDeliverReminder_AlreadySentSkipsWithoutEmit(t *testing.T) {
+// TestDeliverReminder_AlreadySentSkipsWithoutSend verifies that the AlreadySent
+// dedup guard returns nil without attempting a notification send.
+func TestDeliverReminder_AlreadySentSkipsWithoutSend(t *testing.T) {
 	t.Parallel()
 
 	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
 	notificationUC := ucmocks.NewMockNotificationUseCase(t)
-	publisher := ucmocks.NewMockEventPublisher(t)
 
 	reminderRepo.EXPECT().
 		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
 		Return(true, nil)
 
-	uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
+	uc := buildDeliveryUC(t, reminderRepo, notificationUC)
 	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
 
 	require.NoError(t, err)
-	publisher.AssertNotCalled(t, "PublishEvent")
 	notificationUC.AssertNotCalled(t, "Notify")
 }
 
-// ---- Infra-error returns (no analytics emit expected) ----
+// ---- Infra-error returns ----
 
-// TestDeliverReminder_AlreadySentErrorReturnsErrWithoutEmit verifies that an
-// AlreadySent repository error propagates and does not emit analytics.
-func TestDeliverReminder_AlreadySentErrorReturnsErrWithoutEmit(t *testing.T) {
+// TestDeliverReminder_AlreadySentErrorReturnsErr verifies that an AlreadySent
+// repository error propagates and does not attempt a send.
+func TestDeliverReminder_AlreadySentErrorReturnsErr(t *testing.T) {
 	t.Parallel()
 
 	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
 	notificationUC := ucmocks.NewMockNotificationUseCase(t)
-	publisher := ucmocks.NewMockEventPublisher(t)
 
 	reminderRepo.EXPECT().
 		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
 		Return(false, errors.New("db error"))
 
-	uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
+	uc := buildDeliveryUC(t, reminderRepo, notificationUC)
 	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
 
 	require.Error(t, err)
-	publisher.AssertNotCalled(t, "PublishEvent")
 	notificationUC.AssertNotCalled(t, "Notify")
 }
 
-// TestDeliverReminder_NotifyErrorReturnsErrWithoutEmit verifies that a Notify
-// error propagates and does not emit analytics.
-func TestDeliverReminder_NotifyErrorReturnsErrWithoutEmit(t *testing.T) {
+// TestDeliverReminder_NotifyErrorReturnsErr verifies that a Notify error
+// propagates.
+func TestDeliverReminder_NotifyErrorReturnsErr(t *testing.T) {
 	t.Parallel()
 
 	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
 	notificationUC := ucmocks.NewMockNotificationUseCase(t)
-	publisher := ucmocks.NewMockEventPublisher(t)
 
 	reminderRepo.EXPECT().
 		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
@@ -110,23 +102,21 @@ func TestDeliverReminder_NotifyErrorReturnsErrWithoutEmit(t *testing.T) {
 		Notify(anyCtx, "user-001", entity.NotificationTypeSalesReminder, validPayload()).
 		Return(nil, errors.New("record creation failed"))
 
-	uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
+	uc := buildDeliveryUC(t, reminderRepo, notificationUC)
 	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
 
 	require.Error(t, err)
-	publisher.AssertNotCalled(t, "PublishEvent")
 }
 
-// ---- nil-payload defensive skip (no analytics emit expected) ----
+// ---- nil-payload defensive skip ----
 
-// TestDeliverReminder_NilPayloadSkipsWithoutEmit verifies the nil-payload
-// defensive guard returns nil without emitting analytics — no send was attempted.
-func TestDeliverReminder_NilPayloadSkipsWithoutEmit(t *testing.T) {
+// TestDeliverReminder_NilPayloadSkips verifies the nil-payload defensive guard
+// returns nil without attempting a send — no send was attempted.
+func TestDeliverReminder_NilPayloadSkips(t *testing.T) {
 	t.Parallel()
 
 	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
 	notificationUC := ucmocks.NewMockNotificationUseCase(t)
-	publisher := ucmocks.NewMockEventPublisher(t)
 
 	reminderRepo.EXPECT().
 		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
@@ -138,25 +128,22 @@ func TestDeliverReminder_NilPayloadSkipsWithoutEmit(t *testing.T) {
 		Stage:   int16(entity.ReminderStageApplyOpen),
 		Payload: nil, // defensive skip
 	}
-	uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
+	uc := buildDeliveryUC(t, reminderRepo, notificationUC)
 	err := uc.DeliverReminder(context.Background(), data)
 
 	require.NoError(t, err)
-	publisher.AssertNotCalled(t, "PublishEvent")
 	notificationUC.AssertNotCalled(t, "Notify")
 }
 
 // ---- Terminal delivery outcome: no_subscription ----
 
-// TestDeliverReminder_NoSubscriptionEmitsNoSubscription verifies that
-// delivery_status="no_subscription" is emitted when the notification service
-// reports no active push subscription for the user.
-func TestDeliverReminder_NoSubscriptionEmitsNoSubscription(t *testing.T) {
+// TestDeliverReminder_NoSubscriptionRecordsSent verifies that a no-subscription
+// outcome records sent (suppressing future re-delivery) and returns nil.
+func TestDeliverReminder_NoSubscriptionRecordsSent(t *testing.T) {
 	t.Parallel()
 
 	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
 	notificationUC := ucmocks.NewMockNotificationUseCase(t)
-	publisher := ucmocks.NewMockEventPublisher(t)
 
 	reminderRepo.EXPECT().
 		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyClose24H).
@@ -171,19 +158,9 @@ func TestDeliverReminder_NoSubscriptionEmitsNoSubscription(t *testing.T) {
 	reminderRepo.EXPECT().
 		RecordSent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyClose24H).
 		Return(nil).
-		Maybe()
-	publisher.EXPECT().
-		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
-			mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
-				return d.UserID == "user-001" &&
-					d.PhaseStage == "APPLY_CLOSE_24H" &&
-					d.DeliveryStatus == "no_subscription"
-			}),
-		).
-		Return(nil).
 		Once()
 
-	uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
+	uc := buildDeliveryUC(t, reminderRepo, notificationUC)
 	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyClose24H))
 
 	require.NoError(t, err)
@@ -191,14 +168,13 @@ func TestDeliverReminder_NoSubscriptionEmitsNoSubscription(t *testing.T) {
 
 // ---- Terminal delivery outcome: delivered ----
 
-// TestDeliverReminder_SuccessfulSendEmitsDelivered verifies that
-// delivery_status="delivered" is emitted after a successful notification.
-func TestDeliverReminder_SuccessfulSendEmitsDelivered(t *testing.T) {
+// TestDeliverReminder_SuccessfulSendRecordsSent verifies that a successful
+// notification records sent and returns nil.
+func TestDeliverReminder_SuccessfulSendRecordsSent(t *testing.T) {
 	t.Parallel()
 
 	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
 	notificationUC := ucmocks.NewMockNotificationUseCase(t)
-	publisher := ucmocks.NewMockEventPublisher(t)
 
 	reminderRepo.EXPECT().
 		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
@@ -211,18 +187,8 @@ func TestDeliverReminder_SuccessfulSendEmitsDelivered(t *testing.T) {
 	reminderRepo.EXPECT().
 		RecordSent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
 		Return(nil)
-	publisher.EXPECT().
-		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
-			mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
-				return d.UserID == "user-001" &&
-					d.PhaseStage == "APPLY_OPEN" &&
-					d.DeliveryStatus == "delivered"
-			}),
-		).
-		Return(nil).
-		Once()
 
-	uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
+	uc := buildDeliveryUC(t, reminderRepo, notificationUC)
 	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
 
 	require.NoError(t, err)
@@ -230,16 +196,14 @@ func TestDeliverReminder_SuccessfulSendEmitsDelivered(t *testing.T) {
 
 // ---- Terminal delivery outcome: failed ----
 
-// TestDeliverReminder_TransientFailureEmitsFailed verifies that
-// delivery_status="failed" is emitted when the notification service reports a
-// transient failure (not the no-subscription sentinel), and RecordSent is NOT
-// called so the next scan can retry.
-func TestDeliverReminder_TransientFailureEmitsFailed(t *testing.T) {
+// TestDeliverReminder_TransientFailureDoesNotRecordSent verifies that on a
+// transient failure (not the no-subscription sentinel) RecordSent is NOT called
+// so the next scan can retry, and no error is returned.
+func TestDeliverReminder_TransientFailureDoesNotRecordSent(t *testing.T) {
 	t.Parallel()
 
 	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
 	notificationUC := ucmocks.NewMockNotificationUseCase(t)
-	publisher := ucmocks.NewMockEventPublisher(t)
 
 	reminderRepo.EXPECT().
 		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageResultDay).
@@ -252,64 +216,20 @@ func TestDeliverReminder_TransientFailureEmitsFailed(t *testing.T) {
 			FailureReason:  "push service unavailable",
 		}, nil)
 	// RecordSent must NOT be called — leave the sent-log empty so the next scan retries.
-	publisher.EXPECT().
-		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
-			mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
-				return d.UserID == "user-001" &&
-					d.PhaseStage == "RESULT_DAY" &&
-					d.DeliveryStatus == "failed"
-			}),
-		).
-		Return(nil).
-		Once()
 
-	uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
+	uc := buildDeliveryUC(t, reminderRepo, notificationUC)
 	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageResultDay))
 
 	// Total failure is not returned as an error — the next scan will retry.
 	require.NoError(t, err)
+	reminderRepo.AssertNotCalled(t, "RecordSent")
 }
 
-// ---- Publish non-fatal ----
+// ---- phase_stage coverage across stages ----
 
-// TestDeliverReminder_PublishErrorIsNonFatal verifies that a PublishEvent
-// failure does not change DeliverReminder's return value or the once-only
-// RecordSent semantics.
-func TestDeliverReminder_PublishErrorIsNonFatal(t *testing.T) {
-	t.Parallel()
-
-	reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
-	notificationUC := ucmocks.NewMockNotificationUseCase(t)
-	publisher := ucmocks.NewMockEventPublisher(t)
-
-	reminderRepo.EXPECT().
-		AlreadySent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
-		Return(false, nil)
-	notificationUC.EXPECT().
-		Notify(anyCtx, "user-001", entity.NotificationTypeSalesReminder, mock.Anything).
-		Return(&entity.Notification{
-			DeliveryStatus: entity.NotificationDeliveryStatusDelivered,
-		}, nil)
-	reminderRepo.EXPECT().
-		RecordSent(anyCtx, "user-001", "phase-001", entity.ReminderStageApplyOpen).
-		Return(nil)
-	publisher.EXPECT().
-		PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered, mock.Anything).
-		Return(errors.New("nats unavailable")).
-		Once()
-
-	uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
-	err := uc.DeliverReminder(context.Background(), validDueData(entity.ReminderStageApplyOpen))
-
-	// Publish failure must NOT be returned — push delivered, RecordSent was called.
-	require.NoError(t, err)
-}
-
-// ---- phase_stage string form ----
-
-// TestDeliverReminder_PhaseStageStrings verifies that each ReminderStage value
-// serialises to the expected string in the published payload.
-func TestDeliverReminder_PhaseStageStrings(t *testing.T) {
+// TestDeliverReminder_AllStagesDeliver verifies that DeliverReminder handles
+// each ReminderStage value on the delivered path without error.
+func TestDeliverReminder_AllStagesDeliver(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -328,7 +248,6 @@ func TestDeliverReminder_PhaseStageStrings(t *testing.T) {
 
 			reminderRepo := entitymocks.NewMockSalesPhaseReminderRepository(t)
 			notificationUC := ucmocks.NewMockNotificationUseCase(t)
-			publisher := ucmocks.NewMockEventPublisher(t)
 
 			reminderRepo.EXPECT().
 				AlreadySent(anyCtx, "user-001", "phase-001", tt.stage).
@@ -341,17 +260,8 @@ func TestDeliverReminder_PhaseStageStrings(t *testing.T) {
 			reminderRepo.EXPECT().
 				RecordSent(anyCtx, "user-001", "phase-001", tt.stage).
 				Return(nil)
-			publisher.EXPECT().
-				PublishEvent(anyCtx, entity.SubjectSalesReminderDelivered,
-					mock.MatchedBy(func(d entity.SalesReminderDeliveredData) bool {
-						assert.Equal(t, tt.wantStage, d.PhaseStage, "unexpected phase_stage")
-						return d.PhaseStage == tt.wantStage
-					}),
-				).
-				Return(nil).
-				Once()
 
-			uc := buildDeliveryUC(t, reminderRepo, notificationUC, publisher)
+			uc := buildDeliveryUC(t, reminderRepo, notificationUC)
 			err := uc.DeliverReminder(context.Background(), validDueData(tt.stage))
 			require.NoError(t, err)
 		})

--- a/internal/usecase/user_uc.go
+++ b/internal/usecase/user_uc.go
@@ -208,11 +208,6 @@ func (uc *userUseCase) GetByExternalID(ctx context.Context, externalID string) (
 // the repository — mirrors UpdateHome's `home.Validate()` posture so that
 // non-RPC callers (integration tests, future internal handlers, scripts)
 // don't bypass the wire-layer protovalidate constraint.
-//
-// Captures the prior PreferredLanguage value via a pre-update Get so the
-// USER.preferred_language_updated event can carry both from_locale and
-// to_locale. The extra read is acceptable: this operation is rare and the
-// event's analytical value depends on the locale-transition pair.
 func (uc *userUseCase) UpdatePreferredLanguage(ctx context.Context, id, lang string) (*entity.User, error) {
 	if id == "" {
 		return nil, apperr.New(codes.InvalidArgument, "user id is required")
@@ -221,13 +216,6 @@ func (uc *userUseCase) UpdatePreferredLanguage(ctx context.Context, id, lang str
 		return nil, apperr.New(codes.InvalidArgument,
 			"preferred_language must match ISO 639-1 (^[a-z]{2}$)",
 			slog.String("preferred_language", lang),
-		)
-	}
-
-	prior, err := uc.userRepo.Get(ctx, id)
-	if err != nil {
-		return nil, apperr.Wrap(err, codes.NotFound, "failed to load user for preferred-language update",
-			slog.String("user_id", id),
 		)
 	}
 
@@ -240,17 +228,6 @@ func (uc *userUseCase) UpdatePreferredLanguage(ctx context.Context, id, lang str
 		slog.String("user_id", id),
 		slog.String("preferred_language", lang),
 	)
-
-	if err := uc.publishEvent(ctx, entity.SubjectUserPreferredLanguageUpdated, entity.UserPreferredLanguageUpdatedData{
-		UserID:     user.ID,
-		FromLocale: prior.PreferredLanguage,
-		ToLocale:   user.PreferredLanguage,
-	}); err != nil {
-		uc.logger.Error(ctx, "failed to publish USER.preferred_language_updated event", err,
-			slog.String("user_id", user.ID),
-		)
-		// Non-fatal: the language change is already persisted.
-	}
 
 	return user, nil
 }

--- a/internal/usecase/user_uc_test.go
+++ b/internal/usecase/user_uc_test.go
@@ -549,18 +549,12 @@ func TestUserUseCase_UpdatePreferredLanguage(t *testing.T) {
 		t.Parallel()
 		d := newUserTestDeps(t)
 
-		priorUser := &entity.User{
-			ID:                "user-lang-1",
-			Email:             "lang@example.com",
-			PreferredLanguage: "ja",
-		}
 		updatedUser := &entity.User{
 			ID:                "user-lang-1",
 			Email:             "lang@example.com",
 			PreferredLanguage: "en",
 		}
 
-		d.repo.EXPECT().Get(ctx, "user-lang-1").Return(priorUser, nil).Once()
 		d.repo.EXPECT().UpdatePreferredLanguage(ctx, "user-lang-1", "en").
 			Return(updatedUser, nil).Once()
 
@@ -571,27 +565,10 @@ func TestUserUseCase_UpdatePreferredLanguage(t *testing.T) {
 		assert.Equal(t, "en", result.PreferredLanguage)
 	})
 
-	t.Run("not found — pre-fetch Get returns NotFound", func(t *testing.T) {
-		t.Parallel()
-		d := newUserTestDeps(t)
-
-		d.repo.EXPECT().Get(ctx, "ghost-id").
-			Return(nil, apperr.New(codes.NotFound, "user not found")).Once()
-		// UpdatePreferredLanguage MUST NOT be called when the pre-fetch fails.
-
-		result, err := d.uc.UpdatePreferredLanguage(ctx, "ghost-id", "ja")
-
-		assert.Error(t, err)
-		assert.Nil(t, result)
-		assert.ErrorIs(t, err, apperr.ErrNotFound)
-	})
-
 	t.Run("not found — repository returns NotFound at update", func(t *testing.T) {
 		t.Parallel()
 		d := newUserTestDeps(t)
 
-		priorUser := &entity.User{ID: "ghost-id", PreferredLanguage: "en"}
-		d.repo.EXPECT().Get(ctx, "ghost-id").Return(priorUser, nil).Once()
 		d.repo.EXPECT().UpdatePreferredLanguage(ctx, "ghost-id", "ja").
 			Return(nil, apperr.New(codes.NotFound, "user not found")).Once()
 


### PR DESCRIPTION
## Summary

Prunes the backend product-analytics event set to match the observable loop (OpenSpec change `prune-analytics-event-collection`).

- Deletes phantom / never-wired constants (`user.deleted`, ticket lottery + purchase) and their `knownBackendEvents` entries.
- Renames `account.login` → `account.signin` (NATS transport subject `ACCOUNT.login` unchanged).
- Removes `sales_reminder.delivered` end to end (constant, subject, payload, `AllSubjects`, `SALES_REMINDER` stream, consumer wiring). Reach stays on `notification.delivered` (`type="sales_reminder"`); non-success outcomes now emit a structured `sales_reminder delivery outcome` log (`outcome`, `phase_stage`) consumed by a Cloud Monitoring log-based metric (cloud-provisioning PR).
- Removes the `preferred_language` analytics event and its publish (analytics was the only subscriber of `USER.preferred_language_updated`).

## Testing

`make check` (gofmt + golangci-lint + full test suite) passes locally.

## Part of

Cross-repo change tracked by liverty-music/specification#692. No proto change → no BSR dependency; can merge independently once CI is green.