### PR TITLE
perf(gemini): consolidate concert Step 1 to one slice on gemini-3.6-flash

### DIFF
--- a/internal/infrastructure/gcp/gemini/abeval_test.go
+++ b/internal/infrastructure/gcp/gemini/abeval_test.go
@@ -62,7 +62,7 @@ func TestLoadGroundTruth_FixtureWellFormed(t *testing.T) {
 	gt, err := gemini.LoadGroundTruth()
 	require.NoError(t, err)
 
-	assert.Equal(t, "2026-05-20", gt.EvaluationFrom)
+	assert.Equal(t, "2026-07-27", gt.EvaluationFrom)
 	assert.NotEmpty(t, gt.CapturedAt)
 	require.Len(t, gt.Artists, 4, "fixture must cover 4 artists")
 

--- a/internal/infrastructure/gcp/gemini/retry_test.go
+++ b/internal/infrastructure/gcp/gemini/retry_test.go
@@ -80,11 +80,10 @@ func TestSearch_RetryOnTransientError(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, "Retry Success Tour", got[0].Title)
-	// Step 1 fans out into 3 parallel slices. The first request (whichever
-	// slice wins the race) returns 503 and retries once; the other two
-	// slices succeed on their first attempt. Step 2 parses the merged
-	// envelope. Total: 3 slice calls + 1 retry + 1 parse = 5.
-	assert.Equal(t, int32(5), callCount.Load(), "3 slices + 1 retry + Step 2 = 5 calls")
+	// Step 1 runs a single grounded slice. The first request returns 503
+	// and retries once; the retry succeeds. Step 2 parses the envelope.
+	// Total: 1 (503) + 1 (retry success) + 1 (parse) = 3 calls.
+	assert.Equal(t, int32(3), callCount.Load(), "1 slice + 1 retry + Step 2 = 3 calls")
 }
 
 func TestSearch_AllRetriesExhausted(t *testing.T) {
@@ -124,11 +123,11 @@ func TestSearch_AllRetriesExhausted(t *testing.T) {
 	// exhaustion at the slice level; fail hard only on permanent errors".
 	assert.NoError(t, err)
 	assert.Empty(t, got)
-	// 3 parallel slices × 3 retries each = 9 total slice attempts. Step 2
-	// is skipped because every slice exhausts retries (empty envelope set →
+	// 1 grounded slice × 3 retries = 3 total slice attempts. Step 2 is
+	// skipped because the slice exhausts retries (empty envelope set →
 	// runStep1Grounded returns "" → runStep2Parse short-circuits on the
 	// empty draft list).
-	assert.Equal(t, int32(9), callCount.Load(), "3 slices × 3 retries = 9 calls")
+	assert.Equal(t, int32(3), callCount.Load(), "1 slice × 3 retries = 3 calls")
 }
 
 func TestSearch_NonRetryableErrorStopsImmediately(t *testing.T) {
@@ -162,10 +161,10 @@ func TestSearch_NonRetryableErrorStopsImmediately(t *testing.T) {
 	assert.Nil(t, got)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, apperr.ErrInvalidArgument)
-	// All 3 parallel Step 1 slices hit the 400. Permanent errors abort
-	// each slice immediately (no retries). Step 2 is skipped because
-	// runStep1Grounded surfaces the first error. Total: 3 calls.
-	assert.Equal(t, int32(3), callCount.Load(), "3 slices × 1 (non-retryable) = 3 calls")
+	// The single Step 1 slice hits the 400. Permanent errors abort the
+	// slice immediately (no retries). Step 2 is skipped because
+	// runStep1Grounded surfaces the error. Total: 1 call.
+	assert.Equal(t, int32(1), callCount.Load(), "1 slice × 1 (non-retryable) = 1 call")
 }
 
 func TestSearch_ContextCancellationStopsRetry(t *testing.T) {
@@ -201,7 +200,7 @@ func TestSearch_ContextCancellationStopsRetry(t *testing.T) {
 
 	assert.Nil(t, got)
 	assert.Error(t, err)
-	// 3 slices × 3 retries would be 9 calls if backoff ran to completion.
-	// Context cancellation during backoff stops some retries.
-	assert.Less(t, callCount.Load(), int32(9), "should not exhaust all retries when context is cancelled")
+	// 1 slice × 3 retries would be 3 calls if backoff ran to completion.
+	// Context cancellation during the first backoff stops further retries.
+	assert.Less(t, callCount.Load(), int32(3), "should not exhaust all retries when context is cancelled")
 }

--- a/internal/infrastructure/gcp/gemini/searcher.go
+++ b/internal/infrastructure/gcp/gemini/searcher.go
@@ -100,14 +100,20 @@ func thinkingLevelFromConfig(level string) genai.ThinkingLevel {
 }
 
 const (
-	// systemInstructionStep1Tour is the Step 1 system instruction used by
-	// the tour-focused slices. Workflow-style (numbered steps); each tour
-	// has a single <source_url> child.
-	systemInstructionStep1Tour = `あなたはライブ音楽情報システム向けのデータ抽出エージェントです。下記の手順に従って、音楽ファンに提供するための、正確な公式情報を抽出することがゴールです。
+	// systemInstructionStep1 is the single consolidated Step 1 system
+	// instruction. It extracts both tours and standalones in one grounded
+	// call (English; url_context + google_search), including off-domain tour
+	// pages, and excludes multi-artist festivals.
+	systemInstructionStep1 = `You are a data-extraction agent for a live-music information system. Your goal is to extract accurate official concert information to serve music fans. Follow the workflow below.
 
-1. 対象アーティストの公式サイトから、指定の期間内に開催される全てのツアー詳細ページを探索。複数ある場合も漏れが無いように。
+1. Starting from the artist's official-site host, use the url_context and google_search tools to comprehensively discover the artist's tour and concert pages. A tour may have a dedicated page on a domain different from the official site — include those too so nothing is missed.
 
-2. 全てのツアー日程の正確な情報を読み込み、下記の出力フォーマットで指定されたフィールドに値をセット。
+2. Extract both of the following that take place on or after the given start date:
+   - Tours: multi-venue / multi-date runs. Emit one <tour> block per tour, with one <event> per date.
+   - Standalone shows: solo one-off shows, fan-club-only shows, and 2-4 act named co-headliner bills (対バン). Emit one <standalone> block with a single <event>.
+   Exclude music festivals that have a multi-artist lineup (events where the target artist is only one of many performers). A 2-4 act named co-headliner bill is NOT a festival and MUST be extracted as a standalone.
+
+3. Read each page's exact information and set the fields in the output format below.
 
 <extracted>
   <tour>
@@ -120,42 +126,7 @@ const (
       <open_time>開場 17:00</open_time>
       <start_time>開演 18:00</start_time>
     </event>
-    <event>
-      <venue>大阪府・Zepp Osaka Bayside</venue>
-      <country>JP</country>
-      <local_date>2026.3.16(日)</local_date>
-      <open_time>17:00</open_time>
-      <start_time>18:00</start_time>
-    </event>
   </tour>
-  <tour>...</tour>
-</extracted>
-
-抽出ルール:
-- source_url: そのツアー用の特設ページ、もしくは最も詳細な情報を記載しているページのURL。
-- country: コンサート開催予定の国コード (ISO 3166-1 alpha-2)。
-- country 以外は必ず、verbatim (一字一句そのまま) でコピーすること。
-- ページに該当する情報が記載されていない場合は、タグを空のままにすること。
-- local_date に年表記が無い場合 (例: "01.16. sat" や "8月7日" のように MM.DD のみ) は、ページ context (tour title の年表記、ページ見出しの開催年度、ツアー会期の前後関係など) から年を推定し、verbatim な日付の先頭に年を付加して emit する。 例: tour title が "TOUR 2026-2027" で 1月-3月 の日程が翌年に該当する場合、"2027.01.16. sat" のように年を補う。
-
-3. venue, local_date, start_time の3つのフィールドが同じコンサートは重複と判定し、除外する。
-
-4. 指定期間中の全てのツアーの全ての日程がMECEで抽出できていることをチェック。
-
-5. 余計なテキストは含めず、XMLのみをレスポンスに含める。
-`
-
-	// systemInstructionStep1Standalone is the Step 1 system instruction
-	// used by the standalone-focused slice. Mirrors the tour instruction
-	// in workflow shape; the inner <event> appears exactly once per
-	// <standalone>.
-	systemInstructionStep1Standalone = `あなたはライブ音楽情報システム向けのデータ抽出エージェントです。下記の手順に従って、音楽ファンに提供するための、正確な公式情報を抽出することがゴールです。
-
-1. 対象アーティストの公式サイトから、指定の期間内に開催される全ての単発公演の告知ページを探索。複数ある場合も漏れが無いように。
-
-2. 全ての公演の正確な情報を読み込み、下記の出力フォーマットで指定されたフィールドに値をセット。
-
-<extracted>
   <standalone>
     <title>UVERworld 武道館単独公演 2026</title>
     <source_url>https://www.uverworld.jp/news/detail/budokan</source_url>
@@ -167,21 +138,20 @@ const (
       <start_time>19:00</start_time>
     </event>
   </standalone>
-  <standalone>...</standalone>
 </extracted>
 
-抽出ルール:
-- source_url: その公演用の特設ページ、もしくは最も詳細な情報を記載しているページのURL。
-- country: コンサート開催予定の国コード (ISO 3166-1 alpha-2)。
-- country 以外は必ず、verbatim (一字一句そのまま) でコピーすること。
-- ページに該当する情報が記載されていない場合は、タグを空のままにすること。
-- local_date に年表記が無い場合 (例: "01.16. sat" や "8月7日" のように MM.DD のみ) は、ページ context (公演タイトルの年表記、ページ見出しの開催年度など) から年を推定し、verbatim な日付の先頭に年を付加して emit する。 例: タイトルが "武道館単独公演 2027" で日付が "01.16. sat" の場合、"2027.01.16. sat" のように年を補う。
+Extraction rules:
+- source_url: the dedicated page for that tour/show, or the page with the most detailed information.
+- country: the ISO 3166-1 alpha-2 code of the country where the concert is held.
+- Every field except country MUST be copied verbatim (character for character).
+- Leave a tag empty when the page does not provide that information.
+- When local_date has no year (e.g. "01.16. sat" or "8月7日", i.e. only MM.DD), infer the year from page context (the year in the title, the heading's event year, the sequence of the run's dates) and prepend it to the verbatim date. Example: if the title is "TOUR 2026-2027" and the January-March dates fall in the following year, emit "2027.01.16. sat".
 
-3. venue, local_date, start_time の3つのフィールドが同じコンサートは重複と判定し、除外する。
+4. Treat concerts that share the same venue, local_date, and start_time as duplicates and drop them.
 
-4. 指定期間中の全ての単発公演がMECEで抽出できていることをチェック。
+5. Verify that every tour and standalone on or after the start date is covered (MECE).
 
-5. 余計なテキストは含めず、XMLのみをレスポンスに含める。
+6. Respond with the XML only — no extra text.
 `
 
 	// systemInstructionStep2Parse is the Step 2 system instruction. Static
@@ -195,19 +165,12 @@ You receive a JSON array of input events with raw venue, country, and date/time 
 3. Output only the JSON defined by the schema. No Markdown decoration or comments.
 `
 
-	// promptTemplateStep1Tour carries the per-call variables for a Step 1
-	// tour slice. Placeholders (4): from_date (YYYY-MM-DD), to_date
-	// (YYYY-MM-DD), artist name, official site host.
-	promptTemplateStep1Tour = `開催日が %s から %s に含まれる %s のツアーを全て抽出して。音楽フェスと単発公演は除外して。
+	// promptTemplateStep1 carries the per-call variables for the single Step 1
+	// slice. Placeholders (3): from_date (YYYY-MM-DD), artist name, official
+	// site host. The discovery window is open-ended (no end date).
+	promptTemplateStep1 = `Extract all tours and standalone shows taking place on or after %s for %s. Exclude music festivals with a multi-artist lineup.
 
-公式サイト host: %s
-`
-
-	// promptTemplateStep1Standalone carries the per-call variables for a
-	// Step 1 standalone slice. Same 4 placeholders as the tour template.
-	promptTemplateStep1Standalone = `開催日が %s から %s に含まれる %s の単発公演 (ソロ単独ライブ、ファンクラブ限定ライブ、2-4組の named co-headliner との対バン) を全て抽出して。音楽フェスとツアーは除外して。
-
-公式サイト host: %s
+Official site host: %s
 `
 
 	// Step 2's prompt body is the JSON list payload itself (output of
@@ -676,52 +639,27 @@ func mirrorStep2(md *SearchMetadata, pm *PassMetadata) {
 type Step1Slice struct {
 	// Name is a stable identifier used in logs and per-slice metadata.
 	Name string
-	// SystemInstruction selects the tour-only or standalone-only Step 1
-	// system instruction.
+	// SystemInstruction is the Step 1 system instruction for this slice.
 	SystemInstruction string
-	// PromptTemplate is the per-slice prompt template (tour or standalone
-	// variant). It carries 4 %s placeholders in order: from_date, to_date,
-	// artist name, official site host.
+	// PromptTemplate is the Step 1 prompt template. It carries 3 %s
+	// placeholders in order: from_date, artist name, official site host.
 	PromptTemplate string
 	// FromMonthsOffset is the offset in calendar months added to the
 	// base date (time.Now()) to compute the slice's from_date.
 	FromMonthsOffset int
-	// ToMonthsOffset is the offset in calendar months added to the base
-	// date to compute the slice's to_date.
-	ToMonthsOffset int
 }
 
-// defaultStep1Slices is the three-slice split used by SearchExt:
-//  1. Tours opening within the next 12 months.
-//  2. Tours opening between 12 and 24 months from now.
-//  3. Upcoming one-off / standalone shows (any time in the next 24 months).
-//
-// Each slice's prompt narrows the open-date window so the model can
-// focus on a single bucket per call. Cross-slice duplicates (e.g. the
-// same tour discovered by both tour slices on a boundary date) are
-// removed downstream by parseStep2Response's (local_date, venue,
-// start_time) dedup.
+// defaultStep1Slices is the single grounded slice used by SearchExt. One
+// call extracts both tours and standalones from the base date onward
+// (open-ended window). The fan-out mechanism is retained so the slice
+// count stays configurable, but the default is one. Duplicates are removed
+// downstream by parseStep2Response's (local_date, venue, start_time) dedup.
 var defaultStep1Slices = []Step1Slice{
 	{
-		Name:              "tours_near",
-		SystemInstruction: systemInstructionStep1Tour,
-		PromptTemplate:    promptTemplateStep1Tour,
+		Name:              "all",
+		SystemInstruction: systemInstructionStep1,
+		PromptTemplate:    promptTemplateStep1,
 		FromMonthsOffset:  0,
-		ToMonthsOffset:    12,
-	},
-	{
-		Name:              "tours_far",
-		SystemInstruction: systemInstructionStep1Tour,
-		PromptTemplate:    promptTemplateStep1Tour,
-		FromMonthsOffset:  12,
-		ToMonthsOffset:    24,
-	},
-	{
-		Name:              "standalones",
-		SystemInstruction: systemInstructionStep1Standalone,
-		PromptTemplate:    promptTemplateStep1Standalone,
-		FromMonthsOffset:  0,
-		ToMonthsOffset:    24,
 	},
 }
 
@@ -805,8 +743,7 @@ func (s *ConcertSearcher) runStep1Slice(
 	attrs []slog.Attr,
 ) (string, *PassMetadata, error) {
 	from := baseDate.AddDate(0, slice.FromMonthsOffset, 0).Format("2006-01-02")
-	to := baseDate.AddDate(0, slice.ToMonthsOffset, 0).Format("2006-01-02")
-	prompt := fmt.Sprintf(slice.PromptTemplate, from, to, artistName, officialSiteHost)
+	prompt := fmt.Sprintf(slice.PromptTemplate, from, artistName, officialSiteHost)
 
 	now := time.Now().UTC().Truncate(time.Second)
 	searchTool := &genai.Tool{

--- a/internal/infrastructure/gcp/gemini/searcher_integration_test.go
+++ b/internal/infrastructure/gcp/gemini/searcher_integration_test.go
@@ -39,10 +39,12 @@ const (
 
 // abMatrix returns the Cartesian product of the matrix axes plus repetitions.
 //
-// Current run is a tuning matrix on the most complex artist (Vaundy):
-//   - Models: 3.1-flash-lite, 3.5-flash (3-flash-preview dropped — dominated)
+// Current run is a cost-optimization tuning matrix on the most complex
+// artist (Vaundy), using the single consolidated Step 1 slice:
+//   - Extract model: gemini-3.6-flash (cell.Model); parse model fixed to
+//     gemini-3.1-flash-lite (see the parseModel default below).
 //   - Temperature: 1.0 (fixed — prior 54-cell run showed monotonic gain to 1.0)
-//   - Thinking: medium, high (re-comparing now that prompt + schema changed)
+//   - Thinking: low, medium (extract-step tuning to reduce query fan-out cost)
 //   - Artists: filtered to Vaundy via GEMINI_AB_EVAL_ARTISTS (largest fixture,
 //     most tour/standalone/festival edge cases)
 //   - Repetitions: 3 (more samples per cell since artist count is small)
@@ -87,8 +89,7 @@ func abMatrix(artists []gemini.GroundTruthArtist) []abCell {
 		}}
 	}
 	models := []string{
-		"gemini-3.1-flash-lite",
-		"gemini-3.5-flash",
+		"gemini-3.6-flash",
 	}
 	if filter := strings.TrimSpace(os.Getenv(abEvalModelsEnvVar)); filter != "" {
 		want := map[string]bool{}
@@ -105,7 +106,7 @@ func abMatrix(artists []gemini.GroundTruthArtist) []abCell {
 	}
 
 	temps := []float32{1.0}
-	thinks := []string{"medium", "high"}
+	thinks := []string{"low", "medium"}
 	const reps = 3
 
 	var cells []abCell
@@ -343,16 +344,16 @@ func runCell(
 		Repetition:    cell.Repetition,
 	}
 
-	// In the matrix harness, cell.Model and cell.Thinking are applied
-	// uniformly across both steps unless per-step env overrides are set.
-	// Production wire-up sets these independently via
-	// GCP_GEMINI_SEARCH_MODEL_{DISCOVERY,EXTRACT,PARSE} (and the future
-	// equivalents for thinking).
+	// In the matrix harness, cell.Model sets the Step 1 (extract) model —
+	// the axis under test. The Step 2 (parse) model is fixed to
+	// gemini-3.1-flash-lite (matching the production default), independent of
+	// the extract axis, since only the extract step is being tuned. Both are
+	// overridable via GEMINI_AB_EVAL_MODEL_{EXTRACT,PARSE}.
 	extractModel := cell.Model
 	if m := strings.TrimSpace(os.Getenv(abEvalModelExtractEnvVar)); m != "" {
 		extractModel = m
 	}
-	parseModel := cell.Model
+	parseModel := "gemini-3.1-flash-lite"
 	if m := strings.TrimSpace(os.Getenv(abEvalModelParseEnvVar)); m != "" {
 		parseModel = m
 	}

--- a/internal/infrastructure/gcp/gemini/testdata/README.md
+++ b/internal/infrastructure/gcp/gemini/testdata/README.md
@@ -21,6 +21,16 @@ GEMINI_AB_EVAL=1 GCP_PROJECT_ID=<dev-project> \
   ./internal/infrastructure/gcp/gemini/...
 ```
 
+Cost-optimization run (Vaundy only, extract `gemini-3.6-flash`, thinking `low`/`medium`,
+single consolidated Step 1 slice — 2 thinking × 3 reps = 6 cells):
+
+```bash
+GEMINI_AB_EVAL=1 GEMINI_AB_EVAL_ARTISTS=Vaundy GCP_PROJECT_ID=<dev-project> \
+  go test -tags=integration -timeout=1h -v \
+  -run TestConcertSearcher_ABEval \
+  ./internal/infrastructure/gcp/gemini/...
+```
+
 Smoke run (1 cell, ~$0.01, ~2 min — for auth + API sanity check):
 
 ```bash
@@ -36,14 +46,33 @@ Prerequisites:
 - Vertex AI + Google Search grounding enabled on the project.
 - Project has budget for the run (grounding is free under 5,000/month).
 
+## Latest result (2026-07-27, optimize-concert-searcher-cost)
+
+Run: `gemini-3.6-flash` extract / `gemini-3.1-flash-lite` parse, single consolidated
+Step 1 slice, Vaundy + SUPER BEAVER, thinking `{low, medium}` × 3 reps.
+
+| Artist | thinking | recall_public (mean) | note |
+|---|---|---|---|
+| SUPER BEAVER | low | 0.97 | good |
+| SUPER BEAVER | medium | 0.99 | near-perfect |
+| Vaundy | low | 0.77 | unstable — one run 0.61, **dropped the 2028 tour tail (10 dates)** |
+| Vaundy | medium | 0.89 | stable; only misses = 2 "会場未定/TBD" placeholder venues (fixture artifact) |
+
+**Decision: thinking = `medium`.** `low` truncates long tours; `medium` enumerates them
+fully. All cells returned `webSearchQueries = 0` (grounding stays invisible on 3.6-flash),
+and the harness cost is `$0` — the search-query fan-out is not observable here and must be
+verified post-deploy via the "search query gemini 3 paid" billing SKU.
+
 ## Matrix axes (full run)
 
 | Axis | Values |
 |---|---|
-| Model | `gemini-3.1-flash-lite` |
-| Temperature | 0.2, 0.5, 1.0 |
-| ThinkingLevel | `medium`, `high` |
-| Artist | UVERworld, Vaundy, SUPER BEAVER |
+| Extract model (Step 1) | `gemini-3.6-flash` (cell.Model) |
+| Parse model (Step 2) | `gemini-3.1-flash-lite` (fixed) |
+| Step 1 slices | 1 (consolidated tours + standalones, open-ended window) |
+| Temperature | 1.0 |
+| ThinkingLevel | `low`, `medium` |
+| Artist | UVERworld, Vaundy, SUPER BEAVER (filter to Vaundy for the cost run) |
 | Repetitions | 3 |
 
 Excluded by design: Gemini 3 Flash Preview (unstable under grounding load —

--- a/internal/infrastructure/gcp/gemini/testdata/ab_ground_truth.json
+++ b/internal/infrastructure/gcp/gemini/testdata/ab_ground_truth.json
@@ -1,6 +1,6 @@
 {
-  "evaluation_from": "2026-05-20",
-  "captured_at": "2026-05-21",
+  "evaluation_from": "2026-07-27",
+  "captured_at": "2026-07-27",
   "artists": [
     {
       "id": "019e302a-01ec-7b8e-80e4-2111c2e4fe0a",
@@ -121,83 +121,71 @@
       "official_site_url": "https://vaundy.jp/",
       "events": [
         {
-          "event_name": "NUMBER SHOT 2026",
+          "event_name": "NUMBER SHOT2026",
           "venue": "福岡PayPayドーム・シーサイドももち海浜公園地行浜ビーチ",
           "admin_area": "福岡県",
           "local_date": "2026-08-01",
           "open_time": "2026-08-01T08:30:00+09:00",
-          "start_time": "2026-08-01T10:30:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11180",
+          "start_time": "2026-08-01T19:00:00+09:00",
+          "source_url": "https://vaundy.jp/news/detail/11181",
           "confidence": "confirmed",
           "visibility": "public",
           "excluded_per_spec": true
         },
         {
           "event_name": "OSAKA GIGANTIC MUSIC FESTIVAL 2026 -THANKS 10TH GIGA-",
-          "venue": "舞洲スポーツアイランド",
+          "venue": "大阪舞洲スポーツアイランド ジャイガ特設会場",
           "admin_area": "大阪府",
           "local_date": "2026-08-02",
           "open_time": "",
-          "start_time": "",
-          "source_url": "https://vaundy.jp/news/detail/11202",
+          "start_time": "2026-08-02T20:20:00+09:00",
+          "source_url": "https://vaundy.jp/news/detail/11203",
           "confidence": "confirmed",
           "visibility": "public",
           "excluded_per_spec": true
         },
         {
-          "event_name": "Vaundy VAWS one man live 2026",
+          "event_name": "Vaundy VAWS one man live 2026 at Zepp Sapporo",
           "venue": "Zepp Sapporo",
           "admin_area": "北海道",
           "local_date": "2026-08-12",
           "open_time": "2026-08-12T18:00:00+09:00",
           "start_time": "2026-08-12T19:00:00+09:00",
-          "source_url": "https://member.vaundy.jp/news/detail/11073",
+          "source_url": "https://vaundy.jp/news/detail/11070",
           "confidence": "confirmed",
           "visibility": "members-only"
         },
         {
-          "event_name": "Vaundy VAWS one man live 2026",
+          "event_name": "Vaundy VAWS one man live 2026 at Zepp Sapporo",
           "venue": "Zepp Sapporo",
           "admin_area": "北海道",
           "local_date": "2026-08-13",
           "open_time": "2026-08-13T18:00:00+09:00",
           "start_time": "2026-08-13T19:00:00+09:00",
-          "source_url": "https://member.vaundy.jp/news/detail/11073",
+          "source_url": "https://vaundy.jp/news/detail/11071",
           "confidence": "confirmed",
           "visibility": "members-only"
-        },
-        {
-          "event_name": "RISING SUN ROCK FESTIVAL 2026 in EZO",
-          "venue": "石狩湾新港樽川ふ頭横野外特設ステージ",
-          "admin_area": "北海道",
-          "local_date": "2026-08-14",
-          "open_time": "2026-08-14T10:00:00+09:00",
-          "start_time": "2026-08-14T14:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11178",
-          "confidence": "tentative",
-          "visibility": "public",
-          "excluded_per_spec": true
         },
         {
           "event_name": "RISING SUN ROCK FESTIVAL 2026 in EZO",
           "venue": "石狩湾新港樽川ふ頭横野外特設ステージ",
           "admin_area": "北海道",
           "local_date": "2026-08-15",
-          "open_time": "2026-08-15T10:00:00+09:00",
-          "start_time": "2026-08-15T12:30:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11178",
-          "confidence": "tentative",
+          "open_time": "",
+          "start_time": "2026-08-15T21:00:00+09:00",
+          "source_url": "https://vaundy.jp/news/detail/11179",
+          "confidence": "confirmed",
           "visibility": "public",
           "excluded_per_spec": true
         },
         {
-          "event_name": "音楽と髭達2026-TIME MACHINE-",
+          "event_name": "音楽と髭達2026 -TIME MACHINE-",
           "venue": "HARD OFF ECOスタジアム新潟",
           "admin_area": "新潟県",
           "local_date": "2026-08-29",
-          "open_time": "2026-08-29T09:00:00+09:00",
-          "start_time": "2026-08-29T11:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11193",
+          "open_time": "",
+          "start_time": "2026-08-29T18:00:00+09:00",
+          "source_url": "https://vaundy.jp/news/detail/11194",
           "confidence": "confirmed",
           "visibility": "public",
           "excluded_per_spec": true
@@ -207,9 +195,9 @@
           "venue": "山中湖交流プラザ きらら",
           "admin_area": "山梨県",
           "local_date": "2026-08-30",
-          "open_time": "2026-08-30T09:00:00+09:00",
-          "start_time": "2026-08-30T10:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11185",
+          "open_time": "",
+          "start_time": "2026-08-30T19:10:00+09:00",
+          "source_url": "https://vaundy.jp/news/detail/11186",
           "confidence": "confirmed",
           "visibility": "public",
           "excluded_per_spec": true
@@ -221,7 +209,7 @@
           "local_date": "2026-09-05",
           "open_time": "2026-09-05T16:30:00+09:00",
           "start_time": "2026-09-05T18:00:00+09:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -232,18 +220,18 @@
           "local_date": "2026-09-06",
           "open_time": "2026-09-06T14:30:00+09:00",
           "start_time": "2026-09-06T16:00:00+09:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
         {
           "event_name": "ROCK IN JAPAN FESTIVAL 2026",
-          "venue": "国営ひたち海浜公園",
-          "admin_area": "茨城県",
+          "venue": "千葉市蘇我スポーツ公園",
+          "admin_area": "千葉県",
           "local_date": "2026-09-12",
           "open_time": "",
-          "start_time": "",
-          "source_url": "https://vaundy.jp/news/detail/11206",
+          "start_time": "2026-09-12T18:45:00+09:00",
+          "source_url": "https://vaundy.jp/news/detail/11207",
           "confidence": "confirmed",
           "visibility": "public",
           "excluded_per_spec": true
@@ -253,9 +241,9 @@
           "venue": "INSPIRE ARENA",
           "admin_area": "",
           "local_date": "2026-09-19",
-          "open_time": "2026-09-19T15:00:00+09:00",
-          "start_time": "2026-09-19T17:00:00+09:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "open_time": "",
+          "start_time": "",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -264,20 +252,20 @@
           "venue": "INSPIRE ARENA",
           "admin_area": "",
           "local_date": "2026-09-20",
-          "open_time": "2026-09-20T14:00:00+09:00",
-          "start_time": "2026-09-20T16:00:00+09:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "open_time": "",
+          "start_time": "",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
         {
-          "event_name": "熱闘 JAM 2026",
+          "event_name": "熱闘甲子園 presents 熱闘 JAM 2026",
           "venue": "GLION ARENA KOBE",
           "admin_area": "兵庫県",
           "local_date": "2026-09-23",
           "open_time": "2026-09-23T14:00:00+09:00",
           "start_time": "2026-09-23T15:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11200",
+          "source_url": "https://vaundy.jp/news/detail/11201",
           "confidence": "confirmed",
           "visibility": "public",
           "excluded_per_spec": true
@@ -287,9 +275,9 @@
           "venue": "AsiaWorld-Arena",
           "admin_area": "",
           "local_date": "2026-10-03",
-          "open_time": "2026-10-03T16:00:00+08:00",
-          "start_time": "2026-10-03T20:00:00+08:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "open_time": "",
+          "start_time": "",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -300,7 +288,7 @@
           "local_date": "2026-10-24",
           "open_time": "2026-10-24T16:30:00+09:00",
           "start_time": "2026-10-24T18:00:00+09:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -311,7 +299,7 @@
           "local_date": "2026-10-25",
           "open_time": "2026-10-25T14:30:00+09:00",
           "start_time": "2026-10-25T16:00:00+09:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -320,9 +308,9 @@
           "venue": "Taipei Arena",
           "admin_area": "",
           "local_date": "2026-10-31",
-          "open_time": "2026-10-31T17:30:00+08:00",
-          "start_time": "2026-10-31T19:00:00+08:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "open_time": "",
+          "start_time": "",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -331,31 +319,31 @@
           "venue": "Taipei Arena",
           "admin_area": "",
           "local_date": "2026-11-01",
-          "open_time": "2026-11-01T17:30:00+08:00",
-          "start_time": "2026-11-01T19:00:00+08:00",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "open_time": "",
+          "start_time": "",
+          "source_url": "https://vaundy.jp/news/detail/11144",
           "confidence": "confirmed",
           "visibility": "public"
         },
         {
           "event_name": "Vaundy ASIA ARENA TOUR 2026 \"HORO\"",
-          "venue": "",
+          "venue": "上海（会場未定 -STAY TUNED-）",
           "admin_area": "",
           "local_date": "2026-11-14",
           "open_time": "",
           "start_time": "",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "source_url": "https://vaundy.jp/news/detail/11108",
           "confidence": "tentative",
           "visibility": "public"
         },
         {
           "event_name": "Vaundy ASIA ARENA TOUR 2026 \"HORO\"",
-          "venue": "",
+          "venue": "上海（会場未定 -STAY TUNED-）",
           "admin_area": "",
           "local_date": "2026-11-15",
           "open_time": "",
           "start_time": "",
-          "source_url": "https://member.vaundy.jp/feature/ASIAARENATOUR_2026",
+          "source_url": "https://vaundy.jp/news/detail/11108",
           "confidence": "tentative",
           "visibility": "public"
         },
@@ -366,7 +354,7 @@
           "local_date": "2027-08-14",
           "open_time": "2027-08-14T17:00:00+09:00",
           "start_time": "2027-08-14T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -377,29 +365,29 @@
           "local_date": "2027-08-15",
           "open_time": "2027-08-15T15:00:00+09:00",
           "start_time": "2027-08-15T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
         {
           "event_name": "Vaundy JAPAN ARENA TOUR 2027-2028",
-          "venue": "日本ガイシホール",
+          "venue": "クロコくんホール（旧 日本ガイシホール）",
           "admin_area": "愛知県",
           "local_date": "2027-08-28",
           "open_time": "2027-08-28T17:00:00+09:00",
           "start_time": "2027-08-28T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
         {
           "event_name": "Vaundy JAPAN ARENA TOUR 2027-2028",
-          "venue": "日本ガイシホール",
+          "venue": "クロコくんホール（旧 日本ガイシホール）",
           "admin_area": "愛知県",
           "local_date": "2027-08-29",
           "open_time": "2027-08-29T15:00:00+09:00",
           "start_time": "2027-08-29T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -410,7 +398,7 @@
           "local_date": "2027-09-19",
           "open_time": "2027-09-19T17:00:00+09:00",
           "start_time": "2027-09-19T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -421,7 +409,7 @@
           "local_date": "2027-09-20",
           "open_time": "2027-09-20T15:00:00+09:00",
           "start_time": "2027-09-20T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -432,7 +420,7 @@
           "local_date": "2027-09-25",
           "open_time": "2027-09-25T17:00:00+09:00",
           "start_time": "2027-09-25T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -443,7 +431,7 @@
           "local_date": "2027-09-26",
           "open_time": "2027-09-26T15:00:00+09:00",
           "start_time": "2027-09-26T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -454,7 +442,7 @@
           "local_date": "2027-10-02",
           "open_time": "2027-10-02T17:00:00+09:00",
           "start_time": "2027-10-02T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -465,7 +453,7 @@
           "local_date": "2027-10-03",
           "open_time": "2027-10-03T15:00:00+09:00",
           "start_time": "2027-10-03T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -476,7 +464,7 @@
           "local_date": "2027-10-16",
           "open_time": "2027-10-16T17:00:00+09:00",
           "start_time": "2027-10-16T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -487,7 +475,7 @@
           "local_date": "2027-10-17",
           "open_time": "2027-10-17T15:00:00+09:00",
           "start_time": "2027-10-17T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -498,7 +486,7 @@
           "local_date": "2027-10-23",
           "open_time": "2027-10-23T17:00:00+09:00",
           "start_time": "2027-10-23T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -509,29 +497,29 @@
           "local_date": "2027-10-24",
           "open_time": "2027-10-24T15:00:00+09:00",
           "start_time": "2027-10-24T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
         {
           "event_name": "Vaundy JAPAN ARENA TOUR 2027-2028",
-          "venue": "盛岡タカヤアリーナ(盛岡市総合アリーナ)",
+          "venue": "盛岡タカヤアリーナ（盛岡市総合アリーナ）",
           "admin_area": "岩手県",
           "local_date": "2027-11-20",
           "open_time": "2027-11-20T17:00:00+09:00",
           "start_time": "2027-11-20T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
         {
           "event_name": "Vaundy JAPAN ARENA TOUR 2027-2028",
-          "venue": "盛岡タカヤアリーナ(盛岡市総合アリーナ)",
+          "venue": "盛岡タカヤアリーナ（盛岡市総合アリーナ）",
           "admin_area": "岩手県",
           "local_date": "2027-11-21",
-          "open_time": "2027-11-21T15:00:00+09:00",
-          "start_time": "2027-11-21T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "open_time": "2027-11-21T17:00:00+09:00",
+          "start_time": "2027-11-21T18:00:00+09:00",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -542,7 +530,7 @@
           "local_date": "2027-11-27",
           "open_time": "",
           "start_time": "",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "tentative",
           "visibility": "public"
         },
@@ -553,7 +541,7 @@
           "local_date": "2027-11-28",
           "open_time": "",
           "start_time": "",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "tentative",
           "visibility": "public"
         },
@@ -564,7 +552,7 @@
           "local_date": "2027-12-11",
           "open_time": "2027-12-11T17:00:00+09:00",
           "start_time": "2027-12-11T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -575,7 +563,7 @@
           "local_date": "2027-12-12",
           "open_time": "2027-12-12T15:00:00+09:00",
           "start_time": "2027-12-12T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -586,7 +574,7 @@
           "local_date": "2028-01-09",
           "open_time": "2028-01-09T17:00:00+09:00",
           "start_time": "2028-01-09T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -597,7 +585,7 @@
           "local_date": "2028-01-10",
           "open_time": "2028-01-10T15:00:00+09:00",
           "start_time": "2028-01-10T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -608,7 +596,7 @@
           "local_date": "2028-01-15",
           "open_time": "2028-01-15T17:00:00+09:00",
           "start_time": "2028-01-15T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -619,7 +607,7 @@
           "local_date": "2028-01-16",
           "open_time": "2028-01-16T15:00:00+09:00",
           "start_time": "2028-01-16T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -630,7 +618,7 @@
           "local_date": "2028-01-22",
           "open_time": "2028-01-22T17:00:00+09:00",
           "start_time": "2028-01-22T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -641,7 +629,7 @@
           "local_date": "2028-01-23",
           "open_time": "2028-01-23T15:00:00+09:00",
           "start_time": "2028-01-23T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -652,7 +640,7 @@
           "local_date": "2028-02-05",
           "open_time": "2028-02-05T17:00:00+09:00",
           "start_time": "2028-02-05T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -663,7 +651,7 @@
           "local_date": "2028-02-06",
           "open_time": "2028-02-06T15:00:00+09:00",
           "start_time": "2028-02-06T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -674,7 +662,7 @@
           "local_date": "2028-02-26",
           "open_time": "2028-02-26T17:00:00+09:00",
           "start_time": "2028-02-26T18:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -685,7 +673,7 @@
           "local_date": "2028-02-27",
           "open_time": "2028-02-27T15:00:00+09:00",
           "start_time": "2028-02-27T16:00:00+09:00",
-          "source_url": "https://vaundy.jp/news/detail/11145",
+          "source_url": "https://member.vaundy.jp/feature/ARENATOUR_2728?lang=ja",
           "confidence": "confirmed",
           "visibility": "public"
         }
@@ -697,46 +685,13 @@
       "official_site_url": "http://www.super-beaver.com/",
       "events": [
         {
-          "event_name": "都会のラクダ TOUR 2026-2027 〜ラクダの人生、ゴーゴーゴー〜",
-          "venue": "広島文化学園HBGホール",
-          "admin_area": "広島県",
-          "local_date": "2026-07-07",
-          "open_time": "2026-07-07T17:00:00+09:00",
-          "start_time": "2026-07-07T18:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/live_information/detail/6038",
-          "confidence": "confirmed",
-          "visibility": "public"
-        },
-        {
-          "event_name": "都会のラクダ TOUR 2026-2027 〜ラクダの人生、ゴーゴーゴー〜",
-          "venue": "下関市民会館 大ホール",
-          "admin_area": "山口県",
-          "local_date": "2026-07-12",
-          "open_time": "2026-07-12T17:30:00+09:00",
-          "start_time": "2026-07-12T18:30:00+09:00",
-          "source_url": "https://sp.super-beaver.com/live_information/detail/6039",
-          "confidence": "confirmed",
-          "visibility": "public"
-        },
-        {
-          "event_name": "都会のラクダ TOUR 2026-2027 〜ラクダの人生、ゴーゴーゴー〜",
-          "venue": "ベネックス長崎ブリックホール 大ホール",
-          "admin_area": "長崎県",
-          "local_date": "2026-07-14",
-          "open_time": "2026-07-14T17:30:00+09:00",
-          "start_time": "2026-07-14T18:30:00+09:00",
-          "source_url": "https://sp.super-beaver.com/live_information/detail/6040",
-          "confidence": "confirmed",
-          "visibility": "public"
-        },
-        {
           "event_name": "都会のラクダ DOME TOUR 2026",
           "venue": "京セラドーム大阪",
           "admin_area": "大阪府",
           "local_date": "2026-08-01",
           "open_time": "2026-08-01T15:00:00+09:00",
           "start_time": "2026-08-01T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/live_information/detail/6031",
+          "source_url": "https://sp.super-beaver.com/feature/dometour2026",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -747,7 +702,7 @@
           "local_date": "2026-08-02",
           "open_time": "2026-08-02T15:00:00+09:00",
           "start_time": "2026-08-02T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/live_information/detail/6032",
+          "source_url": "https://sp.super-beaver.com/feature/dometour2026",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -813,7 +768,7 @@
           "local_date": "2026-09-10",
           "open_time": "2026-09-10T17:30:00+09:00",
           "start_time": "2026-09-10T18:30:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6046",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -846,7 +801,7 @@
           "local_date": "2026-10-03",
           "open_time": "2026-10-03T16:30:00+09:00",
           "start_time": "2026-10-03T17:30:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6047",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -857,7 +812,7 @@
           "local_date": "2026-10-09",
           "open_time": "2026-10-09T17:30:00+09:00",
           "start_time": "2026-10-09T18:30:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6048",
           "confidence": "confirmed",
           "visibility": "public"
         },
@@ -868,9 +823,21 @@
           "local_date": "2026-10-16",
           "open_time": "2026-10-16T17:30:00+09:00",
           "start_time": "2026-10-16T18:30:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6049",
           "confidence": "confirmed",
           "visibility": "public"
+        },
+        {
+          "event_name": "murffin discs 20th Anniversary \"murffin Carnival!!\"",
+          "venue": "国立代々木競技場 第一体育館",
+          "admin_area": "東京都",
+          "local_date": "2026-10-18",
+          "open_time": "2026-10-18T14:00:00+09:00",
+          "start_time": "2026-10-18T14:30:00+09:00",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6062",
+          "confidence": "confirmed",
+          "visibility": "public",
+          "excluded_per_spec": true
         },
         {
           "event_name": "都会のラクダ TOUR 2026-2027 〜ラクダの人生、ゴーゴーゴー〜",
@@ -879,8 +846,8 @@
           "local_date": "2027-01-16",
           "open_time": "2027-01-16T16:30:00+09:00",
           "start_time": "2027-01-16T18:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6050",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -890,8 +857,8 @@
           "local_date": "2027-01-17",
           "open_time": "2027-01-17T15:30:00+09:00",
           "start_time": "2027-01-17T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6051",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -901,8 +868,8 @@
           "local_date": "2027-01-23",
           "open_time": "2027-01-23T16:00:00+09:00",
           "start_time": "2027-01-23T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6052",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -912,8 +879,8 @@
           "local_date": "2027-01-24",
           "open_time": "2027-01-24T16:00:00+09:00",
           "start_time": "2027-01-24T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6053",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -923,8 +890,8 @@
           "local_date": "2027-02-13",
           "open_time": "2027-02-13T16:00:00+09:00",
           "start_time": "2027-02-13T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6054",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -934,8 +901,8 @@
           "local_date": "2027-02-14",
           "open_time": "2027-02-14T16:00:00+09:00",
           "start_time": "2027-02-14T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6055",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -945,8 +912,8 @@
           "local_date": "2027-02-20",
           "open_time": "2027-02-20T16:00:00+09:00",
           "start_time": "2027-02-20T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6056",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -956,8 +923,8 @@
           "local_date": "2027-02-21",
           "open_time": "2027-02-21T16:00:00+09:00",
           "start_time": "2027-02-21T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6057",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -967,8 +934,8 @@
           "local_date": "2027-03-06",
           "open_time": "2027-03-06T16:00:00+09:00",
           "start_time": "2027-03-06T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6058",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -978,8 +945,8 @@
           "local_date": "2027-03-07",
           "open_time": "2027-03-07T16:00:00+09:00",
           "start_time": "2027-03-07T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6059",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -989,8 +956,8 @@
           "local_date": "2027-03-20",
           "open_time": "2027-03-20T16:00:00+09:00",
           "start_time": "2027-03-20T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6060",
+          "confidence": "confirmed",
           "visibility": "public"
         },
         {
@@ -1000,8 +967,8 @@
           "local_date": "2027-03-21",
           "open_time": "2027-03-21T16:00:00+09:00",
           "start_time": "2027-03-21T17:00:00+09:00",
-          "source_url": "https://sp.super-beaver.com/feature/tour2627",
-          "confidence": "tentative",
+          "source_url": "https://sp.super-beaver.com/live_information/detail/6061",
+          "confidence": "confirmed",
           "visibility": "public"
         }
       ]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -301,7 +301,7 @@ type GCPConfig struct {
 	// there is no shared workload-wide fallback.
 	//
 	// Step defaults:
-	//   - Step 1 (grounded extract, GoogleSearch + URLContext, no schema): gemini-3.5-flash
+	//   - Step 1 (grounded extract, GoogleSearch + URLContext, no schema): gemini-3.6-flash
 	//   - Step 2 (JSON coerce, responseJsonSchema, no tools): gemini-3.1-flash-lite
 	GeminiSearchModelExtract string `envconfig:"GCP_GEMINI_SEARCH_MODEL_EXTRACT"`
 	GeminiSearchModelParse   string `envconfig:"GCP_GEMINI_SEARCH_MODEL_PARSE"`
@@ -382,7 +382,7 @@ type GCPConfig struct {
 // flash's reliability with those tools; Step 2 is a pure text-to-JSON
 // coercion with no tools where lite is cheap and reliable.
 const (
-	defaultSearchModelExtract = "gemini-3.5-flash"
+	defaultSearchModelExtract = "gemini-3.6-flash"
 	defaultSearchModelParse   = "gemini-3.1-flash-lite"
 )
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -441,6 +441,18 @@ func TestGCPConfig_ParserModelResolution(t *testing.T) {
 	}
 }
 
+func TestGCPConfig_SearchModelExtractResolution(t *testing.T) {
+	t.Run("env override takes precedence", func(t *testing.T) {
+		c := GCPConfig{GeminiSearchModelExtract: "gemini-3.5-flash"}
+		assert.Equal(t, "gemini-3.5-flash", c.SearchModelExtract())
+	})
+	t.Run("default applied when unset", func(t *testing.T) {
+		c := GCPConfig{}
+		assert.Equal(t, defaultSearchModelExtract, c.SearchModelExtract())
+		assert.Equal(t, "gemini-3.6-flash", c.SearchModelExtract())
+	})
+}
+
 func TestGCPConfig_SearchCacheTTLResolution(t *testing.T) {
 	t.Run("env override takes precedence", func(t *testing.T) {
 		c := GCPConfig{GeminiSearchCacheTTL: 72 * time.Hour}


### PR DESCRIPTION
## 🔗 Related Issue

Refs #323 (also relates to #303)

<!-- Not "Closes": the cost-reduction goal is only proven once deployed and the
"search query gemini 3 paid" billing SKU drops on the next prod concert-discovery
run. Keeping #323 open until that post-deploy verification. -->

## 📝 Summary of Changes

**Why.** The `concert-discovery` Step 1 grounded call dominates Gemini spend. The
`google_search` tool fans out into ~22 **invisible** billed search queries per request
on `gemini-3.5-flash` (they never appear in `groundingMetadata.webSearchQueries`),
amplified 3× by the three-slice fan-out (`tours_near` / `tours_far` / `standalones`).
Search-query charges were ~59–69% of total Gemini spend (June ¥3,298, recurring in July).

**What.** Reduce both the call volume and per-call cost of Step 1:

- **Model**: extract-step default `gemini-3.5-flash` → `gemini-3.6-flash` (cheaper output,
  better token efficiency). `sales-phase-discovery` / `merch-discovery` pin flash-lite via
  env and are **unaffected**.
- **Single slice**: collapse the three Step 1 slices into one that extracts both tours and
  standalones over an **open-ended (start-date-only)** window (drops the `to_date` placeholder).
- **Consolidated English prompt**: replace the two Japanese tour/standalone instructions with
  one English `systemInstructionStep1` — includes off-domain tour pages, excludes multi-artist
  festivals (2–4 act co-headliner bills stay standalones).
- `google_search` + `url_context` are **kept** (grounding is required for coverage).

**A/B result** (dev key, refreshed 2026-07-27 fixture: Vaundy + SUPER BEAVER, thinking {low, medium}):

| Artist | thinking | recall_public (mean) |
|---|---|---|
| SUPER BEAVER | low / medium | 0.97 / 0.99 |
| Vaundy | low / medium | 0.77 (one run 0.61, **dropped the 2028 tour tail**) / 0.89 (stable) |

→ **thinking = `medium`** chosen: `low` truncates long tours; `medium` enumerates them fully
(its only misses are 2 unmatchable "会場未定/TBD" placeholder venues — a fixture artifact).
All cells returned `webSearchQueries = 0`, so the search-query fan-out is **not observable in
the API or the A/B harness** (`total_cost=$0`) — it is verified **post-deploy** via the billing SKU.

OpenSpec change: `optimize-concert-searcher-cost` (specification repo).

## 📋 Commit Log

```
perf(gemini): consolidate concert Step 1 to one slice on gemini-3.6-flash
```

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [x] I have updated the relevant documentation (`testdata/README.md`).
- [x] I have run `make check` (lint + tests) locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.

## 📸 Screenshots or Logs

A/B summary (12 cells, `gemini-3.6-flash` extract / `gemini-3.1-flash-lite` parse, single slice):

```
SUPER BEAVER  th=low     recallPub=0.97  F1=0.97
SUPER BEAVER  th=medium  recallPub=0.99  F1=0.99
Vaundy        th=low     recallPub=0.77  F1=0.80   (one run 0.61: dropped 10 real 2028 dates)
Vaundy        th=medium  recallPub=0.89  F1=0.89   (misses = 2 "会場未定" placeholders only)
all cells: webSearchQueries=0, grounding_chunks=0, url_context_retrieved=0
extract thinking tokens: 3.6-flash 94–1,253  (vs 3.5-flash 4,000–5,500)
```
