### PR TITLE
feat(concert): reconcile duplicate events at admin approval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ tool (
 )
 
 require (
-	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260630020701-1957d02b08e6.1
-	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260630020701-1957d02b08e6.1
+	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260725094030-77573c77fc22.1
+	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260725094030-77573c77fc22.1
 	cloud.google.com/go/cloudsqlconn v1.20.0
 	connectrpc.com/authn v0.2.0
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,10 @@ buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57
 buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57e197.1/go.mod h1:eGjb9P6sl1irS46NKyXnxkyozT2aWs3BF4tbYWQuCsw=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1 h1:q+tABqEH2Cpcp8fO9TBZlvKok7zorHGy+/UyywXaAKo=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1/go.mod h1:Y3m+VD8IH6JTgnFYggPHvFul/ry6dL3QDliy8xH7610=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260630020701-1957d02b08e6.1 h1:vLyw4aY9KnNRVH/FJJCx3aTcLF0Hgn94HAERrWmeXm0=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260630020701-1957d02b08e6.1/go.mod h1:iZokqCGRrVPlbLoXHFJ/m72G7E2QXOP2aKQzN+q0woM=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260630020701-1957d02b08e6.1 h1:cTAZiI72uGes2Hkkq41i2V1Mu8bXztMprK/LQETYGZg=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260630020701-1957d02b08e6.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260725094030-77573c77fc22.1 h1:mHFVm7yAwNBYgMg1T3/GG2PyjQXJEH1FD69tH6Lj+ic=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260725094030-77573c77fc22.1/go.mod h1:vJtRnp1rv8v6XcOyqzD+bR1DABbSlVbFTChrRnUeT04=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260725094030-77573c77fc22.1 h1:orS/WsJCVxmNgXFQgWgZB5ShVtEgnWljNxebD8omLq0=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260725094030-77573c77fc22.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1 h1:KuP+b+in6LGh2ukof5KgDCD8hPXotEq6EVOo13Wg1pE=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1/go.mod h1:dV1Kz6zdmyXt7QWm5OXby44OFpyLemllUDBUG5HMLio=
 buf.build/go/app v0.1.0 h1:nlqD/h0rhIN73ZoiDElprrPiO2N6JV+RmNK34K29Ihg=

--- a/internal/adapter/rpc/admin_concert_handler.go
+++ b/internal/adapter/rpc/admin_concert_handler.go
@@ -4,12 +4,14 @@ import (
 	"context"
 
 	adminv1connect "buf.build/gen/go/liverty-music/schema/connectrpc/go/liverty_music/rpc/admin/v1/adminv1connect"
+	entityv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/entity/v1"
 	adminv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/rpc/admin/v1"
 	"connectrpc.com/connect"
 	"github.com/liverty-music/backend/internal/adapter/rpc/mapper"
 	"github.com/liverty-music/backend/internal/infrastructure/auth"
 	"github.com/liverty-music/backend/internal/usecase"
 	"github.com/pannpers/go-logging/logging"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Compile-time check that AdminConcertHandler implements the generated service interface.
@@ -73,19 +75,75 @@ func (h *AdminConcertHandler) ListPending(
 	}), nil
 }
 
