### PR TITLE
feat(consumer): fail loud and reflect real consumption in liveness (Phase 1)

### DIFF
--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -86,6 +86,11 @@ func run() error {
 	}
 
 	healthSrv.SetReady()
+	// Now that the router and subscriber exist, make /healthz reflect real
+	// consumption: unhealthy when the router has stopped, the NATS connection is
+	// down, or any expected durable is unbound. This lets Kubernetes restart a
+	// wedged pod instead of leaving it Running while it consumes nothing.
+	healthSrv.SetLiveness(app.Health.Live)
 	shutdown.AddDrainPhase(healthSrv)
 
 	app.Logger.Info(ctx, "consumer router starting")

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -37,6 +37,10 @@ type ConsumerApp struct {
 	Router          *message.Router
 	Logger          *logging.Logger
 	ShutdownTimeout time.Duration
+	// Health reflects whether the consumer is actively consuming (NATS
+	// connected + all durables bound + router running). The entry point wires
+	// it into the liveness probe so a wedged pod is restarted.
+	Health *messaging.ConsumerHealth
 }
 
 // InitializeConsumerApp creates a ConsumerApp with all event handler dependencies wired.
@@ -93,7 +97,11 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		return nil, fmt.Errorf("create messaging publisher: %w", err)
 	}
 
-	subscriber, err := messaging.NewSubscriber(cfg.NATS, wmLogger, goChannel)
+	// consumerHealth reflects real consumption into the liveness probe: the NATS
+	// subscriber updates connection + per-topic bound state, and the router
+	// probe (set below) reports whether the router is running.
+	consumerHealth := messaging.NewConsumerHealth()
+	subscriber, err := messaging.NewSubscriber(cfg.NATS, wmLogger, goChannel, consumerHealth)
 	if err != nil {
 		return nil, fmt.Errorf("create messaging subscriber: %w", err)
 	}
@@ -192,6 +200,16 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create messaging router: %w", err)
 	}
+
+	// IsClosed reports true only after the router has been closed — including
+	// when watermill closes it because all handlers stopped (a wedge). It stays
+	// false during the pre-start window (the entry point runs the router in a
+	// goroutine after wiring), so this probe does not false-negative at boot;
+	// readiness gates traffic during initialization. A closed router makes
+	// liveness unhealthy so Kubernetes restarts the wedged pod.
+	consumerHealth.SetRouterProbe(func() bool {
+		return !router.IsClosed()
+	})
 
 	router.AddConsumerHandler(
 		"create-concerts",
@@ -350,5 +368,6 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		Router:          router,
 		Logger:          logger,
 		ShutdownTimeout: cfg.ShutdownTimeout,
+		Health:          consumerHealth,
 	}, nil
 }

