### PR TITLE
refactor(consumer): behavior-named per-handler consumers + startup reconcile (Phase 2)

### DIFF
--- a/internal/adapter/event/analytics_consumer.go
+++ b/internal/adapter/event/analytics_consumer.go
@@ -110,21 +110,21 @@ func (c *AnalyticsConsumer) HandleUserCreated(msg *message.Message) error {
 	return nil
 }
 
-// HandleAccountLogin forwards the ACCOUNT.login NATS subject as the
+// HandleUserLoggedIn forwards the USER.logged_in NATS subject as the
 // catalogue event usecase.EventAccountSignin. The subject is published once
 // per user-initiated sign-in (Zitadel session.user.checked), never on a token
 // refresh, so this event is a returning/active-user signal. No properties
 // are attached: the distinct_id (platform UserID) is the whole payload, and
 // no PII (email, sub) is ever forwarded.
-func (c *AnalyticsConsumer) HandleAccountLogin(msg *message.Message) error {
+func (c *AnalyticsConsumer) HandleUserLoggedIn(msg *message.Message) error {
 	ctx := msg.Context()
 	defer c.recordLag(ctx, msg)
 
-	var data entity.AccountLoginData
+	var data entity.UserLoggedInData
 	if err := messaging.ParseCloudEventData(msg, &data); err != nil {
-		c.logger.Error(ctx, "failed to parse ACCOUNT.login event", err)
+		c.logger.Error(ctx, "failed to parse USER.logged_in event", err)
 		c.metrics.RecordMessage(ctx, statusSkippedParseError)
-		return apperr.Wrap(err, codes.Internal, "parse ACCOUNT.login event")
+		return apperr.Wrap(err, codes.Internal, "parse USER.logged_in event")
 	}
 
 	if c.client == nil {
@@ -137,7 +137,7 @@ func (c *AnalyticsConsumer) HandleAccountLogin(msg *message.Message) error {
 	}
 
 	if data.UserID == "" {
-		c.logger.Warn(ctx, "ACCOUNT.login event missing user_id, skipping forward")
+		c.logger.Warn(ctx, "USER.logged_in event missing user_id, skipping forward")
 		c.metrics.RecordMessage(ctx, statusSkippedEmptyUserID)
 		return nil
 	}

--- a/internal/adapter/event/analytics_consumer_test.go
+++ b/internal/adapter/event/analytics_consumer_test.go
@@ -145,10 +145,10 @@ func TestAnalyticsConsumer_HandleUserCreated(t *testing.T) {
 	}
 }
 
-// TestAnalyticsConsumer_HandleAccountLogin covers the routing/validation
-// surface of the ACCOUNT.login handler. account.signin carries no properties —
+// TestAnalyticsConsumer_HandleUserLoggedIn covers the routing/validation
+// surface of the USER.logged_in handler. account.signin carries no properties —
 // the distinct_id (platform UserID) is the whole signal.
-func TestAnalyticsConsumer_HandleAccountLogin(t *testing.T) {
+func TestAnalyticsConsumer_HandleUserLoggedIn(t *testing.T) {
 	t.Parallel()
 
 	const validUserID = "11111111-2222-3333-4444-555555555555"
@@ -161,29 +161,29 @@ func TestAnalyticsConsumer_HandleAccountLogin(t *testing.T) {
 	}
 	tests := []struct {
 		name      string
-		data      entity.AccountLoginData
+		data      entity.UserLoggedInData
 		want      want
 		nilClient bool
 	}{
 		{
 			name: "forwards account.signin when client + UserID present",
-			data: entity.AccountLoginData{UserID: validUserID},
+			data: entity.UserLoggedInData{UserID: validUserID},
 			want: want{expectEnqueue: true, expectStatus: "forwarded"},
 		},
 		{
 			name:      "skips forward when client is nil (local dev)",
-			data:      entity.AccountLoginData{UserID: validUserID},
+			data:      entity.UserLoggedInData{UserID: validUserID},
 			want:      want{expectEnqueue: false, expectStatus: "skipped_nil_client"},
 			nilClient: true,
 		},
 		{
 			name: "skips forward when UserID is empty",
-			data: entity.AccountLoginData{UserID: ""},
+			data: entity.UserLoggedInData{UserID: ""},
 			want: want{expectEnqueue: false, expectStatus: "skipped_empty_user_id"},
 		},
 		{
 			name: "wraps Enqueue error as apperr.ErrInternal",
-			data: entity.AccountLoginData{UserID: validUserID},
+			data: entity.UserLoggedInData{UserID: validUserID},
 			want: want{
 				expectEnqueue:    true,
 				expectEnqueueErr: errors.New("queue full"),
@@ -225,7 +225,7 @@ func TestAnalyticsConsumer_HandleAccountLogin(t *testing.T) {
 				Once()
 
 			handler := event.NewAnalyticsConsumer(client, metricsMock, newTestLogger(t))
-			err := handler.HandleAccountLogin(makeAnalyticsMsg(t, tt.data))
+			err := handler.HandleUserLoggedIn(makeAnalyticsMsg(t, tt.data))
 
 			if tt.want.err != nil {
 				assert.ErrorIs(t, err, tt.want.err)

--- a/internal/adapter/webhook/login_event_handler.go
+++ b/internal/adapter/webhook/login_event_handler.go
@@ -198,7 +198,7 @@ func (h *LoginEventHandler) emitAccountLogin(ctx context.Context, sub string) {
 		return
 	}
 
-	if err := h.publisher.PublishEvent(ctx, entity.SubjectAccountLogin, entity.AccountLoginData{UserID: user.ID}); err != nil {
+	if err := h.publisher.PublishEvent(ctx, entity.SubjectUserLoggedIn, entity.UserLoggedInData{UserID: user.ID}); err != nil {
 		h.logger.Error(ctx, "login-event: failed to publish ACCOUNT.login", err)
 	}
 }

--- a/internal/adapter/webhook/login_event_handler_test.go
+++ b/internal/adapter/webhook/login_event_handler_test.go
@@ -99,9 +99,9 @@ func TestLoginEventHandler_UserInitiatedLogin_EmitsAccountLoginOnce(t *testing.T
 	assert.Equal(t, "zitadel-sub-123", users.lastExtID)
 	// ...and exactly one ACCOUNT.login was published carrying that UserID.
 	require.Equal(t, 1, pub.calls)
-	assert.Equal(t, entity.SubjectAccountLogin, pub.subject)
-	data, ok := pub.data.(entity.AccountLoginData)
-	require.True(t, ok, "published data must be entity.AccountLoginData")
+	assert.Equal(t, entity.SubjectUserLoggedIn, pub.subject)
+	data, ok := pub.data.(entity.UserLoggedInData)
+	require.True(t, ok, "published data must be entity.UserLoggedInData")
 	assert.Equal(t, "platform-uuid-1", data.UserID)
 }
 

--- a/internal/di/consumer.go
+++ b/internal/di/consumer.go
@@ -43,6 +43,15 @@ type ConsumerApp struct {
 	Health *messaging.ConsumerHealth
 }
 
+// behaviorEntry pairs a behavior name with the subject it subscribes to and
+// the handler function that processes messages. One entry = one JetStream
+// durable consumer with durable == deliver_group == behavior name.
+type behaviorEntry struct {
+	behavior string
+	subject  string
+	handler  message.NoPublishHandlerFunc
+}
+
 // InitializeConsumerApp creates a ConsumerApp with all event handler dependencies wired.
 func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	cfg, err := config.Load[config.ConsumerConfig]()
@@ -98,13 +107,9 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	}
 
 	// consumerHealth reflects real consumption into the liveness probe: the NATS
-	// subscriber updates connection + per-topic bound state, and the router
+	// subscriber updates connection + per-behavior bound state, and the router
 	// probe (set below) reports whether the router is running.
 	consumerHealth := messaging.NewConsumerHealth()
-	subscriber, err := messaging.NewSubscriber(cfg.NATS, wmLogger, goChannel, consumerHealth)
-	if err != nil {
-		return nil, fmt.Errorf("create messaging subscriber: %w", err)
-	}
 
 	// Infrastructure - Google Maps Places API (required for venue resolution).
 	// Uses OAuth via ADC (Workload Identity in GKE).
@@ -195,6 +200,35 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 	salesPhaseAnnouncementConsumer := event.NewSalesPhaseAnnouncementConsumer(salesPhaseAnnouncementUC, logger)
 	salesReminderConsumer := event.NewSalesReminderConsumer(salesReminderDeliveryUC, logger)
 
+	// behaviorTable is the canonical behavior → subject → handler mapping.
+	// Each row becomes one independent JetStream durable consumer with
+	// durable == deliver_group == behavior name. Two rows on the same subject
+	// (e.g. SubjectArtistCreated, SubjectUserCreated) produce independent
+	// durables — each receives every message on that subject — which is the
+	// fan-out fix the old single shared-group subscriber broke.
+	behaviorTable := []behaviorEntry{
+		{"ingest-concert", entity.SubjectConcertDiscovered, concertConsumer.Handle},
+		{"notify-concert", entity.SubjectConcertCreated, notificationConsumer.Handle},
+		{"resolve-artist-name", entity.SubjectArtistCreated, artistNameConsumer.Handle},
+		{"resolve-artist-image", entity.SubjectArtistCreated, artistImageConsumer.Handle},
+		{"verify-user-email", entity.SubjectUserCreated, userConsumer.Handle},
+		{"track-user-created", entity.SubjectUserCreated, analyticsConsumer.HandleUserCreated},
+		{"track-user-logged-in", entity.SubjectUserLoggedIn, analyticsConsumer.HandleUserLoggedIn},
+		{"track-artist-followed", entity.SubjectArtistFollowed, analyticsConsumer.HandleArtistFollowed},
+		{"track-artist-unfollowed", entity.SubjectArtistUnfollowed, analyticsConsumer.HandleArtistUnfollowed},
+		{"track-notification-subscribed", entity.SubjectNotificationSubscribed, analyticsConsumer.HandleNotificationSubscribed},
+		{"track-notification-unsubscribed", entity.SubjectNotificationUnsubscribed, analyticsConsumer.HandleNotificationUnsubscribed},
+		{"track-notification-delivered", entity.SubjectNotificationDelivered, analyticsConsumer.HandleNotificationDelivered},
+		{"track-entry-verified", entity.SubjectEntryZkProofVerified, analyticsConsumer.HandleEntryZkProofVerified},
+		{"track-entry-rejected", entity.SubjectEntryZkProofRejected, analyticsConsumer.HandleEntryZkProofRejected},
+		{"track-ticket-journey", entity.SubjectTicketJourneyStatusChanged, analyticsConsumer.HandleTicketJourneyStatusChanged},
+		{"track-ticket-mint", entity.SubjectTicketMintCompleted, analyticsConsumer.HandleTicketMintCompleted},
+		{"track-ticket-email", entity.SubjectTicketEmailParsed, analyticsConsumer.HandleTicketEmailParsed},
+		{"log-poison", messaging.PoisonQueueSubject, poisonConsumer.Handle},
+		{"notify-sales-phase", entity.SubjectSalesPhaseDiscovered, salesPhaseAnnouncementConsumer.Handle},
+		{"notify-sales-reminder", entity.SubjectSalesPhaseReminderDue, salesReminderConsumer.Handle},
+	}
+
 	// Router
 	router, err := messaging.NewRouter(wmLogger, publisher, messaging.PoisonQueueSubject)
 	if err != nil {
@@ -211,147 +245,49 @@ func InitializeConsumerApp(ctx context.Context) (*ConsumerApp, error) {
 		return !router.IsClosed()
 	})
 
-	router.AddConsumerHandler(
-		"create-concerts",
-		entity.SubjectConcertDiscovered,
-		subscriber,
-		concertConsumer.Handle,
-	)
+	if cfg.NATS.URL == "" {
+		// Local development: use the single GoChannel subscriber for all
+		// handlers. Fan-out and durable isolation are not relevant locally —
+		// all handlers run in-process against the same in-memory channel.
+		for _, e := range behaviorTable {
+			router.AddConsumerHandler(e.behavior, e.subject, goChannel, e.handler)
+		}
+	} else {
+		// Production NATS path.
+		//
+		// Step 1: delete stale durables before the router subscribes so we do
+		// not leave old consumer_* prefixed, shared-group, or orphaned
+		// durables that would misbind new per-behavior subscriptions.
+		desiredBehaviors := make([]string, 0, len(behaviorTable))
+		for _, e := range behaviorTable {
+			desiredBehaviors = append(desiredBehaviors, e.behavior)
+		}
+		if err := messaging.ReconcileConsumers(ctx, cfg.NATS, desiredBehaviors, logger.Slog()); err != nil {
+			return nil, fmt.Errorf("reconcile NATS consumers: %w", err)
+		}
 
-	router.AddConsumerHandler(
-		"notify-fans",
-		entity.SubjectConcertCreated,
-		subscriber,
-		notificationConsumer.Handle,
-	)
+		// Step 2: open the long-lived shared *nats.Conn. One TCP connection
+		// serves all ~20 durables; per-handler isolation comes from distinct
+		// durable names and deliver groups, not separate connections.
+		sharedConn, err := messaging.ConnectNATS(ctx, cfg.NATS, consumerHealth)
+		if err != nil {
+			return nil, fmt.Errorf("connect shared NATS connection: %w", err)
+		}
+		// Drain the shared connection during shutdown (after the router has
+		// stopped consuming) so in-flight acks flush before the process exits.
+		shutdown.AddExternalPhase(messaging.NATSConnCloser(sharedConn))
 
-	router.AddConsumerHandler(
-		"resolve-artist-name",
-		entity.SubjectArtistCreated,
-		subscriber,
-		artistNameConsumer.Handle,
-	)
-
-	router.AddConsumerHandler(
-		"resolve-artist-image",
-		entity.SubjectArtistCreated,
-		subscriber,
-		artistImageConsumer.Handle,
-	)
-
-	router.AddConsumerHandler(
-		"send-email-verification",
-		entity.SubjectUserCreated,
-		subscriber,
-		userConsumer.Handle,
-	)
-
-	router.AddConsumerHandler(
-		"forward-user-created-to-analytics",
-		entity.SubjectUserCreated,
-		subscriber,
-		analyticsConsumer.HandleUserCreated,
-	)
-
-	router.AddConsumerHandler(
-		"forward-account-login-to-analytics",
-		entity.SubjectAccountLogin,
-		subscriber,
-		analyticsConsumer.HandleAccountLogin,
-	)
-
-	router.AddConsumerHandler(
-		"forward-artist-followed-to-analytics",
-		entity.SubjectArtistFollowed,
-		subscriber,
-		analyticsConsumer.HandleArtistFollowed,
-	)
-
-	router.AddConsumerHandler(
-		"forward-artist-unfollowed-to-analytics",
-		entity.SubjectArtistUnfollowed,
-		subscriber,
-		analyticsConsumer.HandleArtistUnfollowed,
-	)
-
-	router.AddConsumerHandler(
-		"forward-notification-subscribed-to-analytics",
-		entity.SubjectNotificationSubscribed,
-		subscriber,
-		analyticsConsumer.HandleNotificationSubscribed,
-	)
-
-	router.AddConsumerHandler(
-		"forward-notification-unsubscribed-to-analytics",
-		entity.SubjectNotificationUnsubscribed,
-		subscriber,
-		analyticsConsumer.HandleNotificationUnsubscribed,
-	)
-
-	// NOTIFICATION.delivered matches the existing NOTIFICATION.* stream
-	// (see messaging.streams) — no new JetStream stream is required.
-	router.AddConsumerHandler(
-		"forward-notification-delivered-to-analytics",
-		entity.SubjectNotificationDelivered,
-		subscriber,
-		analyticsConsumer.HandleNotificationDelivered,
-	)
-
-	router.AddConsumerHandler(
-		"forward-entry-zk-proof-verified-to-analytics",
-		entity.SubjectEntryZkProofVerified,
-		subscriber,
-		analyticsConsumer.HandleEntryZkProofVerified,
-	)
-
-	router.AddConsumerHandler(
-		"forward-entry-zk-proof-rejected-to-analytics",
-		entity.SubjectEntryZkProofRejected,
-		subscriber,
-		analyticsConsumer.HandleEntryZkProofRejected,
-	)
-
-	router.AddConsumerHandler(
-		"forward-ticket-journey-status-changed-to-analytics",
-		entity.SubjectTicketJourneyStatusChanged,
-		subscriber,
-		analyticsConsumer.HandleTicketJourneyStatusChanged,
-	)
-
-	router.AddConsumerHandler(
-		"forward-ticket-mint-completed-to-analytics",
-		entity.SubjectTicketMintCompleted,
-		subscriber,
-		analyticsConsumer.HandleTicketMintCompleted,
-	)
-
-	router.AddConsumerHandler(
-		"forward-ticket-email-parsed-to-analytics",
-		entity.SubjectTicketEmailParsed,
-		subscriber,
-		analyticsConsumer.HandleTicketEmailParsed,
-	)
-
-	router.AddConsumerHandler(
-		"log-poison-queue",
-		messaging.PoisonQueueSubject,
-		subscriber,
-		poisonConsumer.Handle,
-	)
-
-	router.AddConsumerHandler(
-		"announce-sales-phase",
-		entity.SubjectSalesPhaseDiscovered,
-		subscriber,
-		salesPhaseAnnouncementConsumer.Handle,
-	)
-
-	router.AddConsumerHandler(
-		"send-sales-phase-reminder",
-		entity.SubjectSalesPhaseReminderDue,
-		subscriber,
-		salesReminderConsumer.Handle,
-	)
+		// Step 3: create one per-behavior watermill subscriber for each entry
+		// and register it with the router. Each subscriber binds to the
+		// behavior-named durable, so the router sees 20 independent cursors.
+		for _, e := range behaviorTable {
+			sub, err := messaging.NewBehaviorSubscriber(sharedConn, e.behavior, wmLogger, consumerHealth)
+			if err != nil {
+				return nil, fmt.Errorf("create subscriber for behavior %q: %w", e.behavior, err)
+			}
+			router.AddConsumerHandler(e.behavior, e.subject, sub, e.handler)
+		}
+	}
 
 	// Register shutdown phases.
 	shutdown.Init(logger)

--- a/internal/entity/event_data.go
+++ b/internal/entity/event_data.go
@@ -30,7 +30,9 @@ const (
 	SubjectSalesPhaseDiscovered = "SALES_PHASE.discovered"
 	// SubjectSalesPhaseReminderDue is published by the reminder scan for each
 	// (user, phase, stage) triple that became due and has not yet been sent.
-	SubjectSalesPhaseReminderDue = "SALES_PHASE.reminder.due"
+	// Two tokens (reminder_due, not reminder.due) so the SALES_PHASE stream
+	// filter can be a plain `SALES_PHASE.*`.
+	SubjectSalesPhaseReminderDue = "SALES_PHASE.reminder_due"
 	// SubjectTicketJourneyStatusChanged is published by SetStatus after a
 	// successful upsert when the new status differs from the prior one (or
 	// when no prior journey existed). It drives the
@@ -46,14 +48,15 @@ const (
 	// ticket.email.parsed analytics event (email-ingestion data quality,
 	// parser robustness).
 	SubjectTicketEmailParsed = "TICKET_EMAIL.parsed"
-	// SubjectAccountLogin is published by the login-event webhook handler once
+	// SubjectUserLoggedIn is published by the login-event webhook handler once
 	// per user-initiated login, bound to the Zitadel session.user.checked
 	// event. It drives the account.signin analytics event (returning /
 	// active-user retention cohorts). The OIDC refresh_token grant touches only
 	// the oidc_session aggregate and never emits session.user.checked, so this
 	// subject is never published on a silent token refresh — login-specific by
-	// construction. Uses a new ACCOUNT.* JetStream stream.
-	SubjectAccountLogin = "ACCOUNT.login"
+	// construction. Modelled as a USER-domain event (USER.* stream), not a
+	// separate ACCOUNT stream.
+	SubjectUserLoggedIn = "USER.logged_in"
 )
 
 // AllSubjects is the canonical catalogue of every domain-event NATS subject
@@ -80,7 +83,7 @@ var AllSubjects = []string{
 	SubjectTicketJourneyStatusChanged,
 	SubjectTicketMintCompleted,
 	SubjectTicketEmailParsed,
-	SubjectAccountLogin,
+	SubjectUserLoggedIn,
 }
 
 // EntryRejectionReason enumerates the legitimate causes for a
@@ -125,12 +128,12 @@ type UserCreatedData struct {
 	Email string `json:"email"`
 }
 
-// AccountLoginData is the payload for ACCOUNT.login events.
+// UserLoggedInData is the payload for USER.logged_in events.
 // Mapped to the catalogue event account.signin by the analytics-consumer
-// (the NATS transport subject stays ACCOUNT.login). Published by the
+// (the NATS transport subject is USER.logged_in). Published by the
 // login-event webhook handler once per user-initiated sign-in, after the
 // Zitadel sub has been resolved to the platform UserID.
-type AccountLoginData struct {
+type UserLoggedInData struct {
 	// UserID is the platform-internal user identifier (UUID). Used as the
 	// PostHog distinct_id. Never the Zitadel sub, which Enqueue rejects.
 	UserID string `json:"user_id"`

--- a/internal/infrastructure/messaging/reconcile_internal_test.go
+++ b/internal/infrastructure/messaging/reconcile_internal_test.go
@@ -1,0 +1,131 @@
+package messaging
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeConsumerLister is a test double for jsConsumerLister. It serves a fixed
+// set of consumers per stream and records every DeleteConsumer call.
+type fakeConsumerLister struct {
+	byStream map[string][]*nats.ConsumerInfo
+	deleted  []string // "<stream>/<consumer>"
+}
+
+func (f *fakeConsumerLister) ConsumersInfo(stream string, _ ...nats.JSOpt) <-chan *nats.ConsumerInfo {
+	ch := make(chan *nats.ConsumerInfo)
+	go func() {
+		defer close(ch)
+		for _, ci := range f.byStream[stream] {
+			ch <- ci
+		}
+	}()
+	return ch
+}
+
+func (f *fakeConsumerLister) DeleteConsumer(stream, consumer string, _ ...nats.JSOpt) error {
+	f.deleted = append(f.deleted, stream+"/"+consumer)
+	return nil
+}
+
+// consumer builds a *nats.ConsumerInfo with the given durable name, deliver
+// group, and delivery policy.
+func consumer(name, group string, policy nats.DeliverPolicy) *nats.ConsumerInfo {
+	return &nats.ConsumerInfo{
+		Name: name,
+		Config: nats.ConsumerConfig{
+			Durable:       name,
+			DeliverGroup:  group,
+			DeliverPolicy: policy,
+		},
+	}
+}
+
+func TestReconcileConsumers_DeletesStaleKeepsCorrect(t *testing.T) {
+	t.Parallel()
+
+	// All fixtures live on the CONCERT stream (which is in the `streams` list
+	// reconcileConsumers iterates). Desired behaviors for this stream:
+	desired := []string{"ingest-concert", "notify-concert"}
+
+	js := &fakeConsumerLister{
+		byStream: map[string][]*nats.ConsumerInfo{
+			"CONCERT": {
+				// Correct: behavior-named, self-grouped, DeliverNew → KEEP.
+				consumer("notify-concert", "notify-concert", nats.DeliverNewPolicy),
+				// Desired name but the old shared "consumer" group → DELETE
+				// (this is the exact incident misbind config).
+				consumer("ingest-concert", "consumer", nats.DeliverNewPolicy),
+				// Old subject-named orphan, not in desired → DELETE.
+				consumer("CONCERT_created", "consumer", nats.DeliverNewPolicy),
+				// Old prefixed orphan, not in desired → DELETE.
+				consumer("consumer_CONCERT_created", "consumer_CONCERT_created", nats.DeliverNewPolicy),
+				// Desired + self-grouped but wrong delivery policy → DELETE.
+				consumer("notify-concert-x", "notify-concert-x", nats.DeliverAllPolicy),
+			},
+		},
+	}
+
+	err := reconcileConsumers(context.Background(), js, desired, slog.New(slog.DiscardHandler))
+
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"CONCERT/ingest-concert",           // shared deliver group
+		"CONCERT/CONCERT_created",          // not desired
+		"CONCERT/consumer_CONCERT_created", // not desired (prefixed)
+		"CONCERT/notify-concert-x",         // not desired + wrong policy
+	}, js.deleted)
+	assert.NotContains(t, js.deleted, "CONCERT/notify-concert", "a correct behavior durable must be kept")
+}
+
+func TestClassifyConsumer(t *testing.T) {
+	t.Parallel()
+
+	desired := map[string]struct{}{"notify-concert": {}}
+
+	tests := []struct {
+		name       string
+		info       *nats.ConsumerInfo
+		wantStale  bool
+		wantReason reconcileReason
+	}{
+		{
+			name:      "correct behavior durable is kept",
+			info:      consumer("notify-concert", "notify-concert", nats.DeliverNewPolicy),
+			wantStale: false,
+		},
+		{
+			name:       "name not desired is stale",
+			info:       consumer("CONCERT_created", "CONCERT_created", nats.DeliverNewPolicy),
+			wantStale:  true,
+			wantReason: reasonNotDesired,
+		},
+		{
+			name:       "shared deliver group is stale",
+			info:       consumer("notify-concert", "consumer", nats.DeliverNewPolicy),
+			wantStale:  true,
+			wantReason: reasonSharedDeliverGroup,
+		},
+		{
+			name:       "wrong delivery policy is stale",
+			info:       consumer("notify-concert", "notify-concert", nats.DeliverAllPolicy),
+			wantStale:  true,
+			wantReason: reasonWrongDeliverPolicy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason, stale := classifyConsumer(tt.info, desired)
+			assert.Equal(t, tt.wantStale, stale)
+			if tt.wantStale {
+				assert.Equal(t, tt.wantReason, reason)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/messaging/streams.go
+++ b/internal/infrastructure/messaging/streams.go
@@ -85,16 +85,6 @@ var streams = []nats.StreamConfig{
 		Duplicates: 2 * time.Minute,
 	},
 	{
-		Name:       "ACCOUNT",
-		Subjects:   []string{"ACCOUNT.*"},
-		Retention:  nats.LimitsPolicy,
-		MaxAge:     7 * 24 * time.Hour,
-		Storage:    nats.FileStorage,
-		Discard:    nats.DiscardOld,
-		Replicas:   1,
-		Duplicates: 2 * time.Minute,
-	},
-	{
 		Name:       "ENTRY",
 		Subjects:   []string{"ENTRY.*"},
 		Retention:  nats.LimitsPolicy,
@@ -106,11 +96,10 @@ var streams = []nats.StreamConfig{
 	},
 	{
 		Name: "SALES_PHASE",
-		// `>` (not `*`) because this domain has nested subjects:
-		// SALES_PHASE.discovered (one token) AND SALES_PHASE.reminder.due
-		// (two tokens). A single-token `SALES_PHASE.*` would not match the
-		// latter, so a subscriber would fail with "no stream matches subject".
-		Subjects:   []string{"SALES_PHASE.>"},
+		// Both subjects are two-token (SALES_PHASE.discovered,
+		// SALES_PHASE.reminder_due), so a single-token `SALES_PHASE.*` matches
+		// them all.
+		Subjects:   []string{"SALES_PHASE.*"},
 		Retention:  nats.LimitsPolicy,
 		MaxAge:     7 * 24 * time.Hour,
 		Storage:    nats.FileStorage,
@@ -255,16 +244,22 @@ func EnsureStreams(ctx context.Context, cfg config.NATSConfig) error {
 
 // connectWithRetry attempts to connect to NATS with exponential backoff.
 // It returns the first successful connection or the last error if the
-// context is cancelled or all attempts are exhausted.
-func connectWithRetry(ctx context.Context, url string) (*nats.Conn, error) {
+// context is cancelled or all attempts are exhausted. Extra options are
+// appended after the baseline reconnect/timeout options so callers may
+// register connection lifecycle handlers (e.g. DisconnectErrHandler) on the
+// connection that is ultimately returned.
+func connectWithRetry(ctx context.Context, url string, extra ...nats.Option) (*nats.Conn, error) {
 	var lastErr error
 
+	baseOpts := []nats.Option{
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(time.Second),
+		nats.Timeout(natsConnectTimeout),
+	}
+	opts := append(baseOpts, extra...)
+
 	for attempt := range connectBackoff {
-		nc, err := nats.Connect(url,
-			nats.MaxReconnects(-1),
-			nats.ReconnectWait(time.Second),
-			nats.Timeout(natsConnectTimeout),
-		)
+		nc, err := nats.Connect(url, opts...)
 		if err == nil {
 			if attempt > 0 {
 				slog.Info("NATS connection established after retry",
@@ -294,11 +289,7 @@ func connectWithRetry(ctx context.Context, url string) (*nats.Conn, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("%w (after %d attempts, last: %w)", context.Cause(ctx), len(connectBackoff), lastErr)
 	}
-	nc, err := nats.Connect(url,
-		nats.MaxReconnects(-1),
-		nats.ReconnectWait(time.Second),
-		nats.Timeout(natsConnectTimeout),
-	)
+	nc, err := nats.Connect(url, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("%w (after %d attempts)", err, len(connectBackoff)+1)
 	}

--- a/internal/infrastructure/messaging/streams_test.go
+++ b/internal/infrastructure/messaging/streams_test.go
@@ -32,8 +32,9 @@ func TestAllSubjectsCoveredByStream(t *testing.T) {
 }
 
 // TestSubjectCoveredByStream exercises the NATS token-matching semantics
-// directly, including the '*' (single token) vs '>' (trailing tokens) nuance
-// that made SALES_PHASE.reminder.due require a '>' filter.
+// directly, including the '*' (single token) vs '>' (trailing tokens) nuance.
+// Both SALES_PHASE subjects are now two-token (reminder_due, not
+// reminder.due), so the stream filter is a plain SALES_PHASE.*.
 func TestSubjectCoveredByStream(t *testing.T) {
 	t.Parallel()
 
@@ -48,12 +49,12 @@ func TestSubjectCoveredByStream(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "nested subject matched by <domain>.> stream",
-			subject: "SALES_PHASE.reminder.due",
+			name:    "two-token SALES_PHASE.reminder_due matched by <domain>.* stream",
+			subject: "SALES_PHASE.reminder_due",
 			want:    true,
 		},
 		{
-			name:    "single-token subject matched by <domain>.> stream",
+			name:    "two-token SALES_PHASE.discovered matched by <domain>.* stream",
 			subject: "SALES_PHASE.discovered",
 			want:    true,
 		},

--- a/internal/infrastructure/messaging/subscriber.go
+++ b/internal/infrastructure/messaging/subscriber.go
@@ -3,7 +3,8 @@ package messaging
 import (
 	"context"
 	"fmt"
-	"strings"
+	"io"
+	"log/slog"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill"
@@ -16,28 +17,117 @@ import (
 	"github.com/liverty-music/backend/pkg/config"
 )
 
-// consumerQueueGroupPrefix is the prefix for the per-topic JetStream deliver
-// (queue) group and durable name. Bumped from the historical bare "consumer"
-// group to segregate consumers per subject (see SubjectCalculator in
-// NewSubscriber for the collision this avoids).
-const consumerQueueGroupPrefix = "consumer"
-
-// consumerName derives a per-topic durable / deliver-group name from a subject,
-// e.g. "NOTIFICATION.delivered" -> "consumer_NOTIFICATION_delivered". Keeping
-// the durable and deliver group identical and unique per topic guarantees each
-// subject on a shared stream provisions its own JetStream consumer.
-func consumerName(topic string) string {
-	return consumerQueueGroupPrefix + "_" + strings.ReplaceAll(topic, ".", "_")
+// ConnectNATS opens a shared *nats.Conn for use across all per-behavior
+// subscribers. It registers the three connection lifecycle handlers so the
+// ConsumerHealth reflects the real connection state immediately when NATS
+// disconnects, reconnects, or closes — without waiting for a Subscribe call.
+//
+// The caller owns the returned connection and must drain/close it during
+// shutdown (after all watermill subscribers have been closed).
+func ConnectNATS(ctx context.Context, cfg config.NATSConfig, health *ConsumerHealth) (*nats.Conn, error) {
+	nc, err := connectWithRetry(ctx, cfg.URL,
+		// Reflect the live NATS connection state into the health tracker so a
+		// dropped connection (which stops all consumption) makes the liveness
+		// probe report unhealthy. These handlers are set once on the shared
+		// conn, not repeated per-subscriber.
+		nats.DisconnectErrHandler(func(_ *nats.Conn, _ error) {
+			health.SetConnected(false)
+		}),
+		nats.ReconnectHandler(func(_ *nats.Conn) {
+			health.SetConnected(true)
+		}),
+		nats.ClosedHandler(func(_ *nats.Conn) {
+			health.SetConnected(false)
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect to NATS: %w", err)
+	}
+	return nc, nil
 }
 
-// NewSubscriber creates a Watermill Subscriber based on configuration.
-// When NATS_URL is set, it returns a NATS JetStream subscriber with durable consumers.
-// When NATS_URL is empty (local development), it returns a GoChannel subscriber
-// using the provided GoChannel instance.
+// natsConnDrainer adapts a *nats.Conn to io.Closer via Drain, so the shared
+// connection can be registered with the shutdown manager. Drain flushes
+// in-flight acks/publishes and unsubscribes before closing, which is the
+// graceful counterpart to Close for a consumer connection.
+type natsConnDrainer struct{ conn *nats.Conn }
+
+// Close drains the underlying NATS connection (flush + unsubscribe + close).
+func (d natsConnDrainer) Close() error { return d.conn.Drain() }
+
+// NATSConnCloser wraps the shared consumer connection as an io.Closer that
+// drains on shutdown. Register it in the shutdown External phase so it runs
+// after the router has stopped consuming.
+func NATSConnCloser(conn *nats.Conn) io.Closer { return natsConnDrainer{conn} }
+
+// NewBehaviorSubscriber creates one watermill Subscriber for a single named
+// behavior (handler). The behavior name is used as BOTH the JetStream durable
+// name and the deliver (queue) group, so each handler has its own independent
+// cursor on the stream. The shared *nats.Conn means no extra TCP connection
+// per handler.
 //
-// The returned NATS subscriber reports its connection and per-topic bound state
-// into health so the consumer's liveness probe reflects real consumption. The
-// GoChannel (local) path has no connection to lose and is returned unwrapped.
+// The returned subscriber is wrapped in a healthTrackingSubscriber that
+// records the behavior's bound state into health when Subscribe is called by
+// the router at startup.
+func NewBehaviorSubscriber(
+	conn *nats.Conn,
+	behavior string,
+	wmLogger watermill.LoggerAdapter,
+	health *ConsumerHealth,
+) (message.Subscriber, error) {
+	cfg := watermillnats.SubscriberSubscriptionConfig{
+		CloseTimeout:   30 * time.Second,
+		AckWaitTimeout: 30 * time.Second,
+		// The SubjectCalculator returns the behavior name as the queue group
+		// for every topic this subscriber is asked to subscribe to. Because
+		// each per-behavior subscriber only ever subscribes to one topic, the
+		// queue group is always the behavior name — independent of the subject.
+		// This gives durable == deliver_group == behavior, which is the
+		// property that prevents the shared-group misbind: sibling handlers
+		// on the same stream each hold their own durable, so nats.go cannot
+		// accidentally bind a new durable to an existing sibling's durable.
+		SubjectCalculator: func(_, topic string) *watermillnats.SubjectDetail {
+			return &watermillnats.SubjectDetail{
+				Primary:    topic,
+				QueueGroup: behavior,
+			}
+		},
+		JetStream: watermillnats.JetStreamConfig{
+			// DurableCalculator ignores the topic and always returns the
+			// behavior name. Combined with SubjectCalculator above this
+			// guarantees durable == deliver_group == behavior regardless of
+			// which subject is passed to Subscribe.
+			DurableCalculator: func(_, _ string) string {
+				return behavior
+			},
+			SubscribeOptions: []nats.SubOpt{
+				nats.AckExplicit(),
+				nats.DeliverNew(),
+			},
+		},
+	}
+
+	sub, err := watermillnats.NewSubscriberWithNatsConn(conn, cfg, wmLogger)
+	if err != nil {
+		return nil, fmt.Errorf("create behavior subscriber for %q: %w", behavior, err)
+	}
+
+	return &healthTrackingSubscriber{
+		Subscriber: sub,
+		health:     health,
+		behavior:   behavior,
+	}, nil
+}
+
+// NewSubscriber creates a single Watermill Subscriber based on configuration.
+// When NATS_URL is empty it returns the provided GoChannel (local dev path).
+// When NATS_URL is set it opens its own connection — used only by the
+// publisher and in tests; the consumer app uses ConnectNATS +
+// NewBehaviorSubscriber to get per-handler durable isolation instead.
+//
+// The returned NATS subscriber wraps with healthTrackingSubscriber that
+// records per-topic bound state into health. The GoChannel path has no
+// connection to lose and is returned unwrapped.
 func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goChannel *gochannel.GoChannel, health *ConsumerHealth) (message.Subscriber, error) {
 	if cfg.URL == "" {
 		if goChannel == nil {
@@ -51,9 +141,6 @@ func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goCh
 		NatsOptions: []nats.Option{
 			nats.MaxReconnects(-1),
 			nats.ReconnectWait(time.Second),
-			// Reflect the live NATS connection state into the health tracker so
-			// a dropped connection (which stops all consumption) makes the
-			// liveness probe report unhealthy.
 			nats.DisconnectErrHandler(func(_ *nats.Conn, _ error) {
 				health.SetConnected(false)
 			}),
@@ -64,29 +151,9 @@ func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goCh
 				health.SetConnected(false)
 			}),
 		},
-		QueueGroupPrefix: consumerQueueGroupPrefix,
-		CloseTimeout:     30 * time.Second,
-		AckWaitTimeout:   30 * time.Second,
-		// Derive BOTH the JetStream deliver (queue) group and the durable name
-		// per topic. This is required — not cosmetic — because several subjects
-		// share one stream (e.g. NOTIFICATION.subscribed/.unsubscribed/.delivered
-		// all live in the NOTIFICATION stream). nats.go's QueueSubscribe, when a
-		// durable does not yet exist, looks up an existing consumer on the stream
-		// by deliver group; with a single shared group it FINDS a sibling and
-		// binds to it instead of creating the new consumer — so the second and
-		// third subjects on a stream silently never get a consumer and their
-		// messages pile up unconsumed. A per-topic deliver group removes the
-		// collision so every subject provisions its own consumer.
-		SubjectCalculator: func(_, topic string) *watermillnats.SubjectDetail {
-			return &watermillnats.SubjectDetail{
-				Primary:    topic,
-				QueueGroup: consumerName(topic),
-			}
-		},
+		CloseTimeout:   30 * time.Second,
+		AckWaitTimeout: 30 * time.Second,
 		JetStream: watermillnats.JetStreamConfig{
-			DurableCalculator: func(_, topic string) string {
-				return consumerName(topic)
-			},
 			SubscribeOptions: []nats.SubOpt{
 				nats.AckExplicit(),
 				nats.DeliverNew(),
@@ -100,38 +167,169 @@ func NewSubscriber(cfg config.NATSConfig, wmLogger watermill.LoggerAdapter, goCh
 	return &healthTrackingSubscriber{Subscriber: sub, health: health}, nil
 }
 
+// jsConsumerLister is the minimal JetStream surface consumed by
+// ReconcileConsumers. Accepting an interface rather than a concrete
+// *nats.JetStreamContext makes the reconcile logic unit-testable without a
+// live NATS server.
+type jsConsumerLister interface {
+	// ConsumersInfo returns a channel of *nats.ConsumerInfo for the named stream.
+	ConsumersInfo(stream string, opts ...nats.JSOpt) <-chan *nats.ConsumerInfo
+	// DeleteConsumer removes the named consumer from the named stream.
+	DeleteConsumer(stream, consumer string, opts ...nats.JSOpt) error
+}
+
+// reconcileReason encodes why a stale durable was deleted, for structured
+// logging at INFO level.
+type reconcileReason string
+
+const (
+	reasonNotDesired         reconcileReason = "not in desired set"
+	reasonSharedDeliverGroup reconcileReason = "deliver_group != name (shared group)"
+	reasonWrongDeliverPolicy reconcileReason = "deliver_policy != DeliverNew"
+)
+
+// ReconcileConsumers deletes JetStream durables that no longer match the
+// desired behavior-named set. It is a no-op when NATS_URL is empty (local
+// dev). It must be called after EnsureStreams and before the watermill
+// router subscribes, so stale durables are cleared before new per-behavior
+// durables are created.
+//
+// A consumer is deleted when ANY of the following hold:
+//   - its name is not in desired (removes old consumer_* prefixed durables,
+//     old subject-named durables, dead orphans such as ACCOUNT.login);
+//   - its Config.DeliverGroup does not equal its own name (shared "consumer"
+//     group or any other drift that causes the misbind bug);
+//   - its Config.DeliverPolicy is not nats.DeliverNewPolicy.
+//
+// Consumers in the desired set that already satisfy all three conditions are
+// left untouched — watermill will bind to them on Subscribe. Consumers on
+// streams not in the configured stream list are never touched.
+func ReconcileConsumers(ctx context.Context, cfg config.NATSConfig, desired []string, logger *slog.Logger) error {
+	if cfg.URL == "" {
+		return nil
+	}
+
+	nc, err := connectWithRetry(ctx, cfg.URL)
+	if err != nil {
+		return fmt.Errorf("connect to NATS for reconcile: %w", err)
+	}
+	defer nc.Drain() //nolint:errcheck
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return fmt.Errorf("get JetStream context for reconcile: %w", err)
+	}
+
+	return reconcileConsumers(ctx, js, desired, logger)
+}
+
+// reconcileConsumers is the testable inner function that accepts the
+// jsConsumerLister interface.
+func reconcileConsumers(ctx context.Context, js jsConsumerLister, desired []string, logger *slog.Logger) error {
+	desiredSet := make(map[string]struct{}, len(desired))
+	for _, name := range desired {
+		desiredSet[name] = struct{}{}
+	}
+
+	for _, stream := range streams {
+		ch := js.ConsumersInfo(stream.Name)
+		for info := range ch {
+			if info == nil {
+				continue
+			}
+
+			reason, stale := classifyConsumer(info, desiredSet)
+			if !stale {
+				continue
+			}
+
+			logger.InfoContext(ctx, "deleting stale JetStream consumer",
+				slog.String("stream", stream.Name),
+				slog.String("consumer", info.Name),
+				slog.String("reason", string(reason)),
+			)
+
+			if err := js.DeleteConsumer(stream.Name, info.Name); err != nil {
+				// Log but do not abort: one unremovable consumer should not
+				// prevent the others from being cleaned up, and the subscriber
+				// will fail loudly at startup if a durable it needs is broken.
+				logger.ErrorContext(ctx, "failed to delete stale JetStream consumer",
+					slog.String("stream", stream.Name),
+					slog.String("consumer", info.Name),
+					slog.String("error", err.Error()),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// classifyConsumer reports whether a JetStream consumer is stale and why.
+// A consumer is stale when it is not in the desired set, has a deliver group
+// that differs from its own name (shared-group misbind), or uses a deliver
+// policy other than DeliverNew.
+func classifyConsumer(info *nats.ConsumerInfo, desired map[string]struct{}) (reconcileReason, bool) {
+	if _, ok := desired[info.Name]; !ok {
+		return reasonNotDesired, true
+	}
+	if info.Config.DeliverGroup != info.Name {
+		return reasonSharedDeliverGroup, true
+	}
+	if info.Config.DeliverPolicy != nats.DeliverNewPolicy {
+		return reasonWrongDeliverPolicy, true
+	}
+	return "", false
+}
+
 // healthTrackingSubscriber wraps a Watermill subscriber and records each
 // topic's bound state into a ConsumerHealth. watermill establishes every
-// subscription synchronously at router startup, so a topic is marked bound the
-// moment its Subscribe succeeds and marked unbound if it fails — letting the
-// liveness probe distinguish a fully-consuming pod from a wedged one.
+// subscription synchronously at router startup, so a topic is marked bound
+// the moment its Subscribe succeeds and marked unbound if it fails — letting
+// the liveness probe distinguish a fully-consuming pod from a wedged one.
+//
+// When behavior is non-empty (per-behavior subscriber created by
+// NewBehaviorSubscriber) the health key is the behavior name. When behavior
+// is empty (legacy single-subscriber path) the key falls back to the topic
+// passed to Subscribe — preserving the original semantics.
 type healthTrackingSubscriber struct {
 	message.Subscriber
-	health *ConsumerHealth
+	health   *ConsumerHealth
+	behavior string
 }
 
 // Subscribe delegates to the wrapped subscriber and records the topic's bound
 // state. On failure it marks the topic unbound (and the router startup fails
 // loud); on success it marks the topic bound.
 func (s *healthTrackingSubscriber) Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
-	s.health.Expect(topic)
+	key := s.healthKey(topic)
+	s.health.Expect(key)
 
 	msgs, err := s.Subscriber.Subscribe(ctx, topic)
 	if err != nil {
-		s.health.MarkUnbound(topic)
+		s.health.MarkUnbound(key)
 		return nil, err
 	}
 
-	s.health.MarkBound(topic)
+	s.health.MarkBound(key)
 	return msgs, nil
 }
 
 // SubscribeInitialize forwards subscription pre-provisioning to the wrapped
-// subscriber when it supports it, keeping this decorator transparent so it does
-// not hide capabilities the underlying watermill subscriber exposes.
+// subscriber when it supports it, keeping this decorator transparent so it
+// does not hide capabilities the underlying watermill subscriber exposes.
 func (s *healthTrackingSubscriber) SubscribeInitialize(topic string) error {
 	if init, ok := s.Subscriber.(message.SubscribeInitializer); ok {
 		return init.SubscribeInitialize(topic)
 	}
 	return nil
+}
+
+// healthKey returns the key used to track this subscription in ConsumerHealth.
+// Per-behavior subscribers use the behavior name (so health reflects handler
+// identity, not subject). The legacy single-subscriber path falls back to topic.
+func (s *healthTrackingSubscriber) healthKey(topic string) string {
+	if s.behavior != "" {
+		return s.behavior
+	}
+	return topic
 }


### PR DESCRIPTION
## Summary

Phase 2 of hardening JetStream consumer reliability. Fixes the recurring **silent-misbind** class where all durables shared `deliver_group="consumer"`: the 2nd+ subject on any stream never got its own consumer, and two handlers on one subject collapsed onto one competing consumer (broken fan-out). **Prod was found in exactly this broken state** (~10 subjects unconsumed, incl. push notifications / sales reminders), so this PR doubles as the remediation.

### Consumers are named by behavior
A subject says *what happened* (`CONCERT.created`); a consumer says *what we do* (`notify-concert`). Each handler now gets its own JetStream durable whose **name IS its deliver group** (`durable == deliver_group == behavior`), so no two consumers can share a group. The two multi-handler subjects become two independent consumers each — correct fan-out:
- `ARTIST.created` → `resolve-artist-name` + `resolve-artist-image`
- `USER.created` → `verify-user-email` + `track-user-created`

Analytics forwarders collapse `forward-…-to-analytics` → `track-…`.

### How (watermill constraint)
`DurableCalculator` only sees `(prefix, topic)`, so per-handler durables are built as **one subscriber per handler via `NewSubscriberWithNatsConn`, all sharing one `*nats.Conn`** (no extra connections). A startup `ReconcileConsumers` pre-flight deletes any durable that is not a desired behavior name, or whose `deliver_group != its own name`, or whose delivery policy drifted; watermill then recreates the correct per-behavior durables. Phase 1's fail-loud + consumption-aware liveness stay.

### Subject normalization (backend-internal Go constants — no proto/BSR)
- `SALES_PHASE.reminder.due` → `SALES_PHASE.reminder_due` (stream filter back to plain `.*`)
- Fold the vestigial `ACCOUNT` stream into `USER`: `ACCOUNT.login` → `USER.logged_in` (the `account.login` webhook was reverted; nothing else uses it)

## Testing
- `make check` passes; golangci-lint 0 issues.
- New white-box unit tests for `reconcileConsumers`/`classifyConsumer`: a shared-group / not-desired / prefixed / wrong-policy durable is deleted; a correct behavior-named self-grouped DeliverNew one is kept.

## Migration note
On rollout, reconciliation deletes the stale shared-group durables and watermill recreates ~20 behavior-named ones (`deliver_group == name`, `push_bound=true`). `DeliverNew` means the ~200 retained-but-unconsumed pre-fix events (mostly no-fan `CONCERT.created` pushes + a few analytics) are dropped — acceptable pre-launch. Pairs with the cloud-provisioning KEDA-rename PR.

Refs: liverty-music/specification#695
