### PR TITLE
perf(gemini): migrate merch searcher to gemini-3.6-flash + medium thinking

### DIFF
--- a/internal/infrastructure/gcp/gemini/merch_searcher_integration_test.go
+++ b/internal/infrastructure/gcp/gemini/merch_searcher_integration_test.go
@@ -251,8 +251,11 @@ func defaultMerchCases() []merchCase {
 			},
 		},
 		{
+			// Refreshed 2026-07-27 to the current tour. Vaundy has no tour-specific
+			// goods page, so the official EC store (store.plusmember.jp/vaundy) or
+			// an official-host page is the expected resolution.
 			artist:      "Vaundy",
-			series:      `Vaundy DOME TOUR 2026 "SILENCE"`,
+			series:      `Vaundy JAPAN ARENA TOUR 2027-2028`,
 			expectFound: true,
 			officialHosts: []string{
 				"vaundy.jp", "member.vaundy.jp",

--- a/internal/infrastructure/gcp/gemini/sales_phase_searcher_integration_test.go
+++ b/internal/infrastructure/gcp/gemini/sales_phase_searcher_integration_test.go
@@ -73,18 +73,22 @@ func TestSalesPhaseSearcher_Vaundy_HORO_Integration(t *testing.T) {
 
 	const (
 		artistName  = "Vaundy"
-		seriesTitle = `Vaundy ASIA ARENA TOUR 2026 "HORO"`
-		seriesID    = "vaundy-horo-2026"
+		seriesTitle = `Vaundy JAPAN ARENA TOUR 2027-2028`
+		seriesID    = "vaundy-arena-2728"
 	)
 
-	// Ground truth: the three real Japan presales (matched by apply_start day).
+	// Ground truth (refreshed 2026-07-27): the one ticket sale phase still open
+	// for this tour — ぴあ抽選先行, apply 2026-07-16 12:00 → 08-02 23:59, lottery
+	// result 2026-08-08 18:00, payment by 08-11. Verified from member.vaundy.jp
+	// /news/detail/11145. CRITICALLY this phase was **announced 2026-07-16**,
+	// AFTER gemini-3.6-flash's March-2026 training cutoff — so extracting it with
+	// the correct apply_start is only possible via LIVE grounding, not memory.
+	// This is the freshness discriminator for the flash-lite-vs-3.6-flash A/B.
 	groundTruth := []struct {
 		name  string
 		start time.Time
 	}{
-		{"VAWS Premium 先行", jst(2026, 2, 15, 20, 0)},
-		{"VAWS Member 先行", jst(2026, 3, 2, 12, 0)},
-		{"Official 先行", jst(2026, 3, 17, 12, 0)},
+		{"ぴあ抽選先行", jst(2026, 7, 16, 12, 0)},
 	}
 
 	// Default to flash-lite for both steps; allow overriding the grounded
@@ -94,7 +98,7 @@ func TestSalesPhaseSearcher_Vaundy_HORO_Integration(t *testing.T) {
 		modelExtract = m
 	}
 
-	for _, thinking := range []string{"medium", "high"} {
+	for _, thinking := range []string{"medium"} {
 		t.Run("extract="+modelExtract+"_thinking_"+thinking, func(t *testing.T) {
 			cfg := gemini.SalesPhaseConfig{
 				APIKey:          apiKey,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -358,10 +358,10 @@ type GCPConfig struct {
 	MerchDiscoveryWindow time.Duration `envconfig:"GCP_MERCH_DISCOVERY_WINDOW"`
 
 	// Thinking level for the merch-url search. Empty falls back to
-	// defaultMerchThinkingLevel ("high"). Live A/B showed Flash-Lite only obeys
-	// the "never fabricate an ID-bearing deep link; fall back to the stable
-	// store-top URL" rule at "high"; "low"/"medium" hallucinate a category_id.
-	// Accepted: "", minimal, low, medium, high.
+	// defaultMerchThinkingLevel ("medium"). gemini-3.6-flash at "medium" returns
+	// the stable ID-free official store URL and never fabricates an ID-bearing
+	// deep link; Flash-Lite needed "high" for the same rule (and still
+	// under-grounded). Accepted: "", minimal, low, medium, high.
 	GeminiMerchThinkingLevel string `envconfig:"GCP_GEMINI_MERCH_THINKING_LEVEL"`
 
 	// Look-ahead window for the sales-phase discovery job. A series is
@@ -395,16 +395,17 @@ const (
 	defaultSearchDiscoveryWindow = 14 * 24 * time.Hour
 )
 
-// Defaults for the merch-url discovery job. Flash-Lite is the cheapest model
-// that handles the single best-URL lookup well; the 60-day window matches when
-// tour merch is typically announced relative to the earliest event.
+// Defaults for the merch-url discovery job. gemini-3.6-flash grounds reliably
+// at "medium" thinking; the 60-day window matches when tour merch is typically
+// announced relative to the earliest event.
 const (
-	defaultMerchModel           = "gemini-3.1-flash-lite"
+	defaultMerchModel           = "gemini-3.6-flash"
 	defaultMerchDiscoveryWindow = 60 * 24 * time.Hour
-	// defaultMerchThinkingLevel is "high": only at "high" does Flash-Lite
-	// reliably return the stable ID-free official store URL instead of a
-	// fabricated category_id deep link (verified 5/5 in live A/B).
-	defaultMerchThinkingLevel = "high"
+	// defaultMerchThinkingLevel is "medium": live A/B (2026-07-27) showed
+	// gemini-3.6-flash at "medium" returns the stable ID-free official store URL
+	// (e.g. store.plusmember.jp/yorushika/), whereas Flash-Lite fabricated a
+	// category_id deep link at low/medium and only behaved at "high".
+	defaultMerchThinkingLevel = "medium"
 )
 
 // Defaults for the sales-phase discovery and reminder jobs.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -453,6 +453,24 @@ func TestGCPConfig_SearchModelExtractResolution(t *testing.T) {
 	})
 }
 
+func TestGCPConfig_MerchModelAndThinkingResolution(t *testing.T) {
+	t.Run("merch model default applied when unset", func(t *testing.T) {
+		c := GCPConfig{}
+		assert.Equal(t, defaultMerchModel, c.MerchModel())
+		assert.Equal(t, "gemini-3.6-flash", c.MerchModel())
+	})
+	t.Run("merch thinking default applied when unset", func(t *testing.T) {
+		c := GCPConfig{}
+		assert.Equal(t, defaultMerchThinkingLevel, c.MerchThinking())
+		assert.Equal(t, "medium", c.MerchThinking())
+	})
+	t.Run("merch env overrides take precedence", func(t *testing.T) {
+		c := GCPConfig{GeminiMerchModel: "gemini-3.1-flash-lite", GeminiMerchThinkingLevel: "high"}
+		assert.Equal(t, "gemini-3.1-flash-lite", c.MerchModel())
+		assert.Equal(t, "high", c.MerchThinking())
+	})
+}
+
 func TestGCPConfig_SearchCacheTTLResolution(t *testing.T) {
 	t.Run("env override takes precedence", func(t *testing.T) {
 		c := GCPConfig{GeminiSearchCacheTTL: 72 * time.Hour}


### PR DESCRIPTION
## 🔗 Related Issue

Refs #323

## 📝 Summary of Changes

Migrate the **merch-url discovery** search off `gemini-3.1-flash-lite` to
`gemini-3.6-flash` at `medium` thinking (mirrors the concert-searcher migration
in v1.24.0). Also refreshes the sales-phase / merch integration-test fixtures.

**Why.** Post-concert-migration, sales-phase + merch (both flash-lite) are the
remaining Gemini search-query cost, and flash-lite is also **lower quality**.
Local A/B (thinking=medium, 2026-07-27):

| Searcher | flash-lite | gemini-3.6-flash |
|---|---|---|
| sales-phase (Vaundy `ぴあ抽選先行`, announced 2026-07-16 = post-cutoff) | **0 phases** | **1/1 exact** (apply/result/payment + pia URL) |
| merch (ヨルシカ「一人称」) | **fabricated** `.../category_id=3428` | **correct** `store.plusmember.jp/yorushika/` |

3.6-flash grounds live post-cutoff data (with `tool_use=0` — metadata under-reports, as with concert) and bills it as cheap tokens instead of per-search-query fan-out.

**Changes**
- `pkg/config`: `defaultMerchModel` → `gemini-3.6-flash`, `defaultMerchThinkingLevel` → `medium` (+ config test).
- Refreshed `sales_phase` / `merch` integration-test fixtures to current Vaundy data.
- **sales-phase extract model** migrates via a cloud-provisioning env change (it overrides the shared default) — separate.

OpenSpec: `optimize-sales-merch-searcher-cost` (specification#714).

## 📋 Commit Log

```
perf(gemini): migrate merch searcher to gemini-3.6-flash + medium thinking
```

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes.
- [x] I have updated the relevant documentation (config comments).
- [x] I have run `make check` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.