--- a/internal/infrastructure/messaging/health.go
+++ b/internal/infrastructure/messaging/health.go
@@ -1,0 +1,120 @@
+package messaging
+
+import "sync"
+
+// defaultLivenessGrace is the number of consecutive unhealthy observations the
+// liveness check tolerates before reporting unhealthy. It absorbs transient
+// blips (e.g. a brief NATS reconnect) so a healthy consumer is not restarted
+// for a momentary flap. It composes with — and is deliberately smaller than —
+// the Kubernetes probe's own failureThreshold.
+const defaultLivenessGrace = 3
+
+// ConsumerHealth tracks, in-process, whether the event consumer is actually
+// consuming: the NATS connection is up and every expected JetStream durable is
+// bound to an active subscription. The wedge that caused the 2026-07 outage
+// left the pod Running while consuming nothing; a plain HTTP-port liveness
+// probe could not see it. This tracker lets the liveness probe reflect real
+// consumption so Kubernetes restarts a wedged pod.
+//
+// ConsumerHealth is safe for concurrent use.
+type ConsumerHealth struct {
+	mu       sync.Mutex
+	expected map[string]bool // topic -> bound
+	// connected reports whether the underlying NATS connection is currently up.
+	// It defaults to true because the GoChannel (local) transport has no
+	// connection to lose and the NATS transport is connected by the time the
+	// subscriber is constructed; NATS connection handlers flip it thereafter.
+	connected bool
+	// routerRunning probes whether the message router is actively running. It
+	// is injected after the router is built (nil before then, treated as up so
+	// startup readiness — not liveness — gates traffic during initialization).
+	routerRunning func() bool
+	// failures counts consecutive unhealthy observations for the grace window.
+	failures int
+	grace    int
+}
+
+// NewConsumerHealth returns a ConsumerHealth with the default liveness grace.
+func NewConsumerHealth() *ConsumerHealth {
+	return &ConsumerHealth{
+		expected:  make(map[string]bool),
+		connected: true,
+		grace:     defaultLivenessGrace,
+	}
+}
+
+// Expect registers a topic whose durable must be bound for the consumer to be
+// considered healthy. Registering an already-known topic preserves its bound
+// state.
+func (h *ConsumerHealth) Expect(topic string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.expected[topic]; !ok {
+		h.expected[topic] = false
+	}
+}
+
+// MarkBound records that the durable for topic is bound to an active
+// subscription.
+func (h *ConsumerHealth) MarkBound(topic string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.expected[topic] = true
+}
+
+// MarkUnbound records that the durable for topic is no longer bound.
+func (h *ConsumerHealth) MarkUnbound(topic string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.expected[topic]; ok {
+		h.expected[topic] = false
+	}
+}
+
+// SetConnected updates the NATS connection status.
+func (h *ConsumerHealth) SetConnected(connected bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.connected = connected
+}
+
+// SetRouterProbe injects a probe reporting whether the message router is
+// running. It is called once the router has been constructed.
+func (h *ConsumerHealth) SetRouterProbe(probe func() bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.routerRunning = probe
+}
+
+// healthy reports the instantaneous health without applying the grace window.
+// The caller must hold h.mu.
+func (h *ConsumerHealth) healthy() bool {
+	if !h.connected {
+		return false
+	}
+	if h.routerRunning != nil && !h.routerRunning() {
+		return false
+	}
+	for _, bound := range h.expected {
+		if !bound {
+			return false
+		}
+	}
+	return true
+}
+
+// Live reports whether the consumer should be considered alive. It applies the
+// grace window: an unhealthy observation is only fatal after `grace`
+// consecutive occurrences, which prevents restart flapping on transient blips.
+// A single healthy observation resets the counter.
+func (h *ConsumerHealth) Live() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.healthy() {
+		h.failures = 0
+		return true
+	}
+	h.failures++
+	return h.failures < h.grace
+}

