### PR TITLE
docs(gemini): note grounding metadata under-reports on gemini-3.x

### DIFF
--- a/internal/infrastructure/gcp/gemini/searcher.go
+++ b/internal/infrastructure/gcp/gemini/searcher.go
@@ -1084,6 +1084,18 @@ func (s *ConcertSearcher) executePass(
 		pm.FinishMessage = candidate.FinishMessage
 		pm.AvgLogprobs = candidate.AvgLogprobs
 
+		// CAVEAT: these grounding metrics UNDER-REPORT actual grounding on
+		// gemini-3.x. On gemini-3.6-flash they come back 0/empty
+		// (WebSearchQueries, GroundingChunks, URLContextMetadata, and
+		// ToolUsePromptTokenCount) even when grounding DID execute — proven in
+		// prod 2026-07-27 when the searcher extracted YOASOBI's North America
+		// Tour 2026 (announced 2026-04-15, after the model's March-2026 training
+		// cutoff, so impossible from memory) with tool_use=0. Do NOT infer
+		// "ungrounded / memory-based / hallucinating" from these zero values;
+		// verify grounding via result freshness (post-cutoff data) instead.
+		// (Billing corollary: 3.5-flash bills grounding as per-search-query
+		// fan-out, 3.6-flash as cheap tokens — hence the cost drop with no
+		// quality loss.)
 		if g := candidate.GroundingMetadata; g != nil {
 			pm.WebSearchQueriesList = g.WebSearchQueries
 			pm.WebSearchQueries = len(g.WebSearchQueries)


### PR DESCRIPTION
## Summary

Comment-only. Documents a Gemini platform pitfall right where the grounding
metadata is read in `searcher.go`.

**The pitfall:** on `gemini-3.6-flash`, the grounding metrics
(`WebSearchQueries`, `GroundingChunks`, `URLContextMetadata`,
`ToolUsePromptTokenCount`) return **0 / empty even when grounding actually
executed**. Proven in prod on 2026-07-27: the concert searcher extracted
**YOASOBI's "North America Tour 2026"** (TD Garden … Hollywood Bowl) — a tour
**announced 2026-04-15**, after the model's **March-2026 training cutoff**, so
impossible from memory — with `tool_use=0` on every grounded request.

So a `tool_use=0` / `webSearchQueries=0` reading must **not** be interpreted as
"ungrounded / memory-based / hallucinating". The reliable signal is whether the
extracted results contain post-training-cutoff data.

This corrects earlier assumptions (and prevents future misreads when using these
metrics for cost attribution or a "is grounding working?" check).

Refs #323.
