### PR TITLE
build: bump Go toolchain to 1.26.5 for GO-2026-5856

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: false
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Download dependencies
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Run govulncheck
@@ -227,7 +227,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Download dependencies

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/liverty-music/backend
 
 go 1.26
 
-// Pin the minimum toolchain to 1.26.4, which fixes the Go stdlib advisories
-// GO-2026-5037 (crypto/x509) and GO-2026-5039 (net/textproto) flagged by
-// govulncheck. Every `go` invocation (local, CI) uses at least this toolchain.
-toolchain go1.26.4
+// Pin the minimum toolchain to 1.26.5, which fixes the Go stdlib advisory
+// GO-2026-5856 (crypto/tls) flagged by govulncheck — reachable via
+// pkg/httpx/retry.go — on top of the earlier GO-2026-5037 (crypto/x509) and
+// GO-2026-5039 (net/textproto). Every `go` invocation (local, CI) uses at
+// least this toolchain.
+toolchain go1.26.5
 
 tool (
 	github.com/bufbuild/buf/cmd/buf


### PR DESCRIPTION
Unblocks the repo-wide `Vulnerability Check` gate. govulncheck flags **GO-2026-5856** (crypto/tls, reachable via `pkg/httpx/retry.go`) on every backend PR; it is present in go1.26.4 and **fixed in go1.26.5**.

Pins the toolchain source of truth (go.mod `toolchain go1.26.5`) + CI `go-version` (lint.yml, test.yml). Runtime image `golang:1.26-alpine` already floats to the latest patch.

Verified locally on go1.26.5: build passes and `govulncheck ./...` reports **0 vulnerabilities**.

Same recurring pattern as #326 → #327 (1.26.4). Rebase #365 onto main after this merges.

Refs: #366