### PR TITLE
feat(mapper): map open_time in PendingConcertToProto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ tool (
 )
 
 require (
-	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260725094030-77573c77fc22.1
-	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260725094030-77573c77fc22.1
+	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260729065116-128371dca6a5.1
+	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260729065116-128371dca6a5.1
 	cloud.google.com/go/cloudsqlconn v1.20.0
 	connectrpc.com/authn v0.2.0
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,10 @@ buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57
 buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57e197.1/go.mod h1:eGjb9P6sl1irS46NKyXnxkyozT2aWs3BF4tbYWQuCsw=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1 h1:q+tABqEH2Cpcp8fO9TBZlvKok7zorHGy+/UyywXaAKo=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1/go.mod h1:Y3m+VD8IH6JTgnFYggPHvFul/ry6dL3QDliy8xH7610=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260725094030-77573c77fc22.1 h1:mHFVm7yAwNBYgMg1T3/GG2PyjQXJEH1FD69tH6Lj+ic=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260725094030-77573c77fc22.1/go.mod h1:vJtRnp1rv8v6XcOyqzD+bR1DABbSlVbFTChrRnUeT04=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260725094030-77573c77fc22.1 h1:orS/WsJCVxmNgXFQgWgZB5ShVtEgnWljNxebD8omLq0=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260725094030-77573c77fc22.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260729065116-128371dca6a5.1 h1:hIYRlzdpoRI5PzSkJo59N/SZP0yBuWKiqAz+9nKVk8E=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260729065116-128371dca6a5.1/go.mod h1:o/at2UVNho0HpB84CCjVZFc7Hr5yQfkrH9D8/ZrVBjg=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260729065116-128371dca6a5.1 h1:r7U8S5ERrNdqhrU/yQ0i9RQoG6y/nOchjYz+Z8iYjzo=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260729065116-128371dca6a5.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1 h1:KuP+b+in6LGh2ukof5KgDCD8hPXotEq6EVOo13Wg1pE=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1/go.mod h1:dV1Kz6zdmyXt7QWm5OXby44OFpyLemllUDBUG5HMLio=
 buf.build/go/app v0.1.0 h1:nlqD/h0rhIN73ZoiDElprrPiO2N6JV+RmNK34K29Ihg=

--- a/internal/adapter/rpc/mapper/pending_concert.go
+++ b/internal/adapter/rpc/mapper/pending_concert.go
@@ -32,6 +32,10 @@ func PendingConcertToProto(sc *entity.StagedConcert, performer *entity.Artist) *
 		proto.StartTime = &entityv1.StartTime{Value: timestamppb.New(*sc.StartTime)}
 	}
 
+	if sc.OpenTime != nil {
+		proto.OpenTime = &entityv1.OpenTime{Value: timestamppb.New(*sc.OpenTime)}
+	}
+
 	if sc.ResolvedPlaceID != nil || sc.ResolvedVenueName != nil {
 		proto.ResolvedVenue = resolvedVenueToProto(sc)
 	}

--- a/internal/adapter/rpc/mapper/pending_concert_test.go
+++ b/internal/adapter/rpc/mapper/pending_concert_test.go
@@ -1,0 +1,87 @@
+package mapper_test
+
+import (
+	"testing"
+	"time"
+
+	entityv1 "buf.build/gen/go/liverty-music/schema/protocolbuffers/go/liverty_music/entity/v1"
+	"github.com/liverty-music/backend/internal/adapter/rpc/mapper"
+	"github.com/liverty-music/backend/internal/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestPendingConcertToProto(t *testing.T) {
+	t.Parallel()
+
+	discoveredAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	localDate := time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)
+	startTime := time.Date(2026, 7, 15, 19, 0, 0, 0, time.UTC)
+	openTime := time.Date(2026, 7, 15, 18, 0, 0, 0, time.UTC)
+
+	performer := &entity.Artist{ID: "artist-1", Name: "Test Band"}
+
+	baseConcert := func() *entity.StagedConcert {
+		return &entity.StagedConcert{
+			ID:              "staged-1",
+			Title:           "Summer Tour 2026",
+			LocalDate:       localDate,
+			ListedVenueName: "Nippon Budokan",
+			DiscoveredTime:  discoveredAt,
+		}
+	}
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, mapper.PendingConcertToProto(nil, performer))
+	})
+
+	t.Run("open_time present maps to proto OpenTime", func(t *testing.T) {
+		t.Parallel()
+		sc := baseConcert()
+		sc.OpenTime = &openTime
+
+		got := mapper.PendingConcertToProto(sc, performer)
+		require.NotNil(t, got)
+		require.NotNil(t, got.OpenTime, "expected OpenTime to be set")
+		assert.Equal(t, timestamppb.New(openTime), got.OpenTime.Value)
+	})
+
+	t.Run("open_time absent leaves proto OpenTime nil", func(t *testing.T) {
+		t.Parallel()
+		sc := baseConcert()
+		sc.OpenTime = nil
+
+		got := mapper.PendingConcertToProto(sc, performer)
+		require.NotNil(t, got)
+		assert.Nil(t, got.OpenTime, "expected OpenTime to be nil when source has no open time")
+	})
+
+	t.Run("start_time present maps independently of open_time", func(t *testing.T) {
+		t.Parallel()
+		sc := baseConcert()
+		sc.StartTime = &startTime
+		sc.OpenTime = &openTime
+
+		got := mapper.PendingConcertToProto(sc, performer)
+		require.NotNil(t, got)
+		require.NotNil(t, got.StartTime)
+		require.NotNil(t, got.OpenTime)
+		assert.Equal(t, timestamppb.New(startTime), got.StartTime.Value)
+		assert.Equal(t, timestamppb.New(openTime), got.OpenTime.Value)
+	})
+
+	t.Run("required fields are always populated", func(t *testing.T) {
+		t.Parallel()
+		sc := baseConcert()
+
+		got := mapper.PendingConcertToProto(sc, performer)
+		require.NotNil(t, got)
+		assert.Equal(t, "staged-1", got.StagedId.GetValue())
+		assert.Equal(t, "Summer Tour 2026", got.Title.GetValue())
+		assert.Equal(t, "Nippon Budokan", got.ListedVenueName.GetValue())
+		assert.Equal(t, timestamppb.New(discoveredAt), got.DiscoveredTime)
+		assert.Equal(t, &entityv1.LocalDate{Value: mapper.TimeToDate(localDate)}, got.LocalDate)
+	})
+}


### PR DESCRIPTION
## Summary

`PendingConcertToProto` was silently dropping `sc.OpenTime` because `PendingConcert` had no `open_time` proto field. Spec v0.49.0 adds `open_time = 10` (`entity.v1.OpenTime`, optional), so this PR upgrades the BSR package and wires up the mapping.

## Changes

- **go.mod / go.sum**: Upgraded BSR packages to `v1.36.11-20260729065116-128371dca6a5.1` (protocolbuffers) and `v1.20.0-20260729065116-128371dca6a5.1` (connectrpc)
- **`internal/adapter/rpc/mapper/pending_concert.go`**: Added `OpenTime` nil-guard mapping following the existing `StartTime` pattern (lines 31–33)
- **`internal/adapter/rpc/mapper/pending_concert_test.go`**: New dedicated test file with `TestPendingConcertToProto` covering `open_time` present and absent

## Test plan

- [ ] `make check` passes locally (all tests green)
- [ ] `TestPendingConcertToProto` runs 5 subtests: nil input, open_time present, open_time absent, start+open independent mapping, required fields always populated

Closes: liverty-music/specification#726

_Part of the `add-open-time-to-approval-queue` OpenSpec change._