--- a/internal/infrastructure/messaging/health_test.go
+++ b/internal/infrastructure/messaging/health_test.go
@@ -1,0 +1,111 @@
+package messaging_test
+
+import (
+	"testing"
+
+	"github.com/liverty-music/backend/internal/infrastructure/messaging"
+	"github.com/stretchr/testify/assert"
+)
+
+// liveAfterGrace calls Live enough times to exhaust the grace window and
+// returns the final verdict. A healthy consumer stays live across the window;
+// an unhealthy one is reported dead once the grace is exhausted.
+func liveAfterGrace(h *messaging.ConsumerHealth) bool {
+	var live bool
+	// The grace tolerates a few consecutive unhealthy observations, so probe
+	// generously to reach the steady-state verdict.
+	for range 10 {
+		live = h.Live()
+	}
+	return live
+}
+
+func TestConsumerHealth_HealthyWhenAllExpectedBound(t *testing.T) {
+	t.Parallel()
+
+	h := messaging.NewConsumerHealth()
+	h.Expect("CONCERT.created")
+	h.Expect("ARTIST.followed")
+	h.MarkBound("CONCERT.created")
+	h.MarkBound("ARTIST.followed")
+
+	assert.True(t, liveAfterGrace(h), "all durables bound and connected should be live")
+}
+
+func TestConsumerHealth_NoExpectationsIsLive(t *testing.T) {
+	t.Parallel()
+
+	// A freshly constructed tracker (e.g. before any subscription, or the
+	// GoChannel local path) has no expectations and is connected by default.
+	h := messaging.NewConsumerHealth()
+
+	assert.True(t, liveAfterGrace(h))
+}
+
+func TestConsumerHealth_UnboundDurableIsUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	h := messaging.NewConsumerHealth()
+	h.Expect("CONCERT.created")
+	h.Expect("NOTIFICATION.delivered")
+	// Only one of the two expected durables is bound — the consumer is not
+	// fully consuming.
+	h.MarkBound("CONCERT.created")
+
+	assert.False(t, liveAfterGrace(h), "a missing subscription must report unhealthy")
+}
+
+func TestConsumerHealth_ConnectionDownIsUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	h := messaging.NewConsumerHealth()
+	h.Expect("CONCERT.created")
+	h.MarkBound("CONCERT.created")
+	h.SetConnected(false)
+
+	assert.False(t, liveAfterGrace(h), "a downed NATS connection must report unhealthy")
+}
+
+func TestConsumerHealth_StoppedRouterIsUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	h := messaging.NewConsumerHealth()
+	h.Expect("CONCERT.created")
+	h.MarkBound("CONCERT.created")
+	h.SetRouterProbe(func() bool { return false })
+
+	assert.False(t, liveAfterGrace(h), "a stopped router must report unhealthy")
+}
+
+func TestConsumerHealth_UnbindThenRebindRecovers(t *testing.T) {
+	t.Parallel()
+
+	h := messaging.NewConsumerHealth()
+	h.Expect("CONCERT.created")
+	h.MarkBound("CONCERT.created")
+
+	h.MarkUnbound("CONCERT.created")
+	assert.False(t, liveAfterGrace(h))
+
+	// Rebinding restores health and the grace counter resets, so a single
+	// healthy observation is enough to report live again.
+	h.MarkBound("CONCERT.created")
+	assert.True(t, h.Live())
+}
+
+func TestConsumerHealth_GraceAbsorbsTransientBlip(t *testing.T) {
+	t.Parallel()
+
+	h := messaging.NewConsumerHealth()
+	h.Expect("CONCERT.created")
+	h.MarkBound("CONCERT.created")
+
+	// A single unhealthy observation (a transient blip) is absorbed by the
+	// grace window and does not immediately report unhealthy.
+	h.SetConnected(false)
+	assert.True(t, h.Live(), "one unhealthy observation is within grace")
+
+	// Recovering before the grace is exhausted keeps the consumer live.
+	h.SetConnected(true)
+	assert.True(t, h.Live())
+}

--- a/internal/infrastructure/messaging/subscriber.go
+++ b/internal/infrastructure/messaging/subscriber.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -33,7 +34,11 @@ func consumerName(topic string) string {
 // When NATS_URL is set, it returns a NATS JetStream subscriber with durable consumers.
 // When NATS_URL is empty (local development), it returns a GoChannel subscriber
 // using the provided GoChannel instance.
-func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goChannel *gochannel.GoChannel) (message.Subscriber, error) {
+//
+// The returned NATS subscriber reports its connection and per-topic bound state
+// into health so the consumer's liveness probe reflects real consumption. The
+// GoChannel (local) path has no connection to lose and is returned unwrapped.
+func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goChannel *gochannel.GoChannel, health *ConsumerHealth) (message.Subscriber, error) {
 	if cfg.URL == "" {
 		if goChannel == nil {
 			return nil, fmt.Errorf("GoChannel is required when NATS_URL is not set")
@@ -46,6 +51,18 @@ func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goCh
 		NatsOptions: []nats.Option{
 			nats.MaxReconnects(-1),
 			nats.ReconnectWait(time.Second),
+			// Reflect the live NATS connection state into the health tracker so
+			// a dropped connection (which stops all consumption) makes the
+			// liveness probe report unhealthy.
+			nats.DisconnectErrHandler(func(_ *nats.Conn, _ error) {
+				health.SetConnected(false)
+			}),
+			nats.ReconnectHandler(func(_ *nats.Conn) {
+				health.SetConnected(true)
+			}),
+			nats.ClosedHandler(func(_ *nats.Conn) {
+				health.SetConnected(false)
+			}),
 		},
 		QueueGroupPrefix: consumerQueueGroupPrefix,
 		CloseTimeout:     30 * time.Second,
@@ -80,5 +97,41 @@ func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goCh
 		return nil, fmt.Errorf("create NATS subscriber: %w", err)
 	}
 
-	return sub, nil
+	return &healthTrackingSubscriber{Subscriber: sub, health: health}, nil
+}
+
+// healthTrackingSubscriber wraps a Watermill subscriber and records each
+// topic's bound state into a ConsumerHealth. watermill establishes every
+// subscription synchronously at router startup, so a topic is marked bound the
+// moment its Subscribe succeeds and marked unbound if it fails — letting the
+// liveness probe distinguish a fully-consuming pod from a wedged one.
+type healthTrackingSubscriber struct {
+	message.Subscriber
+	health *ConsumerHealth
+}
+
+// Subscribe delegates to the wrapped subscriber and records the topic's bound
+// state. On failure it marks the topic unbound (and the router startup fails
+// loud); on success it marks the topic bound.
+func (s *healthTrackingSubscriber) Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
+	s.health.Expect(topic)
+
+	msgs, err := s.Subscriber.Subscribe(ctx, topic)
+	if err != nil {
+		s.health.MarkUnbound(topic)
+		return nil, err
+	}
+
+	s.health.MarkBound(topic)
+	return msgs, nil
+}
+
+// SubscribeInitialize forwards subscription pre-provisioning to the wrapped
+// subscriber when it supports it, keeping this decorator transparent so it does
+// not hide capabilities the underlying watermill subscriber exposes.
+func (s *healthTrackingSubscriber) SubscribeInitialize(topic string) error {
+	if init, ok := s.Subscriber.(message.SubscribeInitializer); ok {
+		return init.SubscribeInitialize(topic)
+	}
+	return nil
 }