-// Approve promotes a pending staged concert to a published event.
-// The operation is idempotent: if the staged row is already gone the method
-// returns success without creating a duplicate.
+// Approve promotes a pending staged concert to a published event. When the staged
+// concert duplicates an existing event and no resolution was chosen, the response
+// carries a DuplicateConflict and no state is mutated; the console then re-calls
+// Approve with a resolution. The operation is idempotent on a missing staged row.
 func (h *AdminConcertHandler) Approve(
 	ctx context.Context,
 	req *connect.Request[adminv1.ApproveRequest],
 ) (*connect.Response[adminv1.ApproveResponse], error) {
+	// Reviewer identity is captured from the admin JWT (as in Reject) so a
+	// keep-existing reconciliation can attribute the rejection-log entry.
+	claims, ok := auth.GetClaims(ctx)
+	reviewerSub := ""
+	if ok && claims != nil {
+		reviewerSub = claims.Sub
+	}
+
 	stagedID := req.Msg.GetStagedId().GetValue()
-	if err := h.concertUseCase.Approve(ctx, stagedID); err != nil {
+	resolution := approveResolutionFromProto(req.Msg.GetResolution())
+
+	result, err := h.concertUseCase.Approve(ctx, stagedID, resolution, reviewerSub)
+	if err != nil {
 		return nil, err
 	}
 
-	return connect.NewResponse(&adminv1.ApproveResponse{}), nil
+	resp := &adminv1.ApproveResponse{}
+	if result != nil && result.Conflict != nil {
+		resp.Conflict = duplicateConflictToProto(result.Conflict)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// approveResolutionFromProto maps the generated Resolution enum to the usecase's
+// resolution selector, defaulting to Unspecified for unknown values.
+func approveResolutionFromProto(r adminv1.Resolution) usecase.ApproveResolution {
+	switch r {
+	case adminv1.Resolution_RESOLUTION_KEEP_EXISTING:
+		return usecase.ApproveResolutionKeepExisting
+	case adminv1.Resolution_RESOLUTION_ADOPT_STAGED:
+		return usecase.ApproveResolutionAdoptStaged
+	default:
+		return usecase.ApproveResolutionUnspecified
+	}
+}
+
+// duplicateConflictToProto maps a usecase DuplicateConflict to the wire message:
+// the existing event's display fields plus the staged concert preview.
+func duplicateConflictToProto(dc *usecase.DuplicateConflict) *adminv1.DuplicateConflict {
+	return &adminv1.DuplicateConflict{
+		Existing: existingEventToProto(dc.Existing),
+		Staged:   mapper.PendingConcertToProto(dc.Staged, dc.StagedPerformer),
+	}
+}
+
+// existingEventToProto maps the existing-event display DTO to its wire message.
+// Optional start/open times are omitted when unset.
+func existingEventToProto(e *usecase.ExistingEventDisplay) *adminv1.ExistingEvent {
+	proto := &adminv1.ExistingEvent{
+		EventId:         &entityv1.EventId{Value: e.EventID},
+		Title:           &entityv1.Title{Value: e.Title},
+		ListedVenueName: &entityv1.ListedVenueName{Value: e.ListedVenueName},
+		LocalDate:       &entityv1.LocalDate{Value: mapper.TimeToDate(e.LocalDate)},
+	}
+	if e.StartTime != nil {
+		proto.StartTime = &entityv1.StartTime{Value: timestamppb.New(*e.StartTime)}
+	}
+	if e.OpenTime != nil {
+		proto.OpenTime = &entityv1.OpenTime{Value: timestamppb.New(*e.OpenTime)}
+	}
+	return proto
 }
 
 // Reject drops a pending staged concert and records the rejection with the

--- a/internal/adapter/rpc/admin_concert_handler_test.go
+++ b/internal/adapter/rpc/admin_concert_handler_test.go
@@ -289,7 +289,8 @@ func TestAdminConcertHandler_Approve(t *testing.T) {
 			args: args{ctx: adminCtx(), stagedID: "staged-abc"},
 			dep: dep{
 				adminUC: func(m *usecasemocks.MockAdminConcertUseCase) {
-					m.EXPECT().Approve(mock.Anything, "staged-abc").Return(nil).Once()
+					m.EXPECT().Approve(mock.Anything, "staged-abc", usecase.ApproveResolutionUnspecified, mock.Anything).
+						Return(&usecase.ApproveResult{}, nil).Once()
 				},
 			},
 		},

--- a/internal/entity/concert.go
+++ b/internal/entity/concert.go
@@ -394,6 +394,11 @@ type ConcertRepository interface {
 	// The three slices are zipped element-wise; a nil time leaves the column
 	// unchanged. Idempotent: a no-op when eventIDs is empty.
 	FillEventStartTimes(ctx context.Context, eventIDs []string, startTimes, openTimes []*time.Time) error
+	// UpdateEventListedVenueName overwrites the listed_venue_name display field of
+	// an existing event. Used by the admin approval "adopt staged" reconciliation
+	// to replace the stored display name with the staged row's, leaving venue_id
+	// and google_place_id untouched. Idempotent on a missing id (no-op success).
+	UpdateEventListedVenueName(ctx context.Context, eventID string, listedVenueName string) error
 	// List retrieves every published concert with Series, Venue, and Performers
 	// hydrated, ordered by local_event_date ascending. Unlike ListByArtist /
 	// ListByFollower it applies no audience filter — it returns the whole

--- a/internal/entity/mocks/mock_ConcertRepository.go
+++ b/internal/entity/mocks/mock_ConcertRepository.go
@@ -548,6 +548,54 @@ func (_c *MockConcertRepository_ListByIDs_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// UpdateEventListedVenueName provides a mock function with given fields: ctx, eventID, listedVenueName
+func (_m *MockConcertRepository) UpdateEventListedVenueName(ctx context.Context, eventID string, listedVenueName string) error {
+	ret := _m.Called(ctx, eventID, listedVenueName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateEventListedVenueName")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, eventID, listedVenueName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockConcertRepository_UpdateEventListedVenueName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateEventListedVenueName'
+type MockConcertRepository_UpdateEventListedVenueName_Call struct {
+	*mock.Call
+}
+
+// UpdateEventListedVenueName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - eventID string
+//   - listedVenueName string
+func (_e *MockConcertRepository_Expecter) UpdateEventListedVenueName(ctx interface{}, eventID interface{}, listedVenueName interface{}) *MockConcertRepository_UpdateEventListedVenueName_Call {
+	return &MockConcertRepository_UpdateEventListedVenueName_Call{Call: _e.mock.On("UpdateEventListedVenueName", ctx, eventID, listedVenueName)}
+}
+
+func (_c *MockConcertRepository_UpdateEventListedVenueName_Call) Run(run func(ctx context.Context, eventID string, listedVenueName string)) *MockConcertRepository_UpdateEventListedVenueName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockConcertRepository_UpdateEventListedVenueName_Call) Return(_a0 error) *MockConcertRepository_UpdateEventListedVenueName_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockConcertRepository_UpdateEventListedVenueName_Call) RunAndReturn(run func(context.Context, string, string) error) *MockConcertRepository_UpdateEventListedVenueName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockConcertRepository creates a new instance of MockConcertRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockConcertRepository(t interface {

--- a/internal/infrastructure/database/rdb/concert_repo.go
+++ b/internal/infrastructure/database/rdb/concert_repo.go
@@ -740,3 +740,19 @@ func (r *ConcertRepository) FillEventStartTimes(ctx context.Context, eventIDs []
 	}
 	return nil
 }
+
+const updateEventListedVenueNameQuery = `
+	UPDATE events
+	SET listed_venue_name = $2
+	WHERE id = $1
+`
+
+// UpdateEventListedVenueName implements entity.ConcertRepository. It overwrites
+// the listed_venue_name display field of an existing event, leaving venue_id and
+// google_place_id untouched. A missing id updates zero rows and is a no-op.
+func (r *ConcertRepository) UpdateEventListedVenueName(ctx context.Context, eventID string, listedVenueName string) error {
+	if _, err := r.db.Pool.Exec(ctx, updateEventListedVenueNameQuery, eventID, listedVenueName); err != nil {
+		return toAppErr(err, "failed to update event listed venue name", slog.String("event_id", eventID))
+	}
+	return nil
+}

--- a/internal/infrastructure/database/rdb/concert_repo_test.go
+++ b/internal/infrastructure/database/rdb/concert_repo_test.go
@@ -1452,3 +1452,52 @@ func countRows(t *testing.T, ctx context.Context, table, eventID string) int {
 	require.NoError(t, err)
 	return n
 }
+
+func TestConcertRepository_UpdateEventListedVenueName(t *testing.T) {
+	ctx := context.Background()
+	concertRepo := rdb.NewConcertRepository(testDB)
+	artistRepo := rdb.NewArtistRepository(testDB)
+	venueRepo := rdb.NewVenueRepository(testDB)
+	seriesRepo := rdb.NewSeriesRepository(testDB)
+
+	t.Run("overwrites listed_venue_name on an existing event", func(t *testing.T) {
+		cleanDatabase(t)
+
+		artist := &entity.Artist{ID: newTestID(t), Name: "Adopt Test Band", MBID: newTestID(t)}
+		_, err := artistRepo.Create(ctx, artist)
+		require.NoError(t, err)
+		venue := &entity.Venue{ID: newTestID(t), Name: "Adopt Test Arena"}
+		_, err = venueRepo.Create(ctx, venue)
+		require.NoError(t, err)
+
+		concertDate, _ := time.Parse("2006-01-02", "2026-11-30")
+		oldName := "Old Display Name"
+		sid := seedSeries(t, ctx, seriesRepo, "Adopt Concert")
+		eventID := newTestID(t)
+		_, err = concertRepo.Create(ctx, &entity.Concert{
+			Event: entity.Event{
+				ID:              eventID,
+				VenueID:         venue.ID,
+				SeriesID:        sid,
+				ListedVenueName: &oldName,
+				LocalDate:       concertDate,
+			},
+			Series:     &entity.Series{ID: sid, SourceURL: "https://example.com/adopt"},
+			Performers: []*entity.Artist{{ID: artist.ID}},
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, concertRepo.UpdateEventListedVenueName(ctx, eventID, "New Display Name"))
+
+		got, err := concertRepo.ListByArtist(ctx, artist.ID, false)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.NotNil(t, got[0].ListedVenueName)
+		assert.Equal(t, "New Display Name", *got[0].ListedVenueName)
+	})
+
+	t.Run("missing id is a no-op success", func(t *testing.T) {
+		cleanDatabase(t)
+		require.NoError(t, concertRepo.UpdateEventListedVenueName(ctx, newTestID(t), "Whatever"))
+	})
+}

--- a/internal/usecase/concert_admin_uc.go
+++ b/internal/usecase/concert_admin_uc.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/liverty-music/backend/internal/entity"
@@ -19,6 +20,63 @@ type PendingConcertReview struct {
 	Staged *entity.StagedConcert
 	// Performer is the artist who will perform at the concert.
 	Performer *entity.Artist
+}
+
+// ApproveResolution selects how Approve reconciles a staged concert that
+// duplicates an already-published event. It mirrors the admin Approve RPC's
+// Resolution enum but is defined in the usecase layer so the business logic does
+// not depend on the generated proto types.
+type ApproveResolution int
+
+const (
+	// ApproveResolutionUnspecified makes Approve return a DuplicateConflict
+	// (without mutating state) when it detects a duplicate; otherwise it publishes.
+	ApproveResolutionUnspecified ApproveResolution = iota
+	// ApproveResolutionKeepExisting logs the staged row to the rejection log with a
+	// duplicate reason and clears it, leaving the existing event unchanged.
+	ApproveResolutionKeepExisting
+	// ApproveResolutionAdoptStaged overwrites the existing event's display fields
+	// from the staged row (listed venue name, and NULL-only start/open fill) and
+	// clears the staged row.
+	ApproveResolutionAdoptStaged
+)
+
+// ApproveResult is the outcome of an approval attempt. A nil Conflict means the
+// concert was published (or reconciled) and the staged row cleared. A non-nil
+// Conflict means a duplicate was detected with no resolution chosen: no state was
+// mutated and the caller must re-invoke Approve with a resolution.
+type ApproveResult struct {
+	// Conflict is set only on an unresolved duplicate; nil otherwise.
+	Conflict *DuplicateConflict
+}
+
+// DuplicateConflict describes a staged concert that maps onto an already-published
+// event, carrying both records so the reviewer can choose a resolution.
+type DuplicateConflict struct {
+	// Existing is the already-published event's display-field preview.
+	Existing *ExistingEventDisplay
+	// Staged is the staged concert the reviewer proposed to publish.
+	Staged *entity.StagedConcert
+	// StagedPerformer is the artist the staged concert was discovered for.
+	StagedPerformer *entity.Artist
+}
+
+// ExistingEventDisplay is the display-field preview of an already-published event
+// that a staged concert collides with. Venue identity is intentionally omitted —
+// reconciliation never changes it.
+type ExistingEventDisplay struct {
+	// EventID is the unique identifier of the already-published event.
+	EventID string
+	// Title is the descriptive title of the existing event (from its series).
+	Title string
+	// ListedVenueName is the venue name currently stored on the existing event.
+	ListedVenueName string
+	// LocalDate is the local calendar date of the existing event.
+	LocalDate time.Time
+	// StartTime is the existing event's start time; nil when unknown.
+	StartTime *time.Time
+	// OpenTime is the existing event's door-open time; nil when unknown.
+	OpenTime *time.Time
 }
 
 // AdminConcertUseCase defines the admin-console operations over concerts: the
@@ -44,22 +102,32 @@ type AdminConcertUseCase interface {
 	//  - Internal: If the repository query or a per-row artist lookup fails.
 	ListPending(ctx context.Context) ([]*PendingConcertReview, error)
 
-	// Approve promotes a pending staged concert to a published event. It
-	// resolves or creates the venues row from the staged resolved fields, builds
-	// the Concert/Series/Event entities, inserts them, publishes CONCERT.created,
-	// and deletes the staged row. The operation is idempotent: if the staged row
-	// is already gone (e.g. double-click), the method returns success without
-	// duplicating.
+	// Approve promotes a pending staged concert to a published event. It resolves
+	// or creates the venues row, and — when the staged concert does not duplicate
+	// an existing event — builds the Concert/Series/Event entities, inserts them,
+	// publishes CONCERT.created, and deletes the staged row. The operation is
+	// idempotent: if the staged row is already gone (e.g. double-click) the method
+	// returns a non-conflict success without duplicating.
+	//
+	// When the staged concert maps onto an already-published event at the resolved
+	// (venue, date, start time), the behavior depends on resolution:
+	//   - ApproveResolutionUnspecified: returns an ApproveResult whose Conflict is
+	//     set to the existing event's display fields plus the staged preview; NO
+	//     state is mutated.
+	//   - ApproveResolutionKeepExisting: records the staged row in the rejection log
+	//     (attributed to reviewerID) with a duplicate reason and clears it, leaving
+	//     the existing event unchanged.
+	//   - ApproveResolutionAdoptStaged: overwrites the existing event's listed venue
+	//     name and fills its start/open time only where currently NULL, leaving
+	//     venue identity and the shared series title unchanged, then clears the
+	//     staged row.
+	//
+	// reviewerID is the calling reviewer's identity (used only by KeepExisting).
 	//
 	// # Possible errors
 	//
-	//  - NotFound: If the staged concert does not exist (idempotent — treated as
-	//    success internally; callers should not distinguish this).
-	//  - FailedPrecondition: If an equivalent known-start event already covers
-	//    the same (venue, date) and the staged concert has no start time. The
-	//    staged row is preserved so a reviewer can reject it to clear the queue.
-	//  - Internal: If the venue, series, or event insert fails.
-	Approve(ctx context.Context, stagedID string) error
+	//  - Internal: If the venue, series, or event mutation fails.
+	Approve(ctx context.Context, stagedID string, resolution ApproveResolution, reviewerID string) (*ApproveResult, error)
 
 	// Reject records the staged concert in the rejection log and deletes the
 	// staged row. It is idempotent: if the staged row is already gone, the
@@ -130,30 +198,44 @@ func (uc *concertUseCase) ListPending(ctx context.Context) ([]*PendingConcertRev
 	return reviews, nil
 }
 
-// Approve promotes a pending staged concert to a published event.
-func (uc *concertUseCase) Approve(ctx context.Context, stagedID string) error {
+// Approve promotes a pending staged concert to a published event, reconciling a
+// duplicate existing event per the resolution when one is detected.
+func (uc *concertUseCase) Approve(ctx context.Context, stagedID string, resolution ApproveResolution, reviewerID string) (*ApproveResult, error) {
 	sc, err := uc.stagedConcertRepo.GetByID(ctx, stagedID)
 	if err != nil {
 		if errors.Is(err, apperr.ErrNotFound) {
 			// Idempotent: staged row already gone (already approved or rejected).
+			// This also covers the second phase of a two-call reconcile where the
+			// first call already cleared the row.
 			uc.logger.Info(ctx, "approve: staged concert already gone — treating as success",
 				slog.String("staged_concert_id", stagedID),
 			)
-			return nil
+			return &ApproveResult{}, nil
 		}
-		return fmt.Errorf("get staged concert: %w", err)
+		return nil, fmt.Errorf("get staged concert: %w", err)
 	}
 
 	// Resolve or create the venues row from the staged resolved fields.
 	venueID, err := uc.resolveOrCreateVenue(ctx, sc)
 	if err != nil {
-		return fmt.Errorf("resolve or create venue for staged concert %q: %w", stagedID, err)
+		return nil, fmt.Errorf("resolve or create venue for staged concert %q: %w", stagedID, err)
 	}
 
-	// Convert the staged row back into a ScrapedConcert so buildAndInsertConcerts
-	// can run the same series-adoption + fill + bulk-insert logic.
-	scraped := stagedToScraped(sc)
+	// Detect a duplicate existing event at the resolved (venue, date, start time)
+	// BEFORE any event mutation, so an unresolved conflict returns without side
+	// effects. Re-checked on every call, so a two-phase reconcile re-validates.
+	conflictEvent, err := uc.detectDuplicateEvent(ctx, sc, venueID)
+	if err != nil {
+		return nil, fmt.Errorf("detect duplicate event for staged concert %q: %w", stagedID, err)
+	}
+	if conflictEvent != nil {
+		return uc.reconcileDuplicate(ctx, sc, conflictEvent, resolution, reviewerID)
+	}
 
+	// No duplicate — publish normally. buildAndInsertConcerts also handles the
+	// fill case (a known-start staged row filling an existing unknown-start row),
+	// which legitimately inserts nothing; that is a success, not a conflict.
+	scraped := stagedToScraped(sc)
 	insertedIDs, err := buildAndInsertConcerts(
 		ctx,
 		sc.ArtistID,
@@ -164,21 +246,27 @@ func (uc *concertUseCase) Approve(ctx context.Context, stagedID string) error {
 		uc.logger,
 	)
 	if err != nil {
-		return fmt.Errorf("build and insert concerts for staged concert %q: %w", stagedID, err)
+		return nil, fmt.Errorf("build and insert concerts for staged concert %q: %w", stagedID, err)
 	}
 
-	// When zero events were inserted it means an equivalent known-start event
-	// already exists for this (venue, date) and the staged concert carries no
-	// start time. Deleting the staged row here would silently lose it with no
-	// recovery path. Instead, return FailedPrecondition so the caller surfaces
-	// the condition to the reviewer, who can then reject it to clear the queue.
-	if len(insertedIDs) == 0 {
-		uc.logger.Warn(ctx, "approve: equivalent event already exists — staged row preserved for manual rejection",
-			slog.String("artist_id", sc.ArtistID),
-			slog.String("staged_concert_id", stagedID),
-		)
-		return apperr.New(codes.FailedPrecondition,
-			"an equivalent event already exists for this venue and date; reject this entry to remove it from the queue")
+	// Publish CONCERT.created only for genuinely inserted events (a fill inserts
+	// nothing but still updates an existing row, which needs no new-concert event).
+	if len(insertedIDs) > 0 {
+		created := ConcertCreatedData{
+			ArtistID:   sc.ArtistID,
+			ConcertIDs: insertedIDs,
+		}
+		if err := uc.publisher.PublishEvent(ctx, entity.SubjectConcertCreated, created); err != nil {
+			uc.logger.Error(ctx, "failed to publish CONCERT.created after approval", err,
+				slog.String("staged_concert_id", stagedID),
+			)
+			// Non-fatal: event is persisted; notification will retry or be missed.
+		}
+	}
+
+	// Delete the staged row only after a successful publish/fill.
+	if err := uc.stagedConcertRepo.Delete(ctx, stagedID); err != nil {
+		return nil, fmt.Errorf("delete staged concert after approval: %w", err)
 	}
 
 	uc.logger.Info(ctx, "staged concert approved and published",
@@ -187,24 +275,124 @@ func (uc *concertUseCase) Approve(ctx context.Context, stagedID string) error {
 		slog.Int("inserted", len(insertedIDs)),
 	)
 
-	// Publish CONCERT.created for every genuinely inserted event.
-	created := ConcertCreatedData{
-		ArtistID:   sc.ArtistID,
-		ConcertIDs: insertedIDs,
+	return &ApproveResult{}, nil
+}
+
+// detectDuplicateEvent returns the already-published event a staged concert
+// duplicates at the resolved (venue, date, start time), or nil when the concert
+// is genuinely new or merely fills an existing unknown-start row. It mirrors the
+// two zero-insert paths the creation path would otherwise hit:
+//   - an exact-start match (equal StartKey, including both-unknown), and
+//   - an unknown-start staged row when a known-start row already covers the slot.
+//
+// The fill case (known-start staged onto an unknown-start existing row) is NOT a
+// duplicate: it proceeds to the creation path, which fills the existing row.
+func (uc *concertUseCase) detectDuplicateEvent(ctx context.Context, sc *entity.StagedConcert, venueID string) (*entity.Event, error) {
+	events, err := uc.concertRepo.FindEventsByVenueAndDate(ctx, []string{venueID}, []time.Time{sc.LocalDate})
+	if err != nil {
+		return nil, fmt.Errorf("find existing events: %w", err)
 	}
-	if err := uc.publisher.PublishEvent(ctx, entity.SubjectConcertCreated, created); err != nil {
-		uc.logger.Error(ctx, "failed to publish CONCERT.created after approval", err,
-			slog.String("staged_concert_id", stagedID),
+
+	scraped := stagedToScraped(sc)
+	match, isFill := resolveExistingEvent(events, scraped, map[string]bool{})
+	if match != nil && !isFill {
+		// Exact-start duplicate (or both-unknown at the same venue/date).
+		return match, nil
+	}
+	if scraped.StartTime.IsZero() {
+		// Unknown-start staged row: a duplicate iff any known-start row exists here.
+		for _, ev := range events {
+			if ev.StartTime != nil && !ev.StartTime.IsZero() {
+				return ev, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// reconcileDuplicate applies the reviewer's resolution to a detected duplicate.
+func (uc *concertUseCase) reconcileDuplicate(ctx context.Context, sc *entity.StagedConcert, existing *entity.Event, resolution ApproveResolution, reviewerID string) (*ApproveResult, error) {
+	switch resolution {
+	case ApproveResolutionKeepExisting:
+		reason := fmt.Sprintf("duplicate of existing event %s", existing.ID)
+		if err := uc.appendRejectionLog(ctx, sc, reason, reviewerID); err != nil {
+			return nil, fmt.Errorf("keep-existing: append rejection log: %w", err)
+		}
+		if err := uc.stagedConcertRepo.Delete(ctx, sc.ID); err != nil {
+			return nil, fmt.Errorf("keep-existing: delete staged concert: %w", err)
+		}
+		uc.logger.Info(ctx, "duplicate reconciled: kept existing event, staged row logged and cleared",
+			slog.String("staged_concert_id", sc.ID),
+			slog.String("existing_event_id", existing.ID),
 		)
-		// Non-fatal: event is persisted; notification will retry or be missed.
+		return &ApproveResult{}, nil
+
+	case ApproveResolutionAdoptStaged:
+		// Overwrite the display venue name and fill start/open only where NULL
+		// (COALESCE), leaving venue identity and the shared series title untouched.
+		if err := uc.concertRepo.UpdateEventListedVenueName(ctx, existing.ID, sc.ListedVenueName); err != nil {
+			return nil, fmt.Errorf("adopt-staged: update listed venue name: %w", err)
+		}
+		if err := uc.concertRepo.FillEventStartTimes(ctx,
+			[]string{existing.ID},
+			[]*time.Time{sc.StartTime},
+			[]*time.Time{sc.OpenTime},
+		); err != nil {
+			return nil, fmt.Errorf("adopt-staged: fill start/open times: %w", err)
+		}
+		if err := uc.stagedConcertRepo.Delete(ctx, sc.ID); err != nil {
+			return nil, fmt.Errorf("adopt-staged: delete staged concert: %w", err)
+		}
+		uc.logger.Info(ctx, "duplicate reconciled: adopted staged display fields onto existing event",
+			slog.String("staged_concert_id", sc.ID),
+			slog.String("existing_event_id", existing.ID),
+		)
+		return &ApproveResult{}, nil
+
+	default:
+		// Unspecified: surface the conflict for reviewer choice; do not mutate.
+		conflict, err := uc.buildDuplicateConflict(ctx, sc, existing)
+		if err != nil {
+			return nil, err
+		}
+		uc.logger.Info(ctx, "approve: duplicate event detected — returning conflict for reviewer choice",
+			slog.String("staged_concert_id", sc.ID),
+			slog.String("existing_event_id", existing.ID),
+		)
+		return &ApproveResult{Conflict: conflict}, nil
+	}
+}
+
+// buildDuplicateConflict assembles the conflict DTO: the existing event's display
+// fields (its title resolved from the shared series) plus the staged preview and
+// its performer.
+func (uc *concertUseCase) buildDuplicateConflict(ctx context.Context, sc *entity.StagedConcert, existing *entity.Event) (*DuplicateConflict, error) {
+	series, err := uc.seriesRepo.Get(ctx, existing.SeriesID)
+	if err != nil {
+		return nil, fmt.Errorf("get series for duplicate conflict: %w", err)
+	}
+	performer, err := uc.artistRepo.Get(ctx, sc.ArtistID)
+	if err != nil {
+		return nil, fmt.Errorf("get performer for duplicate conflict: %w", err)
 	}
 
-	// Delete the staged row only after a successful insertion.
-	if err := uc.stagedConcertRepo.Delete(ctx, stagedID); err != nil {
-		return fmt.Errorf("delete staged concert after approval: %w", err)
+	listedName := ""
+	if existing.ListedVenueName != nil {
+		listedName = *existing.ListedVenueName
 	}
 
-	return nil
+	return &DuplicateConflict{
+		Existing: &ExistingEventDisplay{
+			EventID:         existing.ID,
+			Title:           series.Title,
+			ListedVenueName: listedName,
+			LocalDate:       existing.LocalDate,
+			StartTime:       existing.StartTime,
+			OpenTime:        existing.OpenTime,
+		},
+		Staged:          sc,
+		StagedPerformer: performer,
+	}, nil
 }
 
 // Reject records the staged concert in the rejection log and deletes the
@@ -222,8 +410,28 @@ func (uc *concertUseCase) Reject(ctx context.Context, stagedID string, reason st
 		return fmt.Errorf("get staged concert: %w", err)
 	}
 
-	// Fetch the artist name for the log — it is captured at rejection time for
-	// readability even if the artist is later deleted.
+	if err := uc.appendRejectionLog(ctx, sc, reason, reviewedBy); err != nil {
+		return err
+	}
+
+	if err := uc.stagedConcertRepo.Delete(ctx, stagedID); err != nil {
+		return fmt.Errorf("delete staged concert after rejection: %w", err)
+	}
+
+	uc.logger.Info(ctx, "staged concert rejected and logged",
+		slog.String("artist_id", sc.ArtistID),
+		slog.String("staged_concert_id", stagedID),
+		slog.String("reason", reason),
+	)
+
+	return nil
+}
+
+// appendRejectionLog captures a staged concert in the rejection log with the
+// given reason and reviewer identity. The artist name is snapshotted at write
+// time for readability even if the artist is later deleted. Shared by Reject and
+// the approval keep-existing reconciliation.
+func (uc *concertUseCase) appendRejectionLog(ctx context.Context, sc *entity.StagedConcert, reason, reviewedBy string) error {
 	artist, err := uc.artistRepo.Get(ctx, sc.ArtistID)
 	if err != nil {
 		return fmt.Errorf("get artist for rejection log: %w", err)
@@ -261,17 +469,6 @@ func (uc *concertUseCase) Reject(ctx context.Context, stagedID string, reason st
 	if err := uc.rejectedConcertRepo.Append(ctx, logEntry); err != nil {
 		return fmt.Errorf("append rejection log: %w", err)
 	}
-
-	if err := uc.stagedConcertRepo.Delete(ctx, stagedID); err != nil {
-		return fmt.Errorf("delete staged concert after rejection: %w", err)
-	}
-
-	uc.logger.Info(ctx, "staged concert rejected and logged",
-		slog.String("artist_id", sc.ArtistID),
-		slog.String("staged_concert_id", stagedID),
-		slog.String("reason", reason),
-	)
-
 	return nil
 }
 

--- a/internal/usecase/concert_admin_uc_test.go
+++ b/internal/usecase/concert_admin_uc_test.go
@@ -156,7 +156,7 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 		sub, err := d.publisher.Subscribe(ctx, entity.SubjectConcertCreated)
 		require.NoError(t, err)
 
-		err = d.uc.Approve(ctx, sc.ID)
+		_, err = d.uc.Approve(ctx, sc.ID, usecase.ApproveResolutionUnspecified, "")
 		require.NoError(t, err)
 
 		// Concert was created.
@@ -192,7 +192,7 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 		d := newApprovalTestDeps(t, artist)
 		// Do NOT seed — staged row does not exist.
 
-		err := d.uc.Approve(context.Background(), "staged-nonexistent")
+		_, err := d.uc.Approve(context.Background(), "staged-nonexistent", usecase.ApproveResolutionUnspecified, "")
 		require.NoError(t, err)
 
 		// No concerts or venues created.
@@ -214,7 +214,7 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 
 		sc := seedStaged(d, artist.ID)
 
-		err := d.uc.Approve(context.Background(), sc.ID)
+		_, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionUnspecified, "")
 		require.NoError(t, err)
 
 		// Venue was reused, not re-created.
@@ -253,7 +253,7 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 		}
 		d.stagedRepo.upserted = append(d.stagedRepo.upserted, sc)
 
-		err := d.uc.Approve(context.Background(), sc.ID)
+		_, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionUnspecified, "")
 		require.NoError(t, err)
 
 		// Venue was reused via the listed-name fallback, not re-created.
@@ -292,7 +292,7 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 		}
 		d.stagedRepo.upserted = append(d.stagedRepo.upserted, sc)
 
-		err := d.uc.Approve(context.Background(), sc.ID)
+		_, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionUnspecified, "")
 		require.NoError(t, err)
 
 		// Venue reused, and its NULL place_id was backfilled from the staged row.
@@ -329,7 +329,7 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 		}
 		d.stagedRepo.upserted = append(d.stagedRepo.upserted, sc)
 
-		err := d.uc.Approve(context.Background(), sc.ID)
+		_, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionUnspecified, "")
 		require.NoError(t, err)
 
 		// Reused via the resolved admin_area, not re-created under the raw one.
@@ -379,7 +379,7 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 		approvalCreatedCh, err := approvalDeps.publisher.Subscribe(ctx, entity.SubjectConcertCreated)
 		require.NoError(t, err)
 
-		err = approvalDeps.uc.Approve(ctx, stagedRepo.upserted[0].ID)
+		_, err = approvalDeps.uc.Approve(ctx, stagedRepo.upserted[0].ID, usecase.ApproveResolutionUnspecified, "")
 		require.NoError(t, err)
 
 		select {
@@ -388,6 +388,124 @@ func TestAdminConcertUseCase_Approve(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Fatal("expected CONCERT.created from Approve but got none")
 		}
+	})
+}
+
+// seedConflict wires a staged concert that duplicates an already-published event
+// at the same (venue, date, start time): the venue is pre-seeded so it resolves
+// to a known id, and an existing known-start event plus its series are seeded.
+func seedConflict(d *approvalTestDeps, artistID string) *entity.StagedConcert {
+	d.venueRepo.venues["Venue One"] = &entity.Venue{
+		ID:              "venue-1",
+		Name:            "Venue One",
+		ListedVenueName: new("Venue ABC"),
+	}
+	start := time.Date(2026, 8, 1, 19, 0, 0, 0, time.UTC)
+	d.concertRepo.existing = map[string][]*entity.Event{
+		"venue-1|2026-08-01": {{
+			ID:              "event-1",
+			SeriesID:        "series-1",
+			VenueID:         "venue-1",
+			LocalDate:       time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			StartTime:       &start,
+			ListedVenueName: new("Old Listed Name"),
+		}},
+	}
+	d.seriesRepo.byID = map[string]*entity.Series{
+		"series-1": {ID: "series-1", Title: "Existing Title"},
+	}
+	sc := &entity.StagedConcert{
+		ID:              "staged-dup",
+		ArtistID:        artistID,
+		Title:           "Staged Title",
+		LocalDate:       time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		ListedVenueName: "Venue ABC",
+		StartTime:       &start,
+	}
+	d.stagedRepo.upserted = append(d.stagedRepo.upserted, sc)
+	return sc
+}
+
+func TestAdminConcertUseCase_Approve_Reconciliation(t *testing.T) {
+	t.Parallel()
+
+	artist := &entity.Artist{ID: "artist-1", Name: "Test Artist", MBID: "11111111-1111-1111-1111-111111111111"}
+
+	t.Run("unresolved duplicate returns a conflict and does not mutate", func(t *testing.T) {
+		t.Parallel()
+		d := newApprovalTestDeps(t, artist)
+		sc := seedConflict(d, artist.ID)
+
+		result, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionUnspecified, "reviewer-1")
+		require.NoError(t, err)
+
+		require.NotNil(t, result.Conflict)
+		assert.Equal(t, "event-1", result.Conflict.Existing.EventID)
+		assert.Equal(t, "Existing Title", result.Conflict.Existing.Title)
+		assert.Equal(t, "Old Listed Name", result.Conflict.Existing.ListedVenueName)
+		require.NotNil(t, result.Conflict.Staged)
+		assert.Equal(t, "staged-dup", result.Conflict.Staged.ID)
+		require.NotNil(t, result.Conflict.StagedPerformer)
+
+		// No mutation: staged row preserved, nothing created/logged/updated.
+		assert.Len(t, d.stagedRepo.upserted, 1)
+		assert.Empty(t, d.concertRepo.created)
+		assert.Empty(t, d.rejectedLog.entries)
+		assert.Empty(t, d.concertRepo.updatedListedNames)
+	})
+
+	t.Run("KEEP_EXISTING logs the staged row and clears it, leaving the event unchanged", func(t *testing.T) {
+		t.Parallel()
+		d := newApprovalTestDeps(t, artist)
+		sc := seedConflict(d, artist.ID)
+
+		result, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionKeepExisting, "reviewer-1")
+		require.NoError(t, err)
+		assert.Nil(t, result.Conflict)
+
+		// Staged row logged (with the reviewer) and cleared; event untouched.
+		require.Len(t, d.rejectedLog.entries, 1)
+		assert.Contains(t, d.rejectedLog.entries[0].Reason, "duplicate")
+		require.NotNil(t, d.rejectedLog.entries[0].ReviewedBy)
+		assert.Equal(t, "reviewer-1", *d.rejectedLog.entries[0].ReviewedBy)
+		assert.Empty(t, d.stagedRepo.upserted)
+		assert.Empty(t, d.concertRepo.created)
+		assert.Empty(t, d.concertRepo.updatedListedNames)
+	})
+
+	t.Run("ADOPT_STAGED overwrites the display fields and clears the staged row", func(t *testing.T) {
+		t.Parallel()
+		d := newApprovalTestDeps(t, artist)
+		sc := seedConflict(d, artist.ID)
+
+		result, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionAdoptStaged, "reviewer-1")
+		require.NoError(t, err)
+		assert.Nil(t, result.Conflict)
+
+		// Existing event's listed name overwritten from the staged row; start/open
+		// filled via COALESCE; staged row cleared; nothing logged or newly created.
+		assert.Equal(t, "Venue ABC", d.concertRepo.updatedListedNames["event-1"])
+		assert.Contains(t, d.concertRepo.filledIDs, "event-1")
+		assert.Empty(t, d.stagedRepo.upserted)
+		assert.Empty(t, d.concertRepo.created)
+		assert.Empty(t, d.rejectedLog.entries)
+	})
+
+	t.Run("second reconcile call is idempotent once the staged row is gone", func(t *testing.T) {
+		t.Parallel()
+		d := newApprovalTestDeps(t, artist)
+		sc := seedConflict(d, artist.ID)
+
+		_, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionKeepExisting, "reviewer-1")
+		require.NoError(t, err)
+
+		// Second call: staged row already cleared → non-conflict success.
+		result, err := d.uc.Approve(context.Background(), sc.ID, usecase.ApproveResolutionAdoptStaged, "reviewer-1")
+		require.NoError(t, err)
+		assert.Nil(t, result.Conflict)
+		// No second log entry, no event mutation.
+		assert.Len(t, d.rejectedLog.entries, 1)
+		assert.Empty(t, d.concertRepo.updatedListedNames)
 	})
 }
 

--- a/internal/usecase/concert_creation_uc_test.go
+++ b/internal/usecase/concert_creation_uc_test.go
@@ -82,6 +82,9 @@ func (r *fakeVenueRepo) GetByListedName(_ context.Context, listedVenueName strin
 
 type fakeSeriesRepo struct {
 	created []*entity.Series
+	// byID lets tests seed series so Get resolves a title (e.g. for the
+	// duplicate-conflict preview). Nil map → Get returns NotFound.
+	byID map[string]*entity.Series
 }
 
 func (r *fakeSeriesRepo) Create(_ context.Context, series ...*entity.Series) ([]string, error) {
@@ -95,7 +98,10 @@ func (r *fakeSeriesRepo) Create(_ context.Context, series ...*entity.Series) ([]
 	return ids, nil
 }
 
-func (r *fakeSeriesRepo) Get(_ context.Context, _ string) (*entity.Series, error) {
+func (r *fakeSeriesRepo) Get(_ context.Context, id string) (*entity.Series, error) {
+	if s, ok := r.byID[id]; ok {
+		return s, nil
+	}
 	return nil, apperr.New(codes.NotFound, "series not found")
 }
 
@@ -123,6 +129,9 @@ type fakeConcertRepo struct {
 	// filledIDs / filledStarts capture FillEventStartTimes calls.
 	filledIDs    []string
 	filledStarts []*time.Time
+	// updatedListedNames maps eventID → the listed_venue_name written via
+	// UpdateEventListedVenueName; adopt-staged tests assert on this.
+	updatedListedNames map[string]string
 	// published holds concerts returned by List; admin tests seed this directly.
 	published []*entity.Concert
 	// deleteCalled records whether Delete was invoked; admin tests assert on this.
@@ -154,6 +163,14 @@ func (r *fakeConcertRepo) FindEventsByVenueAndDate(_ context.Context, venueIDs [
 func (r *fakeConcertRepo) FillEventStartTimes(_ context.Context, eventIDs []string, startTimes, _ []*time.Time) error {
 	r.filledIDs = append(r.filledIDs, eventIDs...)
 	r.filledStarts = append(r.filledStarts, startTimes...)
+	return nil
+}
+
+func (r *fakeConcertRepo) UpdateEventListedVenueName(_ context.Context, eventID string, listedVenueName string) error {
+	if r.updatedListedNames == nil {
+		r.updatedListedNames = make(map[string]string)
+	}
+	r.updatedListedNames[eventID] = listedVenueName
 	return nil
 }
 

--- a/internal/usecase/mocks/mock_AdminConcertUseCase.go
+++ b/internal/usecase/mocks/mock_AdminConcertUseCase.go
@@ -24,22 +24,34 @@ func (_m *MockAdminConcertUseCase) EXPECT() *MockAdminConcertUseCase_Expecter {
 	return &MockAdminConcertUseCase_Expecter{mock: &_m.Mock}
 }
 
-// Approve provides a mock function with given fields: ctx, stagedID
-func (_m *MockAdminConcertUseCase) Approve(ctx context.Context, stagedID string) error {
-	ret := _m.Called(ctx, stagedID)
+// Approve provides a mock function with given fields: ctx, stagedID, resolution, reviewerID
+func (_m *MockAdminConcertUseCase) Approve(ctx context.Context, stagedID string, resolution usecase.ApproveResolution, reviewerID string) (*usecase.ApproveResult, error) {
+	ret := _m.Called(ctx, stagedID, resolution, reviewerID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Approve")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, stagedID)
+	var r0 *usecase.ApproveResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, usecase.ApproveResolution, string) (*usecase.ApproveResult, error)); ok {
+		return rf(ctx, stagedID, resolution, reviewerID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, usecase.ApproveResolution, string) *usecase.ApproveResult); ok {
+		r0 = rf(ctx, stagedID, resolution, reviewerID)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*usecase.ApproveResult)
+		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string, usecase.ApproveResolution, string) error); ok {
+		r1 = rf(ctx, stagedID, resolution, reviewerID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MockAdminConcertUseCase_Approve_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Approve'
@@ -50,23 +62,25 @@ type MockAdminConcertUseCase_Approve_Call struct {
 // Approve is a helper method to define mock.On call
 //   - ctx context.Context
 //   - stagedID string
-func (_e *MockAdminConcertUseCase_Expecter) Approve(ctx interface{}, stagedID interface{}) *MockAdminConcertUseCase_Approve_Call {
-	return &MockAdminConcertUseCase_Approve_Call{Call: _e.mock.On("Approve", ctx, stagedID)}
+//   - resolution usecase.ApproveResolution
+//   - reviewerID string
+func (_e *MockAdminConcertUseCase_Expecter) Approve(ctx interface{}, stagedID interface{}, resolution interface{}, reviewerID interface{}) *MockAdminConcertUseCase_Approve_Call {
+	return &MockAdminConcertUseCase_Approve_Call{Call: _e.mock.On("Approve", ctx, stagedID, resolution, reviewerID)}
 }
 
-func (_c *MockAdminConcertUseCase_Approve_Call) Run(run func(ctx context.Context, stagedID string)) *MockAdminConcertUseCase_Approve_Call {
+func (_c *MockAdminConcertUseCase_Approve_Call) Run(run func(ctx context.Context, stagedID string, resolution usecase.ApproveResolution, reviewerID string)) *MockAdminConcertUseCase_Approve_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(usecase.ApproveResolution), args[3].(string))
 	})
 	return _c
 }
 
-func (_c *MockAdminConcertUseCase_Approve_Call) Return(_a0 error) *MockAdminConcertUseCase_Approve_Call {
-	_c.Call.Return(_a0)
+func (_c *MockAdminConcertUseCase_Approve_Call) Return(_a0 *usecase.ApproveResult, _a1 error) *MockAdminConcertUseCase_Approve_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockAdminConcertUseCase_Approve_Call) RunAndReturn(run func(context.Context, string) error) *MockAdminConcertUseCase_Approve_Call {
+func (_c *MockAdminConcertUseCase_Approve_Call) RunAndReturn(run func(context.Context, string, usecase.ApproveResolution, string) (*usecase.ApproveResult, error)) *MockAdminConcertUseCase_Approve_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

Backend phase **A-2** of OpenSpec change `fix-concert-approval-dedup`: admin approval now reconciles a duplicate existing event via a reviewer choice instead of dead-ending with `FailedPrecondition`. Consumes the v0.48.0 schema (Resolution enum + DuplicateConflict), published to BSR.

Depends on liverty-music/specification#705 (merged, Release v0.48.0). Backend fixes A-1/B shipped in #371.

## Changes

`ConcertService.Approve` becomes two-phase. It resolves the venue, then detects a duplicate existing event at the resolved `(venue, date, start time)` **before any event mutation**:

- **`RESOLUTION_UNSPECIFIED`** → returns a `DuplicateConflict` (the existing event's display fields via `ExistingEvent` + the staged `PendingConcert` preview); no state mutated. The console prompts the reviewer.
- **`RESOLUTION_KEEP_EXISTING`** → logs the staged row to `rejected_concerts_log` with a duplicate reason, attributed to the calling reviewer (threaded from the admin JWT like `Reject`), and clears it; the event is untouched.
- **`RESOLUTION_ADOPT_STAGED`** → overwrites the existing event's `listed_venue_name` and fills `start_at`/`open_at` only where NULL (COALESCE), leaving `venue_id`/`google_place_id` and the shared series title unchanged, then clears the staged row.

Duplicate detection mirrors the creation path's two zero-insert cases (exact-start match; unknown-start staged vs known-start existing). The **fill** case (known-start staged onto an unknown-start existing row) and genuinely-new concerts still publish normally — they are not conflicts. The RPC stays a single idempotent verb: a second call re-reads the staged row and, once it is gone, succeeds via the existing already-approved path.

- Adds `ConcertRepository.UpdateEventListedVenueName` (adopt-staged overwrite; reuses the existing COALESCE `FillEventStartTimes`).
- `AdminConcertUseCase.Approve` signature gains `resolution` + `reviewerID` and returns an `ApproveResult` (nil `Conflict` = published/reconciled).
- Refactors the rejection-log append shared by `Reject` and keep-existing.

No DB migration.

## Testing

- `make check` green (lint + unit + integration).
- Usecase: unresolved-duplicate conflict (no mutation), KEEP_EXISTING (logs + clears), ADOPT_STAGED (overwrites display + fills + clears), and two-phase idempotency.
- Repo: `UpdateEventListedVenueName` overwrite + missing-id no-op.
- Handler: Approve maps resolution + conflict result.

## Related

Refs: liverty-music/specification#703
