### PR TITLE
docs(job): add exit-0 rationale comment to sales-phase-discovery

### DIFF
--- a/cmd/job/sales-phase-discovery/main.go
+++ b/cmd/job/sales-phase-discovery/main.go
@@ -28,6 +28,8 @@ func main() {
 	if err := run(); err != nil {
 		logger, _ := logging.New()
 		logger.Error(context.Background(), "sales-phase-discovery job failed", err)
+		// Exit 0 (no os.Exit(1)): a systemic failure should not make the
+		// CronJob retry into the same fault. Monitoring relies on ERROR logs.
 	}
 }
 


### PR DESCRIPTION
## 🔗 Related Issue
Refs: liverty-music/specification#717

## 📝 Summary of Changes

Documentation-only change: adds the exit-0-on-failure rationale comment to `cmd/job/sales-phase-discovery/main.go`, mirroring the comment already present in `cmd/job/merch-discovery/main.go`.

**No behavior change.** The exit-0 design is already correct and intentional — the comment removes the "is this a bug?" ambiguity for future readers.

Background: both discovery jobs catch errors, log them at ERROR severity, and exit 0 so that a broken run does not retry into the same persistent fault. The accompanying cloud-provisioning PR (liverty-music/cloud-provisioning#398) adds the missing ERROR-log Alert Policies that make this design safe.

This PR rides the next routine backend release — no release is needed solely for a comment.

## 📋 Commit Log

```
f2bfe47 docs(job): add exit-0 rationale comment to sales-phase-discovery
```

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests to cover my changes. _(documentation only — no tests needed)_
- [x] I have run `go test -race ./...` and `mise run lint` locally and all checks have passed.
- [x] My code follows the architecture and style guidelines of the project.