--- a/internal/infrastructure/messaging/subscriber_test.go
+++ b/internal/infrastructure/messaging/subscriber_test.go
@@ -18,7 +18,7 @@ func TestNewSubscriber_GoChannelFallback(t *testing.T) {
 	logger := watermill.NopLogger{}
 	ch := gochannel.NewGoChannel(gochannel.Config{}, logger)
 
-	sub, err := messaging.NewSubscriber(cfg, logger, ch)
+	sub, err := messaging.NewSubscriber(cfg, logger, ch, messaging.NewConsumerHealth())
 
 	require.NoError(t, err)
 	assert.NotNil(t, sub)
@@ -32,7 +32,7 @@ func TestNewSubscriber_NilGoChannelWithEmptyURLReturnsError(t *testing.T) {
 	cfg := config.NATSConfig{URL: ""}
 	logger := watermill.NopLogger{}
 
-	sub, err := messaging.NewSubscriber(cfg, logger, nil)
+	sub, err := messaging.NewSubscriber(cfg, logger, nil, messaging.NewConsumerHealth())
 
 	require.Error(t, err)
 	assert.Nil(t, sub)

--- a/internal/infrastructure/server/health.go
+++ b/internal/infrastructure/server/health.go
@@ -16,6 +16,12 @@ type HealthServer struct {
 	srv          *http.Server
 	ready        atomic.Bool
 	shuttingDown atomic.Bool
+	// liveness, when set, gates /healthz: it reports unhealthy (503) when the
+	// probe returns false. It is stored behind an atomic so it can be installed
+	// after the server is already serving (the probe server starts before DI so
+	// Kubernetes can observe the pod during initialization). Until set, /healthz
+	// reports healthy so a booting pod is not killed before it is ready.
+	liveness atomic.Pointer[func() bool]
 }
 
 // NewHealthServer creates a health probe server listening on the given address.
@@ -24,6 +30,11 @@ func NewHealthServer(addr string) *HealthServer {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		if probe := h.liveness.Load(); probe != nil && !(*probe)() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("unhealthy"))
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
@@ -49,6 +60,12 @@ func NewHealthServer(addr string) *HealthServer {
 	return h
 }
 
+// Handler returns the HTTP handler serving the probe endpoints. It is exposed
+// so the endpoints can be exercised in tests without binding a socket.
+func (h *HealthServer) Handler() http.Handler {
+	return h.srv.Handler
+}
+
 // Start begins listening and serving. It blocks until the server is stopped.
 // It returns http.ErrServerClosed when Shutdown is called.
 func (h *HealthServer) Start() error {
@@ -63,6 +80,17 @@ func (h *HealthServer) Start() error {
 // indicating that application initialization is complete.
 func (h *HealthServer) SetReady() {
 	h.ready.Store(true)
+}
+
+// SetLiveness installs a liveness probe for /healthz. Once set, /healthz
+// reports unhealthy (503) whenever probe returns false, so Kubernetes restarts
+// a pod that is no longer consuming. Passing nil clears the probe.
+func (h *HealthServer) SetLiveness(probe func() bool) {
+	if probe == nil {
+		h.liveness.Store(nil)
+		return
+	}
+	h.liveness.Store(&probe)
 }
 
 // SetShuttingDown transitions the readiness endpoint to return 503.

--- a/internal/infrastructure/server/health_test.go
+++ b/internal/infrastructure/server/health_test.go
@@ -1,0 +1,59 @@
+package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/liverty-music/backend/internal/infrastructure/server"
+	"github.com/stretchr/testify/assert"
+)
+
+func get(t *testing.T, h *server.HealthServer, path string) int {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	h.Handler().ServeHTTP(rec, req)
+	return rec.Code
+}
+
+func TestHealthServer_HealthzHealthyByDefault(t *testing.T) {
+	t.Parallel()
+
+	// Before a liveness probe is installed (pod still initializing), /healthz
+	// reports healthy so Kubernetes does not kill a booting pod; readiness
+	// gates traffic instead.
+	h := server.NewHealthServer(":0")
+
+	assert.Equal(t, http.StatusOK, get(t, h, "/healthz"))
+}
+
+func TestHealthServer_HealthzReflectsLiveness(t *testing.T) {
+	t.Parallel()
+
+	h := server.NewHealthServer(":0")
+
+	live := true
+	h.SetLiveness(func() bool { return live })
+	assert.Equal(t, http.StatusOK, get(t, h, "/healthz"), "consuming pod should be healthy")
+
+	// A wedged consumer (router stopped / durable unbound / connection down)
+	// makes the probe return false, so /healthz returns 503 and Kubernetes
+	// restarts the pod.
+	live = false
+	assert.Equal(t, http.StatusServiceUnavailable, get(t, h, "/healthz"), "wedged pod should be unhealthy")
+}
+
+func TestHealthServer_ReadyzGatedUntilReady(t *testing.T) {
+	t.Parallel()
+
+	h := server.NewHealthServer(":0")
+
+	assert.Equal(t, http.StatusServiceUnavailable, get(t, h, "/readyz"), "not ready before SetReady")
+
+	h.SetReady()
+	assert.Equal(t, http.StatusOK, get(t, h, "/readyz"), "ready after SetReady")
+
+	h.SetShuttingDown()
+	assert.Equal(t, http.StatusServiceUnavailable, get(t, h, "/readyz"), "not ready while shutting down")
+}


### PR DESCRIPTION
## Summary

Phase 1 of hardening JetStream consumer reliability (postmortem: a single mis-configured durable silently stopped **all** backend event consumption for ~1 week in 2026-07, undetected because the pod stayed `Running` and the wedge emitted no ERROR/poison).

This PR makes the consumer's **liveness reflect real consumption** so Kubernetes restarts a wedged pod instead of leaving it `Running`:

- **`ConsumerHealth`** tracker (`internal/infrastructure/messaging/health.go`): in-process state of the NATS connection, each expected durable's bound state, and whether the message router is running, with an N-failure grace to avoid flapping.
- **`/healthz` (:8081) is now consumption-aware**: returns 503 when the router has closed, the NATS connection is down, or any expected durable is unbound.
- The NATS subscriber is wrapped to record connection + per-topic bound state; connection handlers flip the state on disconnect/reconnect/close.
- **Fail-loud** is preserved: subscription establishment is synchronous at startup and a subscribe error already propagates to a non-zero exit (crashloop) with a topic-labelled ERROR log; this closes the remaining gap where a *bound-but-not-consuming* pod looked healthy.

Paired cloud-provisioning changes (backlog alert via GMP + `Recreate` strategy) are in a separate cloud-provisioning PR.

## Why Phase 1 first

Safety before migration: fail-loud + liveness (+ the backlog alert in cloud-provisioning) ship **before** the durable-reconciliation and bare-naming migration (Phase 2), so any issue there fails loud and alerts rather than wedging silently.

## Testing

- `make check` passes.
- New unit tests: `ConsumerHealth` liveness decisions (bound/unbound, connection down, router stopped, grace) and `/healthz` gating.

Refs: liverty-music/specification#695
