### PR TITLE
fix(concert): idempotent venue resolution and normalized-name dedup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/oauth2 v0.35.0
+	golang.org/x/text v0.39.0
 	golang.org/x/time v0.15.0
 	google.golang.org/genai v1.57.0
 	google.golang.org/genproto v0.0.0-20260316180232-0b37fe3546d5
@@ -234,7 +235,6 @@ require (
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
 	golang.org/x/term v0.44.0 // indirect
-	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/api v0.259.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/internal/entity/concert.go
+++ b/internal/entity/concert.go
@@ -162,7 +162,10 @@ type ScrapedConcerts []*ScrapedConcert
 // (multiple scraped rows for the same key in the receiver). The key uses
 // ListedVenueName rather than the resolved venue_id because scraped concerts
 // have not yet been venue-resolved; ListedVenueName is the upstream identity
-// that survives both sides of the comparison.
+// that survives both sides of the comparison. The name component is compared
+// through NormalizeVenueName so Gemini's formatting drift across runs
+// (full/half-width, whitespace, "大阪・"/"大阪公演 ＠" location prefixes) does not
+// defeat the match; the (date, start_at) components are unchanged.
 //
 // start_time disambiguates within a (date, venue), but asymmetrically so the
 // downstream resolution stays correct:
@@ -205,7 +208,7 @@ func (ss ScrapedConcerts) FilterNew(existing []*Concert) ScrapedConcerts {
 		if ex.ListedVenueName == nil {
 			continue
 		}
-		mark(vdKey{date: ex.LocalDate.Format("2006-01-02"), venue: *ex.ListedVenueName}, StartKey(ex.StartTime))
+		mark(vdKey{date: ex.LocalDate.Format("2006-01-02"), venue: NormalizeVenueName(*ex.ListedVenueName)}, StartKey(ex.StartTime))
 	}
 
 	var result ScrapedConcerts
@@ -220,7 +223,7 @@ func (ss ScrapedConcerts) FilterNew(existing []*Concert) ScrapedConcerts {
 		if s.ListedVenueName == "" {
 			continue
 		}
-		k := vdKey{date: s.LocalDate.Format("2006-01-02"), venue: s.ListedVenueName}
+		k := vdKey{date: s.LocalDate.Format("2006-01-02"), venue: NormalizeVenueName(s.ListedVenueName)}
 		start := StartKey(NullableTime(s.StartTime))
 		var dup bool
 		if start == "" {

--- a/internal/entity/concert_test.go
+++ b/internal/entity/concert_test.go
@@ -511,6 +511,45 @@ func TestScrapedConcerts_FilterNew(t *testing.T) {
 			},
 		},
 		{
+			name: "venue-name drift against existing is deduped (admin-area prefix)",
+			args: args{
+				scraped: entity.ScrapedConcerts{
+					{LocalDate: date1, ListedVenueName: "大阪・フェスティバルホール", Title: "Drifted"},
+				},
+				existing: []*entity.Concert{
+					{Event: entity.Event{LocalDate: date1, ListedVenueName: new("フェスティバルホール")}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "genuinely different venue on the same date stays distinct",
+			args: args{
+				scraped: entity.ScrapedConcerts{
+					{LocalDate: date1, ListedVenueName: "大阪城ホール", Title: "Different"},
+				},
+				existing: []*entity.Concert{
+					{Event: entity.Event{LocalDate: date1, ListedVenueName: new("フェスティバルホール")}},
+				},
+			},
+			want: entity.ScrapedConcerts{
+				{LocalDate: date1, ListedVenueName: "大阪城ホール", Title: "Different"},
+			},
+		},
+		{
+			name: "within-batch venue-name drift is deduped (performance prefix)",
+			args: args{
+				scraped: entity.ScrapedConcerts{
+					{LocalDate: date1, ListedVenueName: "フェスティバルホール", Title: "First"},
+					{LocalDate: date1, ListedVenueName: "大阪公演 ＠フェスティバルホール", Title: "Drifted"},
+				},
+				existing: []*entity.Concert{},
+			},
+			want: entity.ScrapedConcerts{
+				{LocalDate: date1, ListedVenueName: "フェスティバルホール", Title: "First"},
+			},
+		},
+		{
 			name: "preserve original order of scraped concerts",
 			args: args{
 				scraped:  entity.ScrapedConcerts{sc1, sc2, sc3},

--- a/internal/entity/mocks/mock_VenueRepository.go
+++ b/internal/entity/mocks/mock_VenueRepository.go
@@ -22,22 +22,80 @@ func (_m *MockVenueRepository) EXPECT() *MockVenueRepository_Expecter {
 	return &MockVenueRepository_Expecter{mock: &_m.Mock}
 }
 
+// BackfillPlaceID provides a mock function with given fields: ctx, venueID, placeID
+func (_m *MockVenueRepository) BackfillPlaceID(ctx context.Context, venueID string, placeID string) error {
+	ret := _m.Called(ctx, venueID, placeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BackfillPlaceID")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, venueID, placeID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockVenueRepository_BackfillPlaceID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BackfillPlaceID'
+type MockVenueRepository_BackfillPlaceID_Call struct {
+	*mock.Call
+}
+
+// BackfillPlaceID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - venueID string
+//   - placeID string
+func (_e *MockVenueRepository_Expecter) BackfillPlaceID(ctx interface{}, venueID interface{}, placeID interface{}) *MockVenueRepository_BackfillPlaceID_Call {
+	return &MockVenueRepository_BackfillPlaceID_Call{Call: _e.mock.On("BackfillPlaceID", ctx, venueID, placeID)}
+}
+
+func (_c *MockVenueRepository_BackfillPlaceID_Call) Run(run func(ctx context.Context, venueID string, placeID string)) *MockVenueRepository_BackfillPlaceID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockVenueRepository_BackfillPlaceID_Call) Return(_a0 error) *MockVenueRepository_BackfillPlaceID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVenueRepository_BackfillPlaceID_Call) RunAndReturn(run func(context.Context, string, string) error) *MockVenueRepository_BackfillPlaceID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Create provides a mock function with given fields: ctx, venue
-func (_m *MockVenueRepository) Create(ctx context.Context, venue *entity.Venue) error {
+func (_m *MockVenueRepository) Create(ctx context.Context, venue *entity.Venue) (string, error) {
 	ret := _m.Called(ctx, venue)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Create")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *entity.Venue) error); ok {
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *entity.Venue) (string, error)); ok {
+		return rf(ctx, venue)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *entity.Venue) string); ok {
 		r0 = rf(ctx, venue)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(string)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, *entity.Venue) error); ok {
+		r1 = rf(ctx, venue)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MockVenueRepository_Create_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Create'
@@ -59,12 +117,12 @@ func (_c *MockVenueRepository_Create_Call) Run(run func(ctx context.Context, ven
 	return _c
 }
 
-func (_c *MockVenueRepository_Create_Call) Return(_a0 error) *MockVenueRepository_Create_Call {
-	_c.Call.Return(_a0)
+func (_c *MockVenueRepository_Create_Call) Return(_a0 string, _a1 error) *MockVenueRepository_Create_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockVenueRepository_Create_Call) RunAndReturn(run func(context.Context, *entity.Venue) error) *MockVenueRepository_Create_Call {
+func (_c *MockVenueRepository_Create_Call) RunAndReturn(run func(context.Context, *entity.Venue) (string, error)) *MockVenueRepository_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/entity/venue.go
+++ b/internal/entity/venue.go
@@ -49,12 +49,24 @@ type VenuePlaceSearcher interface {
 
 // VenueRepository defines the data access interface for Venues.
 type VenueRepository interface {
-	// Create creates a new venue.
+	// Create inserts a new venue and returns the id of the surviving row. It is an
+	// idempotent get-or-create: the insert absorbs a conflict on either
+	// place_id or (listed_venue_name, admin_area) and re-SELECTs the existing row,
+	// so a lost race never surfaces a unique violation to the caller.
 	//
 	// # Possible errors
 	//
 	//  - InvalidArgument: If the venue name is invalid.
-	Create(ctx context.Context, venue *Venue) error
+	Create(ctx context.Context, venue *Venue) (string, error)
+
+	// BackfillPlaceID sets google_place_id on a venue that currently has none.
+	// It is a no-op when the row already carries a non-NULL place_id or when a
+	// concurrent backfill already set the value.
+	//
+	// # Possible errors
+	//
+	//  - Internal: If the update fails for a reason other than a benign race.
+	BackfillPlaceID(ctx context.Context, venueID, placeID string) error
 
 	// Get retrieves a venue by ID.
 	//

--- a/internal/entity/venue_normalize.go
+++ b/internal/entity/venue_normalize.go
@@ -17,11 +17,34 @@ var (
 	// already folded the full-width ＠ to an ASCII @ by the time this runs.
 	venuePerformancePrefixRE = regexp.MustCompile(`^.*?公演\s*@\s*`)
 
-	// venueAreaPrefixRE strips a single leading "〈admin_area〉・" prefix, e.g.
-	// "大阪・フェスティバルホール" → "フェスティバルホール". The prefix is bounded
-	// to a short token so it targets prefecture/city names and does not eat venue
-	// names that legitimately embed a middle dot.
-	venueAreaPrefixRE = regexp.MustCompile(`^[^・]{1,6}・`)
+	// japanesePrefectureBases are the 47 prefecture names without their
+	// 都/道/府/県 suffix (北海道 keeps its 道 as it has no bare form). The
+	// admin-area prefix strip fires ONLY for these tokens, so a venue whose own
+	// name embeds a middle dot after a non-prefecture token — e.g.
+	// "東京文化会館・大ホール" or "杉並公会堂・大ホール" — is preserved rather than
+	// truncated to a generic residue like "大ホール". Truncating those would
+	// silently collapse distinct same-date venues into one dedup key and, on the
+	// pending-staged path (which ignores start time), drop a genuinely-new concert
+	// with no DB-level safety net.
+	japanesePrefectureBases = []string{
+		"北海道",
+		"青森", "岩手", "宮城", "秋田", "山形", "福島",
+		"茨城", "栃木", "群馬", "埼玉", "千葉", "東京", "神奈川",
+		"新潟", "富山", "石川", "福井", "山梨", "長野",
+		"岐阜", "静岡", "愛知", "三重",
+		"滋賀", "京都", "大阪", "兵庫", "奈良", "和歌山",
+		"鳥取", "島根", "岡山", "広島", "山口",
+		"徳島", "香川", "愛媛", "高知",
+		"福岡", "佐賀", "長崎", "熊本", "大分", "宮崎", "鹿児島", "沖縄",
+	}
+
+	// venueAreaPrefixRE strips a single leading "〈prefecture〉・" prefix, e.g.
+	// "大阪・フェスティバルホール" → "フェスティバルホール" and
+	// "大阪府・フェスティバルホール" → "フェスティバルホール". The optional
+	// [都道府県] suffix lets a base match with or without its administrative
+	// suffix; the strip requires the prefecture token to be immediately followed
+	// by the middle dot, so non-prefecture facility names are never touched.
+	venueAreaPrefixRE = regexp.MustCompile(`^(?:` + strings.Join(japanesePrefectureBases, "|") + `)[都道府県]?・`)
 )
 
 // NormalizeVenueName canonicalizes a scraped venue name for dedup comparison so

--- a/internal/entity/venue_normalize.go
+++ b/internal/entity/venue_normalize.go
@@ -1,0 +1,44 @@
+package entity
+
+import (
+	"regexp"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+var (
+	// venueWhitespaceRE matches runs of whitespace so they collapse to a single
+	// ASCII space (NFKC has already folded full-width spaces to ASCII by then).
+	venueWhitespaceRE = regexp.MustCompile(`\s+`)
+
+	// venuePerformancePrefixRE strips a leading "〈city〉公演 ＠" location prefix,
+	// e.g. "大阪公演 @フェスティバルホール" → "フェスティバルホール". NFKC has
+	// already folded the full-width ＠ to an ASCII @ by the time this runs.
+	venuePerformancePrefixRE = regexp.MustCompile(`^.*?公演\s*@\s*`)
+
+	// venueAreaPrefixRE strips a single leading "〈admin_area〉・" prefix, e.g.
+	// "大阪・フェスティバルホール" → "フェスティバルホール". The prefix is bounded
+	// to a short token so it targets prefecture/city names and does not eat venue
+	// names that legitimately embed a middle dot.
+	venueAreaPrefixRE = regexp.MustCompile(`^[^・]{1,6}・`)
+)
+
+// NormalizeVenueName canonicalizes a scraped venue name for dedup comparison so
+// that Gemini's formatting drift across discovery runs collapses to one identity:
+// full/half-width forms are NFKC-folded, whitespace is collapsed, and a leading
+// location prefix ("大阪・…" or "大阪公演 ＠…") is stripped. It is a best-effort
+// heuristic — the event natural key `(venue_id, local_event_date, start_at)`
+// remains the DB-level safety net for anything it fails to collapse. A blank or
+// whitespace-only input returns "".
+func NormalizeVenueName(name string) string {
+	// NFKC folds full-width kana/ASCII and the full-width ＠ to canonical forms.
+	s := norm.NFKC.String(name)
+	// Collapse internal/edge whitespace so spacing drift does not defeat the match.
+	s = strings.TrimSpace(venueWhitespaceRE.ReplaceAllString(s, " "))
+	// Strip a leading "〈city〉公演 ＠" prefix before the "〈area〉・" prefix, since the
+	// former can itself contain a middle dot the latter would otherwise mis-strip.
+	s = venuePerformancePrefixRE.ReplaceAllString(s, "")
+	s = venueAreaPrefixRE.ReplaceAllString(s, "")
+	return strings.TrimSpace(s)
+}

--- a/internal/entity/venue_normalize_test.go
+++ b/internal/entity/venue_normalize_test.go
@@ -22,6 +22,23 @@ func TestNormalizeVenueName(t *testing.T) {
 			want: "フェスティバルホール",
 		},
 		{
+			name: "full-form prefecture dot prefix is stripped",
+			in:   "大阪府・フェスティバルホール",
+			want: "フェスティバルホール",
+		},
+		{
+			// A ≤6-rune FACILITY name before a middle dot must be preserved — only
+			// prefecture tokens are stripped, not any short token.
+			name: "short non-prefecture facility name before a dot is preserved",
+			in:   "東京文化会館・大ホール",
+			want: "東京文化会館・大ホール",
+		},
+		{
+			name: "another short facility name before a dot is preserved",
+			in:   "杉並公会堂・大ホール",
+			want: "杉並公会堂・大ホール",
+		},
+		{
 			name: "full-width performance prefix is stripped",
 			in:   "大阪公演 ＠フェスティバルホール",
 			want: "フェスティバルホール",

--- a/internal/entity/venue_normalize_test.go
+++ b/internal/entity/venue_normalize_test.go
@@ -1,0 +1,76 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/liverty-music/backend/internal/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeVenueName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "unprefixed name is unchanged", in: "フェスティバルホール", want: "フェスティバルホール"},
+		{
+			name: "leading admin-area dot prefix is stripped",
+			in:   "大阪・フェスティバルホール",
+			want: "フェスティバルホール",
+		},
+		{
+			name: "full-width performance prefix is stripped",
+			in:   "大阪公演 ＠フェスティバルホール",
+			want: "フェスティバルホール",
+		},
+		{
+			name: "half-width performance prefix is stripped",
+			in:   "東京公演@Zepp Tokyo",
+			want: "Zepp Tokyo",
+		},
+		{
+			name: "full-width ASCII folds to half-width",
+			in:   "Ｚｅｐｐ　Ｔｏｋｙｏ",
+			want: "Zepp Tokyo",
+		},
+		{
+			name: "whitespace is collapsed and trimmed",
+			in:   "  フェスティバル　　ホール  ",
+			want: "フェスティバル ホール",
+		},
+		{name: "blank input returns empty", in: "   ", want: ""},
+		{
+			name: "long token before a middle dot is not treated as a prefix",
+			in:   "サントリーホール・大ホール",
+			want: "サントリーホール・大ホール",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, entity.NormalizeVenueName(tt.in))
+		})
+	}
+}
+
+// TestNormalizeVenueName_DriftCollapsesButDistinctStays asserts the two
+// observed prod-drift spellings collapse to one identity while genuinely
+// different venues stay distinct.
+func TestNormalizeVenueName_DriftCollapsesButDistinctStays(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		entity.NormalizeVenueName("フェスティバルホール"),
+		entity.NormalizeVenueName("大阪・フェスティバルホール"),
+		"prefixed and unprefixed drift must collapse to the same identity",
+	)
+	assert.NotEqual(t,
+		entity.NormalizeVenueName("日本武道館"),
+		entity.NormalizeVenueName("東京国際フォーラム"),
+		"genuinely different venues must stay distinct",
+	)
+}

--- a/internal/infrastructure/database/rdb/concert_repo_test.go
+++ b/internal/infrastructure/database/rdb/concert_repo_test.go
@@ -66,7 +66,10 @@ func TestConcertRepository_Create(t *testing.T) {
 		cleanDatabase(t)
 		_, err := artistRepo.Create(ctx, &entity.Artist{ID: artistID, Name: "Concert Test Band", MBID: "aaaaaaaa-aaaa-aaaa-aaaa-f0e74f1b49a1"})
 		require.NoError(t, err)
-		require.NoError(t, venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "Concert Test Arena"}))
+		{
+			_, cErr := venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "Concert Test Arena"})
+			require.NoError(t, cErr)
+		}
 	}
 
 	t.Run("create valid concert", func(t *testing.T) {
@@ -573,7 +576,10 @@ func TestConcertRepository_CoHeadliners(t *testing.T) {
 		&entity.Artist{ID: opener, Name: "Opening Act", MBID: "33333333-4444-5555-6666-777777777ccc"},
 	)
 	require.NoError(t, err)
-	require.NoError(t, venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "Co-Headliner Arena"}))
+	{
+		_, cErr := venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "Co-Headliner Arena"})
+		require.NoError(t, cErr)
+	}
 	seriesID := seedSeries(t, ctx, seriesRepo, "Triple Bill")
 
 	_, err = concertRepo.Create(ctx, &entity.Concert{
@@ -632,7 +638,10 @@ func TestConcertRepository_PhysicalNaturalKey(t *testing.T) {
 		MBID: "44444444-5555-6666-7777-888888888ddd",
 	})
 	require.NoError(t, err)
-	require.NoError(t, venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "Shared Arena"}))
+	{
+		_, cErr := venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "Shared Arena"})
+		require.NoError(t, cErr)
+	}
 
 	seriesA := seedSeries(t, ctx, seriesRepo, "Series A")
 	seriesB := seedSeries(t, ctx, seriesRepo, "Series B")
@@ -762,7 +771,10 @@ func TestConcertRepository_ListedVenueName(t *testing.T) {
 			_, err := artistRepo.Create(ctx, artist)
 			require.NoError(t, err)
 			venue := &entity.Venue{ID: "018b2f19-e591-7d12-bf9e-f0e74f1b4bb1", Name: "VenueName Test Arena"}
-			require.NoError(t, venueRepo.Create(ctx, venue))
+			{
+				_, cErr := venueRepo.Create(ctx, venue)
+				require.NoError(t, cErr)
+			}
 
 			tt.setup(t, artist.ID, venue.ID)
 
@@ -806,7 +818,7 @@ func TestConcertRepository_ListByArtist(t *testing.T) {
 	require.NoError(t, err)
 	_, err = artistRepo.Create(ctx, testArtist2)
 	require.NoError(t, err)
-	err = venueRepo.Create(ctx, testVenue)
+	_, err = venueRepo.Create(ctx, testVenue)
 	require.NoError(t, err)
 
 	// Relative to now so the "upcoming" filter stays correct over time (a
@@ -990,7 +1002,10 @@ func TestConcertRepository_ListByArtist(t *testing.T) {
 		_, err := artistRepo.Create(ctx, artist)
 		require.NoError(t, err)
 		venue := &entity.Venue{ID: "018b2f19-e591-7d12-bf9e-f0e74f1b4bb1", Name: "VenueName Test Arena"}
-		require.NoError(t, venueRepo.Create(ctx, venue))
+		{
+			_, cErr := venueRepo.Create(ctx, venue)
+			require.NoError(t, cErr)
+		}
 
 		concertDate, _ := time.Parse("2006-01-02", "2026-12-31")
 
@@ -1022,7 +1037,10 @@ func TestConcertRepository_ListByArtist(t *testing.T) {
 		_, err := artistRepo.Create(ctx, artist)
 		require.NoError(t, err)
 		venue := &entity.Venue{ID: "018b2f19-e591-7d12-bf9e-f0e74f1b4bb1", Name: "VenueName Test Arena"}
-		require.NoError(t, venueRepo.Create(ctx, venue))
+		{
+			_, cErr := venueRepo.Create(ctx, venue)
+			require.NoError(t, cErr)
+		}
 
 		concertDate, _ := time.Parse("2006-01-02", "2026-12-31")
 
@@ -1071,7 +1089,10 @@ func TestConcertRepository_ListByArtists(t *testing.T) {
 			Name:        "Multi Venue",
 			Coordinates: &entity.Coordinates{Latitude: 33.5904, Longitude: 130.4017},
 		}
-		require.NoError(t, venueRepo.Create(ctx, venue))
+		{
+			_, cErr := venueRepo.Create(ctx, venue)
+			require.NoError(t, cErr)
+		}
 
 		concertDate, _ := time.Parse("2006-01-02", "2026-10-01")
 		startTime, _ := time.Parse("15:04", "19:00")
@@ -1133,7 +1154,10 @@ func TestConcertRepository_ListByArtists(t *testing.T) {
 		require.NoError(t, err)
 
 		venue := &entity.Venue{ID: "018b2f19-e591-7d12-bf9e-f0e74f1b6012", Name: "No Coord Venue"}
-		require.NoError(t, venueRepo.Create(ctx, venue))
+		{
+			_, cErr := venueRepo.Create(ctx, venue)
+			require.NoError(t, cErr)
+		}
 
 		concertDate, _ := time.Parse("2006-01-02", "2026-11-01")
 		sid := seedSeries(t, ctx, seriesRepo, "No Coord Concert")
@@ -1180,7 +1204,10 @@ func TestConcertRepository_ListByFollower(t *testing.T) {
 		require.NoError(t, err)
 
 		venue := &entity.Venue{ID: "018b2f19-e591-7d12-bf9e-f0e74f1b5021", Name: "Follower Test Venue"}
-		require.NoError(t, venueRepo.Create(ctx, venue))
+		{
+			_, cErr := venueRepo.Create(ctx, venue)
+			require.NoError(t, cErr)
+		}
 
 		concertDate, _ := time.Parse("2006-01-02", "2026-08-01")
 		startTime, _ := time.Parse("15:04", "19:00")
@@ -1244,7 +1271,10 @@ func TestConcertRepository_ListByFollower(t *testing.T) {
 			Name:        "Enriched Venue",
 			Coordinates: &entity.Coordinates{Latitude: 35.6894, Longitude: 139.6917},
 		}
-		require.NoError(t, venueRepo.Create(ctx, venue))
+		{
+			_, cErr := venueRepo.Create(ctx, venue)
+			require.NoError(t, cErr)
+		}
 
 		concertDate, _ := time.Parse("2006-01-02", "2026-09-01")
 		sid := seedSeries(t, ctx, seriesRepo, "Coord Concert")
@@ -1304,7 +1334,10 @@ func TestConcertRepository_List(t *testing.T) {
 		_, err := artistRepo.Create(ctx, &entity.Artist{ID: artistID, Name: "List Test Band", MBID: newTestID(t)})
 		require.NoError(t, err)
 		venueID := newTestID(t)
-		require.NoError(t, venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "List Test Arena"}))
+		{
+			_, cErr := venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "List Test Arena"})
+			require.NoError(t, cErr)
+		}
 
 		s1 := seedSeries(t, ctx, seriesRepo, "List Concert 1")
 		s2 := seedSeries(t, ctx, seriesRepo, "List Concert 2")
@@ -1355,7 +1388,10 @@ func TestConcertRepository_Delete(t *testing.T) {
 		_, err := artistRepo.Create(ctx, &entity.Artist{ID: artistID, Name: "Delete Test Band", MBID: newTestID(t)})
 		require.NoError(t, err)
 		venueID := newTestID(t)
-		require.NoError(t, venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "Delete Test Arena"}))
+		{
+			_, cErr := venueRepo.Create(ctx, &entity.Venue{ID: venueID, Name: "Delete Test Arena"})
+			require.NoError(t, cErr)
+		}
 		seriesID := seedSeries(t, ctx, seriesRepo, "Delete Test Concert")
 
 		eventID := newTestID(t)

--- a/internal/infrastructure/database/rdb/venue_repo.go
+++ b/internal/infrastructure/database/rdb/venue_repo.go
@@ -2,9 +2,14 @@ package rdb
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/liverty-music/backend/internal/entity"
+	"github.com/pannpers/go-apperr/apperr"
+	"github.com/pannpers/go-apperr/apperr/codes"
 )
 
 // VenueRepository implements entity.VenueRepository for PostgreSQL.
@@ -13,9 +18,23 @@ type VenueRepository struct {
 }
 
 const (
+	// insertVenueQuery uses an untargeted ON CONFLICT DO NOTHING so a lost race or
+	// a violation on EITHER partial-unique index (idx_venues_google_place_id or
+	// idx_venues_listed_name_admin_area) suppresses the insert instead of erroring;
+	// RETURNING id yields the new row only when the insert actually happened.
 	insertVenueQuery = `
 		INSERT INTO venues (id, name, admin_area, google_place_id, latitude, longitude, listed_venue_name)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT DO NOTHING
+		RETURNING id
+	`
+	// backfillVenuePlaceIDQuery fills a NULL google_place_id in place; the WHERE
+	// guard keeps it a no-op when another writer already set a non-NULL value.
+	backfillVenuePlaceIDQuery = `
+		UPDATE venues
+		SET google_place_id = $2
+		WHERE id = $1
+		  AND google_place_id IS NULL
 	`
 	getVenueQuery = `
 		SELECT id, name, admin_area, google_place_id, latitude, longitude, listed_venue_name
@@ -41,30 +60,84 @@ func NewVenueRepository(db *Database) *VenueRepository {
 	return &VenueRepository{db: db}
 }
 
-// Create creates a new venue in the database.
-func (r *VenueRepository) Create(ctx context.Context, venue *entity.Venue) error {
+// Create inserts a new venue and returns the id of the surviving row. It is an
+// idempotent get-or-create: the insert uses ON CONFLICT DO NOTHING, so a lost
+// race or a violation on either partial-unique index resolves to the existing
+// row instead of erroring. When the insert is suppressed, it re-SELECTs by
+// google_place_id first (the more canonical identity) and then by
+// (listed_venue_name, admin_area), returning whichever row won.
+func (r *VenueRepository) Create(ctx context.Context, venue *entity.Venue) (string, error) {
 	var lat, lng *float64
 	if venue.Coordinates != nil {
 		lat = &venue.Coordinates.Latitude
 		lng = &venue.Coordinates.Longitude
 	}
-	_, err := r.db.Pool.Exec(ctx, insertVenueQuery, venue.ID, venue.Name, venue.AdminArea, venue.GooglePlaceID, lat, lng, venue.ListedVenueName)
-	if err != nil {
-		if IsUniqueViolation(err) {
-			r.db.logger.Warn(ctx, "duplicate venue",
-				slog.String("entityType", "venue"),
-				slog.String("venueID", venue.ID),
-				slog.String("name", venue.Name),
-			)
-		}
-		return toAppErr(err, "failed to create venue", slog.String("venue_id", venue.ID), slog.String("name", venue.Name))
+
+	var id string
+	err := r.db.Pool.QueryRow(ctx, insertVenueQuery, venue.ID, venue.Name, venue.AdminArea, venue.GooglePlaceID, lat, lng, venue.ListedVenueName).Scan(&id)
+	if err == nil {
+		r.db.logger.Info(ctx, "venue created",
+			slog.String("entityType", "venue"),
+			slog.String("venueID", id),
+			slog.String("name", venue.Name),
+		)
+		return id, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return "", toAppErr(err, "failed to create venue", slog.String("venue_id", venue.ID), slog.String("name", venue.Name))
 	}
 
-	r.db.logger.Info(ctx, "venue created",
+	// ON CONFLICT suppressed the insert — another row already holds this venue's
+	// identity on one of the partial-unique indexes. Re-SELECT the survivor.
+	r.db.logger.Warn(ctx, "venue create suppressed by conflict — resolving existing row",
 		slog.String("entityType", "venue"),
 		slog.String("venueID", venue.ID),
 		slog.String("name", venue.Name),
 	)
+
+	if venue.GooglePlaceID != nil {
+		existing, selErr := r.GetByPlaceID(ctx, *venue.GooglePlaceID)
+		if selErr == nil {
+			return existing.ID, nil
+		}
+		if !errors.Is(selErr, apperr.ErrNotFound) {
+			return "", fmt.Errorf("re-select venue by place ID after conflict: %w", selErr)
+		}
+	}
+
+	if venue.ListedVenueName != nil {
+		existing, selErr := r.GetByListedName(ctx, *venue.ListedVenueName, venue.AdminArea)
+		if selErr == nil {
+			return existing.ID, nil
+		}
+		if !errors.Is(selErr, apperr.ErrNotFound) {
+			return "", fmt.Errorf("re-select venue by listed name after conflict: %w", selErr)
+		}
+	}
+
+	// The insert was suppressed but neither key found a surviving row — should be
+	// unreachable, but surface it rather than returning an empty id.
+	return "", apperr.New(codes.Internal, "venue create suppressed by conflict but no surviving row found")
+}
+
+// BackfillPlaceID sets google_place_id on a venue that currently has none. It is
+// a no-op when the row already carries a non-NULL place_id. A concurrent backfill
+// that races another writer can still collide on idx_venues_google_place_id (the
+// WHERE guard cannot be expressed as an untargeted ON CONFLICT on an UPDATE); that
+// unique violation is treated as a benign no-op — the place_id is already set.
+func (r *VenueRepository) BackfillPlaceID(ctx context.Context, venueID, placeID string) error {
+	_, err := r.db.Pool.Exec(ctx, backfillVenuePlaceIDQuery, venueID, placeID)
+	if err != nil {
+		if IsUniqueViolation(err) {
+			r.db.logger.Warn(ctx, "venue place_id backfill lost a race — leaving existing value",
+				slog.String("entityType", "venue"),
+				slog.String("venueID", venueID),
+				slog.String("place_id", placeID),
+			)
+			return nil
+		}
+		return toAppErr(err, "failed to backfill venue place ID", slog.String("venue_id", venueID), slog.String("place_id", placeID))
+	}
 	return nil
 }
 

--- a/internal/infrastructure/database/rdb/venue_repo_test.go
+++ b/internal/infrastructure/database/rdb/venue_repo_test.go
@@ -2,8 +2,10 @@ package rdb_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/infrastructure/database/rdb"
 	"github.com/pannpers/go-apperr/apperr"
@@ -59,14 +61,19 @@ func TestVenueRepository_Create(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "duplicate venue ID",
+			// Untargeted ON CONFLICT DO NOTHING also absorbs a primary-key
+			// collision; with no place_id or listed_venue_name to re-SELECT on,
+			// there is no surviving natural-key row to return, so Create surfaces
+			// Internal rather than silently returning an empty id. (A real UUIDv7
+			// never collides, so this only guards the degenerate path.)
+			name: "duplicate venue ID with no natural key",
 			args: args{
 				venue: &entity.Venue{
 					ID:   "018b2f19-e591-7d12-bf9e-f0e74f1b49e1",
 					Name: "Duplicate Arena",
 				},
 			},
-			wantErr: apperr.ErrAlreadyExists,
+			wantErr: apperr.ErrInternal,
 		},
 		{
 			name: "empty venue name",
@@ -82,7 +89,7 @@ func TestVenueRepository_Create(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := repo.Create(ctx, tt.args.venue)
+			_, err := repo.Create(ctx, tt.args.venue)
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
 				return
@@ -101,14 +108,20 @@ func TestVenueRepository_Get(t *testing.T) {
 		ID:   "018b2f19-e591-7d12-bf9e-f0e74f1b49e3",
 		Name: "Get Test Arena",
 	}
-	require.NoError(t, repo.Create(ctx, testVenue))
+	{
+		_, cErr := repo.Create(ctx, testVenue)
+		require.NoError(t, cErr)
+	}
 
 	testVenueWithAdminArea := &entity.Venue{
 		ID:        "018b2f19-e591-7d12-bf9e-f0e74f1b49e6",
 		Name:      "Zepp Tokyo",
 		AdminArea: new("JP-13"),
 	}
-	require.NoError(t, repo.Create(ctx, testVenueWithAdminArea))
+	{
+		_, cErr := repo.Create(ctx, testVenueWithAdminArea)
+		require.NoError(t, cErr)
+	}
 
 	tests := []struct {
 		name    string
@@ -183,7 +196,10 @@ func TestVenueRepository_GetByListedName(t *testing.T) {
 		GooglePlaceID:   new("ChIJbudokan001"),
 		ListedVenueName: &listedName,
 	}
-	require.NoError(t, repo.Create(ctx, seededWithArea))
+	{
+		_, cErr := repo.Create(ctx, seededWithArea)
+		require.NoError(t, cErr)
+	}
 
 	// Seed: venue with listed_venue_name and NULL admin_area.
 	listedNameNoArea := "Zepp DiverCity"
@@ -193,7 +209,10 @@ func TestVenueRepository_GetByListedName(t *testing.T) {
 		GooglePlaceID:   new("ChIJzepp001"),
 		ListedVenueName: &listedNameNoArea,
 	}
-	require.NoError(t, repo.Create(ctx, seededNoArea))
+	{
+		_, cErr := repo.Create(ctx, seededNoArea)
+		require.NoError(t, cErr)
+	}
 
 	type args struct {
 		listedVenueName string
@@ -253,7 +272,10 @@ func TestVenueRepository_GetByPlaceID(t *testing.T) {
 		Name:          "Place ID Test Arena",
 		GooglePlaceID: new("ChIJtest456"),
 	}
-	require.NoError(t, repo.Create(ctx, seededVenue))
+	{
+		_, cErr := repo.Create(ctx, seededVenue)
+		require.NoError(t, cErr)
+	}
 
 	type args struct {
 		placeID string
@@ -294,4 +316,140 @@ func TestVenueRepository_GetByPlaceID(t *testing.T) {
 			assert.Equal(t, *tt.want.GooglePlaceID, *got.GooglePlaceID)
 		})
 	}
+}
+
+// countVenuesByListedName returns how many venue rows carry the given
+// listed_venue_name — used to assert get-or-create never splits a venue.
+func countVenuesByListedName(t *testing.T, ctx context.Context, listedName string) int {
+	t.Helper()
+	var n int
+	err := testDB.Pool.QueryRow(ctx,
+		"SELECT count(*) FROM venues WHERE listed_venue_name = $1", listedName).Scan(&n)
+	require.NoError(t, err)
+	return n
+}
+
+func TestVenueRepository_Create_GetOrCreate(t *testing.T) {
+	cleanDatabase(t)
+	repo := rdb.NewVenueRepository(testDB)
+	ctx := context.Background()
+
+	// A physical venue that Google Places resolved with two different CIDs across
+	// discovery runs (the observed 和歌山ビッグホエール case).
+	const listedName = "和歌山ビッグホエール"
+	existing := &entity.Venue{
+		ID:              "018b2f19-e591-7d12-bf9e-f0e74f1b4a01",
+		Name:            "Wakayama Big Whale",
+		AdminArea:       new("JP-30"),
+		GooglePlaceID:   new("CID-A"),
+		ListedVenueName: new(listedName),
+	}
+	firstID, err := repo.Create(ctx, existing)
+	require.NoError(t, err)
+	assert.Equal(t, existing.ID, firstID)
+
+	t.Run("different place_id resolves to the existing row", func(t *testing.T) {
+		// Same (listed_venue_name, admin_area) but a DIFFERENT place_id — the
+		// insert conflicts on idx_venues_listed_name_admin_area and re-SELECTs.
+		gotID, err := repo.Create(ctx, &entity.Venue{
+			ID:              "018b2f19-e591-7d12-bf9e-f0e74f1b4a02",
+			Name:            "Wakayama Big Whale (dup)",
+			AdminArea:       new("JP-30"),
+			GooglePlaceID:   new("CID-B"),
+			ListedVenueName: new(listedName),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, existing.ID, gotID)
+		assert.Equal(t, 1, countVenuesByListedName(t, ctx, listedName))
+	})
+}
+
+func TestVenueRepository_Create_ConcurrentSingleRow(t *testing.T) {
+	cleanDatabase(t)
+	repo := rdb.NewVenueRepository(testDB)
+	ctx := context.Background()
+
+	const listedName = "Concurrent Hall"
+	const n = 8
+	ids := make([]string, n)
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Distinct primary keys, identical (listed_venue_name, admin_area),
+			// no place_id: exactly one insert wins; the rest re-SELECT the winner.
+			id, err := repo.Create(ctx, &entity.Venue{
+				ID:              uuid.Must(uuid.NewV7()).String(),
+				Name:            "Concurrent Hall Canonical",
+				AdminArea:       new("JP-13"),
+				ListedVenueName: new(listedName),
+			})
+			ids[i] = id
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range n {
+		require.NoError(t, errs[i])
+		assert.Equal(t, ids[0], ids[i], "every concurrent create must resolve to the same surviving row")
+	}
+	assert.Equal(t, 1, countVenuesByListedName(t, ctx, listedName))
+}
+
+func TestVenueRepository_BackfillPlaceID(t *testing.T) {
+	cleanDatabase(t)
+	repo := rdb.NewVenueRepository(testDB)
+	ctx := context.Background()
+
+	t.Run("fills a NULL place_id and never overwrites a non-NULL one", func(t *testing.T) {
+		v := &entity.Venue{
+			ID:              "018b2f19-e591-7d12-bf9e-f0e74f1b4b01",
+			Name:            "Backfill Hall",
+			ListedVenueName: new("Backfill Hall Listed"),
+		}
+		_, err := repo.Create(ctx, v)
+		require.NoError(t, err)
+
+		require.NoError(t, repo.BackfillPlaceID(ctx, v.ID, "CID-FILL"))
+		got, err := repo.Get(ctx, v.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.GooglePlaceID)
+		assert.Equal(t, "CID-FILL", *got.GooglePlaceID)
+
+		// Second backfill is a no-op: the WHERE guard skips a non-NULL row.
+		require.NoError(t, repo.BackfillPlaceID(ctx, v.ID, "CID-OTHER"))
+		got, err = repo.Get(ctx, v.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.GooglePlaceID)
+		assert.Equal(t, "CID-FILL", *got.GooglePlaceID)
+	})
+
+	t.Run("degrades to a no-op when the place_id already belongs to another venue", func(t *testing.T) {
+		owner := &entity.Venue{
+			ID:              "018b2f19-e591-7d12-bf9e-f0e74f1b4b02",
+			Name:            "Owner Hall",
+			GooglePlaceID:   new("CID-TAKEN"),
+			ListedVenueName: new("Owner Hall Listed"),
+		}
+		_, err := repo.Create(ctx, owner)
+		require.NoError(t, err)
+
+		orphan := &entity.Venue{
+			ID:              "018b2f19-e591-7d12-bf9e-f0e74f1b4b03",
+			Name:            "Orphan Hall",
+			ListedVenueName: new("Orphan Hall Listed"),
+		}
+		_, err = repo.Create(ctx, orphan)
+		require.NoError(t, err)
+
+		// Backfilling the taken place_id would violate idx_venues_google_place_id;
+		// the unique violation is swallowed and the orphan keeps its NULL place_id.
+		require.NoError(t, repo.BackfillPlaceID(ctx, orphan.ID, "CID-TAKEN"))
+		got, err := repo.Get(ctx, orphan.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got.GooglePlaceID)
+	})
 }

--- a/internal/usecase/concert_admin_uc.go
+++ b/internal/usecase/concert_admin_uc.go
@@ -275,10 +275,25 @@ func (uc *concertUseCase) Reject(ctx context.Context, stagedID string, reason st
 	return nil
 }
 
-// resolveOrCreateVenue finds an existing venues row by place_id (or listed
-// name when unresolved) or creates a new one from the staged resolved fields.
-// Returns the venues.id to use for event insertion.
+// resolveVenueAdminArea derives the admin_area used for BOTH the
+// (listed_venue_name, admin_area) lookup and the venue insert, preferring the
+// Places-resolved value and falling back to the Gemini-extracted scraped value.
+// The lookup and insert MUST use the same derivation, else a miss-then-collide
+// asymmetry re-appears (lookup on the raw value, insert on the resolved value).
+func resolveVenueAdminArea(sc *entity.StagedConcert) *string {
+	if sc.ResolvedAdminArea != nil {
+		return sc.ResolvedAdminArea
+	}
+	return sc.AdminArea
+}
+
+// resolveOrCreateVenue is an idempotent get-or-create over the venues row,
+// place_id-authoritative: resolve by place_id, then by (listed_venue_name,
+// admin_area), and only create when neither matches. Returns the venues.id to
+// use for event insertion.
 func (uc *concertUseCase) resolveOrCreateVenue(ctx context.Context, sc *entity.StagedConcert) (string, error) {
+	adminArea := resolveVenueAdminArea(sc)
+
 	// Step 1: if the venue was resolved via Google Places at staging time, look
 	// up an existing venues row by place_id first.
 	if sc.ResolvedPlaceID != nil {
@@ -289,21 +304,30 @@ func (uc *concertUseCase) resolveOrCreateVenue(ctx context.Context, sc *entity.S
 		if !errors.Is(err, apperr.ErrNotFound) {
 			return "", fmt.Errorf("get venue by place ID: %w", err)
 		}
-		// Not found — create a new venues row from the staged resolved fields.
-		return uc.createVenueFromStaged(ctx, sc)
+		// place_id miss: fall through to the listed-name lookup. Google Places can
+		// return a DIFFERENT place_id for a venue that already exists under
+		// (listed_venue_name, admin_area), so creating here would collide on
+		// idx_venues_listed_name_admin_area (the observed 和歌山ビッグホエール case).
 	}
 
-	// Step 2: unresolved venue — try to find by listed name.
-	existing, err := uc.venueRepo.GetByListedName(ctx, sc.ListedVenueName, sc.AdminArea)
+	// Step 2: look up by (listed_venue_name, admin_area).
+	existing, err := uc.venueRepo.GetByListedName(ctx, sc.ListedVenueName, adminArea)
 	if err == nil {
+		// Backfill place_id when the found venue lacks one and the staged row
+		// carries a resolved value — never overwrite a non-NULL place_id.
+		if sc.ResolvedPlaceID != nil && existing.GooglePlaceID == nil {
+			if err := uc.venueRepo.BackfillPlaceID(ctx, existing.ID, *sc.ResolvedPlaceID); err != nil {
+				return "", fmt.Errorf("backfill venue place ID: %w", err)
+			}
+		}
 		return existing.ID, nil
 	}
 	if !errors.Is(err, apperr.ErrNotFound) {
 		return "", fmt.Errorf("get venue by listed name: %w", err)
 	}
 
-	// No existing venue found and no resolved place ID — create a minimal
-	// venues row with only the raw listed name.
+	// Step 3: neither key matched — create. Create absorbs a concurrent-insert
+	// conflict on either index and re-SELECTs the survivor.
 	return uc.createVenueFromStaged(ctx, sc)
 }
 
@@ -322,17 +346,10 @@ func (uc *concertUseCase) createVenueFromStaged(ctx context.Context, sc *entity.
 		name = *sc.ResolvedVenueName
 	}
 
-	// Prefer the resolved admin area when available; fall back to the
-	// Gemini-extracted scraped value so admin_area is never silently lost.
-	adminArea := sc.AdminArea
-	if sc.ResolvedAdminArea != nil {
-		adminArea = sc.ResolvedAdminArea
-	}
-
 	venue := &entity.Venue{
 		ID:              id.String(),
 		Name:            name,
-		AdminArea:       adminArea,
+		AdminArea:       resolveVenueAdminArea(sc),
 		GooglePlaceID:   sc.ResolvedPlaceID,
 		ListedVenueName: &sc.ListedVenueName,
 	}
@@ -343,16 +360,19 @@ func (uc *concertUseCase) createVenueFromStaged(ctx context.Context, sc *entity.
 		}
 	}
 
-	if err := uc.venueRepo.Create(ctx, venue); err != nil {
+	// Create returns the surviving row id: the one we generated on a real insert,
+	// or an existing row's id when a concurrent create won the race.
+	venueID, err := uc.venueRepo.Create(ctx, venue)
+	if err != nil {
 		return "", fmt.Errorf("create venue from staged concert: %w", err)
 	}
 
 	uc.logger.Info(ctx, "created venue from staged concert",
-		slog.String("venue_id", venue.ID),
+		slog.String("venue_id", venueID),
 		slog.String("venue_name", name),
 	)
 
-	return venue.ID, nil
+	return venueID, nil
 }
 
 // stagedToScraped converts a StagedConcert back into a ScrapedConcert so the

--- a/internal/usecase/concert_admin_uc_test.go
+++ b/internal/usecase/concert_admin_uc_test.go
@@ -223,6 +223,121 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 		assert.Equal(t, "venue-existing", d.concertRepo.created[0].VenueID)
 	})
 
+	t.Run("approve resolves an existing venue by listed name when place_id differs", func(t *testing.T) {
+		t.Parallel()
+		d := newApprovalTestDeps(t, artist)
+		// Existing venue already carries a place_id (P1) — Google Places resolved a
+		// DIFFERENT place_id (P2) for the same physical venue on this discovery.
+		existingPlaceID := "place-P1"
+		existingVenue := &entity.Venue{
+			ID:              "venue-existing",
+			Name:            "Venue ABC Canonical",
+			AdminArea:       new("JP-27"),
+			GooglePlaceID:   &existingPlaceID,
+			ListedVenueName: new("Venue ABC"),
+		}
+		d.venueRepo.venues["Venue ABC Canonical"] = existingVenue
+
+		differentPlaceID := "place-P2"
+		venueName := "Venue ABC Canonical"
+		sc := &entity.StagedConcert{
+			ID:                "staged-diff-placeid",
+			ArtistID:          artist.ID,
+			Title:             "Approval Test Concert",
+			LocalDate:         time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			ListedVenueName:   "Venue ABC",
+			AdminArea:         new("JP-27"),
+			ResolvedPlaceID:   &differentPlaceID,
+			ResolvedVenueName: &venueName,
+			ResolvedAdminArea: new("JP-27"),
+		}
+		d.stagedRepo.upserted = append(d.stagedRepo.upserted, sc)
+
+		err := d.uc.Approve(context.Background(), sc.ID)
+		require.NoError(t, err)
+
+		// Venue was reused via the listed-name fallback, not re-created.
+		assert.Empty(t, d.venueRepo.created)
+		require.Len(t, d.concertRepo.created, 1)
+		assert.Equal(t, "venue-existing", d.concertRepo.created[0].VenueID)
+		// A non-NULL place_id is never overwritten by the backfill.
+		require.NotNil(t, existingVenue.GooglePlaceID)
+		assert.Equal(t, "place-P1", *existingVenue.GooglePlaceID)
+	})
+
+	t.Run("approve backfills a NULL place_id on the resolved venue", func(t *testing.T) {
+		t.Parallel()
+		d := newApprovalTestDeps(t, artist)
+		// Existing venue was created before Places resolution — its place_id is NULL.
+		existingVenue := &entity.Venue{
+			ID:              "venue-existing",
+			Name:            "Venue ABC Canonical",
+			AdminArea:       new("JP-27"),
+			ListedVenueName: new("Venue ABC"),
+		}
+		d.venueRepo.venues["Venue ABC Canonical"] = existingVenue
+
+		resolvedPlaceID := "place-P2"
+		venueName := "Venue ABC Canonical"
+		sc := &entity.StagedConcert{
+			ID:                "staged-backfill",
+			ArtistID:          artist.ID,
+			Title:             "Approval Test Concert",
+			LocalDate:         time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			ListedVenueName:   "Venue ABC",
+			AdminArea:         new("JP-27"),
+			ResolvedPlaceID:   &resolvedPlaceID,
+			ResolvedVenueName: &venueName,
+			ResolvedAdminArea: new("JP-27"),
+		}
+		d.stagedRepo.upserted = append(d.stagedRepo.upserted, sc)
+
+		err := d.uc.Approve(context.Background(), sc.ID)
+		require.NoError(t, err)
+
+		// Venue reused, and its NULL place_id was backfilled from the staged row.
+		assert.Empty(t, d.venueRepo.created)
+		require.NotNil(t, existingVenue.GooglePlaceID)
+		assert.Equal(t, "place-P2", *existingVenue.GooglePlaceID)
+	})
+
+	t.Run("approve uses the resolved admin_area symmetrically for the listed-name lookup", func(t *testing.T) {
+		t.Parallel()
+		d := newApprovalTestDeps(t, artist)
+		// Existing venue lives under the RESOLVED admin_area (JP-27).
+		existingVenue := &entity.Venue{
+			ID:              "venue-existing",
+			Name:            "Venue ABC Canonical",
+			AdminArea:       new("JP-27"),
+			ListedVenueName: new("Venue ABC"),
+		}
+		d.venueRepo.venues["Venue ABC Canonical"] = existingVenue
+
+		// Staged row's raw admin_area (JP-99) disagrees with the resolved one
+		// (JP-27); the lookup MUST use the resolved value to find the venue. No
+		// place_id is set so resolution goes straight to the listed-name lookup.
+		venueName := "Venue ABC Canonical"
+		sc := &entity.StagedConcert{
+			ID:                "staged-admin-symmetry",
+			ArtistID:          artist.ID,
+			Title:             "Approval Test Concert",
+			LocalDate:         time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			ListedVenueName:   "Venue ABC",
+			AdminArea:         new("JP-99"),
+			ResolvedVenueName: &venueName,
+			ResolvedAdminArea: new("JP-27"),
+		}
+		d.stagedRepo.upserted = append(d.stagedRepo.upserted, sc)
+
+		err := d.uc.Approve(context.Background(), sc.ID)
+		require.NoError(t, err)
+
+		// Reused via the resolved admin_area, not re-created under the raw one.
+		assert.Empty(t, d.venueRepo.created)
+		require.Len(t, d.concertRepo.created, 1)
+		assert.Equal(t, "venue-existing", d.concertRepo.created[0].VenueID)
+	})
+
 	t.Run("CONCERT.created is published ONLY from Approve, never from CreateFromDiscovered", func(t *testing.T) {
 		t.Parallel()
 		// This test verifies the architectural guarantee: the discovery path

--- a/internal/usecase/concert_creation_uc_test.go
+++ b/internal/usecase/concert_creation_uc_test.go
@@ -28,9 +28,22 @@ func newFakeVenueRepo() *fakeVenueRepo {
 	return &fakeVenueRepo{venues: make(map[string]*entity.Venue)}
 }
 
-func (r *fakeVenueRepo) Create(_ context.Context, v *entity.Venue) error {
+func (r *fakeVenueRepo) Create(_ context.Context, v *entity.Venue) (string, error) {
 	r.venues[v.Name] = v
 	r.created = append(r.created, v)
+	return v.ID, nil
+}
+
+func (r *fakeVenueRepo) BackfillPlaceID(_ context.Context, venueID, placeID string) error {
+	for _, v := range r.venues {
+		if v.ID == venueID {
+			if v.GooglePlaceID == nil {
+				pid := placeID
+				v.GooglePlaceID = &pid
+			}
+			return nil
+		}
+	}
 	return nil
 }
 

--- a/internal/usecase/concert_uc.go
+++ b/internal/usecase/concert_uc.go
@@ -322,17 +322,18 @@ func (uc *concertUseCase) executeSearch(ctx context.Context, artistID string) (r
 	)
 	filterSpan.End()
 
-	// Further deduplicate against pending staged rows. The staged dedup key
-	// uses (local_date, listed_venue_name) — the raw discovery-time identity —
-	// matching FilterNew's semantics.
+	// Further deduplicate against pending staged rows. The staged dedup key uses
+	// (local_date, normalized listed_venue_name), matching FilterNew's semantics:
+	// the venue name is compared through entity.NormalizeVenueName on both sides so
+	// name drift across runs does not re-stage an already-pending concert.
 	if len(pendingKeys) > 0 {
 		pendingSet := make(map[string]bool, len(pendingKeys))
 		for _, k := range pendingKeys {
-			pendingSet[k.LocalDate.Format("2006-01-02")+"|"+k.ListedVenueName] = true
+			pendingSet[k.LocalDate.Format("2006-01-02")+"|"+entity.NormalizeVenueName(k.ListedVenueName)] = true
 		}
 		filtered := newScraped[:0]
 		for _, sc := range newScraped {
-			if pendingSet[sc.LocalDate.Format("2006-01-02")+"|"+sc.ListedVenueName] {
+			if pendingSet[sc.LocalDate.Format("2006-01-02")+"|"+entity.NormalizeVenueName(sc.ListedVenueName)] {
 				continue
 			}
 			filtered = append(filtered, sc)

--- a/internal/usecase/concert_uc_test.go
+++ b/internal/usecase/concert_uc_test.go
@@ -935,6 +935,48 @@ func TestSearchNewConcerts_StagedDedup(t *testing.T) {
 		})
 	})
 
+	t.Run("drifted venue name still matches a pending staged key via normalization", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			d := newConcertTestDeps(t)
+
+			// The pending staged row was captured under the canonical name; this
+			// run's scrape drifted to a prefixed spelling of the same venue.
+			pendingKey := entity.StagedConcertDedupKey{
+				LocalDate:       concertDate,
+				ListedVenueName: "フェスティバルホール",
+			}
+
+			scraped := []*entity.ScrapedConcert{
+				// Same physical venue, drifted name — must be excluded via normalization.
+				{Title: "Drifted Staged", ListedVenueName: "大阪・フェスティバルホール", LocalDate: concertDate, SourceURL: "https://example.com/a"},
+				// Genuinely new — must pass.
+				{Title: "New Show", ListedVenueName: "Osaka Hall", LocalDate: concertDate, SourceURL: "https://example.com/b"},
+			}
+
+			sub, err := d.publisher.Subscribe(ctx, entity.SubjectConcertDiscovered)
+			require.NoError(t, err)
+
+			d.searchLogRepo.EXPECT().GetByArtistID(ctx, artistID).Return(nil, apperr.ErrNotFound).Once()
+			d.searchLogRepo.EXPECT().Upsert(ctx, artistID, entity.SearchLogStatusPending).Return(nil).Once()
+			d.artistRepo.EXPECT().Get(ctx, artistID).Return(artist, nil).Once()
+			d.artistRepo.EXPECT().GetOfficialSite(ctx, artistID).Return(nil, apperr.ErrNotFound).Once()
+			d.concertRepo.EXPECT().ListByArtist(ctx, artistID, true).Return(nil, nil).Once()
+			d.stagedConcertRepo.EXPECT().ListPendingDedupKeysByArtist(mock.Anything, artistID).
+				Return([]entity.StagedConcertDedupKey{pendingKey}, nil).Once()
+			d.searcher.EXPECT().Search(mock.Anything, artist, (*entity.OfficialSite)(nil), mock.AnythingOfType("time.Time")).
+				Return(scraped, nil).Once()
+			d.searchLogRepo.EXPECT().UpdateStatus(mock.Anything, artistID, entity.SearchLogStatusCompleted).Return(nil).Once()
+			d.searchLogRepo.EXPECT().MarkFound(mock.Anything, artistID).Return(nil).Once()
+
+			_, err = d.uc.SearchNewConcerts(ctx, artistID)
+			require.NoError(t, err)
+
+			got := receivePublishedConcerts(t, ctx, sub)
+			assert.Equal(t, 1, got, "drifted-name re-discovery must dedup against the pending staged row; only the new show publishes")
+		})
+	})
+
 	t.Run("pending staged keys do not suppress rejected concerts (rejection log not consulted)", func(t *testing.T) {
 		t.Parallel()
 		synctest.Test(t, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Backend-only fixes (no proto dependency) for OpenSpec change `fix-concert-approval-dedup`, phase A-1 + B. Approving AI-discovered concerts in the admin console crashed with `already_exists` and dead-ended with `failed_precondition` because dedup and venue identity were keyed on values that drift across discovery runs. This PR removes both failure modes at the discovery/approval layer; the reviewer-facing reconciliation dialog (A-2, schema change) follows separately after BSR codegen.

## Changes

### A-1 — Venue resolution is idempotent get-or-create
- `resolveOrCreateVenue` resolves by `google_place_id` first, then falls back to `(listed_venue_name, admin_area)` on a place_id miss. Google Places returns different `place_id`s for the same physical venue (和歌山ビッグホエール has two CIDs), so creating on that miss previously collided on `idx_venues_listed_name_admin_area`.
- `VenueRepository.Create` now inserts via an **untargeted** `ON CONFLICT DO NOTHING` and re-SELECTs the surviving row (by `google_place_id`, then `(listed_venue_name, admin_area)`), returning its id — a lost race or a violation on either partial-unique index resolves to the existing row instead of erroring.
- A NULL `google_place_id` is backfilled from the staged row via `BackfillPlaceID`; a non-NULL value is never overwritten (a concurrent-backfill unique violation degrades to a no-op).
- The `admin_area` used for the lookup and the insert is derived identically (`resolved_admin_area ?? admin_area`), removing the miss-then-collide asymmetry.

### B — Discovery dedup tolerates venue-name drift
- New `entity.NormalizeVenueName`: NFKC full/half-width fold, whitespace collapse, and stripping of leading location prefixes (`大阪・`, `大阪公演 ＠`).
- Applied on **both** sides of the venue-name comparison in `entity.ScrapedConcerts.FilterNew` and the pending-staged dedup in `SearchNewConcerts`, so `フェスティバルホール` vs `大阪・フェスティバルホール` no longer re-stages a known concert. The `(local_event_date, start_at)` key components are unchanged.

No DB migration (all constraints/indexes already exist).

## Testing

- `make check` green (golangci-lint + schema-lint + modernize + unit + integration).
- New venue repo integration tests: different place_id → existing row; concurrent create → single row; NULL-only backfill (incl. taken-place_id no-op).
- New usecase tests: place_id-miss listed-name fallback, admin_area symmetry, NULL-only backfill.
- New unit tests: `NormalizeVenueName` drift cases; `FilterNew` and pending-staged dedup collapse drifted names while keeping genuinely different venues distinct.

## Related

Refs: liverty-music/specification#703
