### PR TITLE
feat(venue): locale-aware languageCode in Places API + listed_venue_name normalization

### DIFF
--- a/cmd/job/normalize-venue-names/main.go
+++ b/cmd/job/normalize-venue-names/main.go
@@ -1,0 +1,238 @@
+// Package main provides a one-time migration job that normalizes listed_venue_name
+// values in staged_concerts and events tables by applying entity.NormalizeVenueName.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/signal"
+	"sort"
+	"syscall"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/liverty-music/backend/internal/entity"
+	"github.com/liverty-music/backend/internal/infrastructure/database/rdb"
+	"github.com/liverty-music/backend/pkg/config"
+	"github.com/liverty-music/backend/pkg/shutdown"
+	"github.com/pannpers/go-logging/logging"
+)
+
+func main() {
+	if err := run(); err != nil {
+		logger, _ := logging.New()
+		logger.Error(context.Background(), "normalize-venue-names migration failed", err)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	bootLogger, _ := logging.New()
+	bootLogger.Info(ctx, "starting normalize-venue-names migration")
+
+	cfg, err := config.Load[config.JobConfig]()
+	if err != nil {
+		return err
+	}
+
+	logger, err := logging.New()
+	if err != nil {
+		return err
+	}
+	slog.SetDefault(logger.Slog())
+
+	db, err := rdb.New(ctx, cfg.Database, cfg.IsLocal(), logger)
+	if err != nil {
+		return err
+	}
+
+	shutdown.Init(logger)
+	shutdown.AddDatastorePhase(db)
+
+	// Run both tables inside a single transaction so a mid-migration crash
+	// leaves neither table in a partially-normalized state.
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin migration transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	stagedUpdated, stagedDeleted, err := normalizeStagedConcerts(ctx, tx, logger)
+	if err != nil {
+		return fmt.Errorf("normalize staged_concerts: %w", err)
+	}
+
+	eventsUpdated, err := normalizeEvents(ctx, tx, logger)
+	if err != nil {
+		return fmt.Errorf("normalize events: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit migration transaction: %w", err)
+	}
+
+	logger.Info(ctx, "normalize-venue-names migration complete",
+		slog.Int("staged_concerts_updated", stagedUpdated),
+		slog.Int("staged_concerts_deleted_duplicates", stagedDeleted),
+		slog.Int("events_updated", eventsUpdated),
+	)
+
+	return nil
+}
+
+// normalizeStagedConcerts normalizes listed_venue_name in staged_concerts.
+//
+// Unresolved rows (resolved_place_id IS NULL) are covered by the partial unique
+// index uq_staged_concerts_by_listed_name(artist_id, local_date, listed_venue_name).
+// Normalizing a prefixed name can produce a value that already exists for another
+// row with the same (artist_id, local_date). To avoid a constraint violation we
+// first detect such duplicate pairs and delete the un-normalized duplicate (keeping
+// the row that already holds, or will hold after the update, the canonical form).
+func normalizeStagedConcerts(ctx context.Context, tx pgx.Tx, logger *logging.Logger) (updated, deleted int, err error) {
+	rows, err := tx.Query(ctx, `
+		SELECT id, artist_id, local_date::text, listed_venue_name, resolved_place_id
+		FROM staged_concerts
+		WHERE listed_venue_name IS NOT NULL
+		ORDER BY id
+	`)
+	if err != nil {
+		return 0, 0, fmt.Errorf("query staged_concerts: %w", err)
+	}
+
+	type stagingRow struct {
+		id              string
+		artistID        string
+		localDate       string
+		name            string
+		resolvedPlaceID *string
+	}
+
+	var all []stagingRow
+	for rows.Next() {
+		var r stagingRow
+		if err := rows.Scan(&r.id, &r.artistID, &r.localDate, &r.name, &r.resolvedPlaceID); err != nil {
+			rows.Close()
+			return 0, 0, fmt.Errorf("scan staged_concerts row: %w", err)
+		}
+		all = append(all, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, 0, fmt.Errorf("iterate staged_concerts rows: %w", err)
+	}
+
+	type withNorm struct {
+		r           stagingRow
+		norm        string
+		needsUpdate bool
+	}
+
+	var unresolved []withNorm
+	var resolved []withNorm
+	for _, r := range all {
+		norm := entity.NormalizeVenueName(r.name)
+		wn := withNorm{r: r, norm: norm, needsUpdate: norm != r.name}
+		if r.resolvedPlaceID == nil {
+			unresolved = append(unresolved, wn)
+		} else {
+			resolved = append(resolved, wn)
+		}
+	}
+
+	// Sort unresolved rows: already-normalized rows first so they "claim" the
+	// dedup key and the un-normalized duplicates are the ones deleted.
+	sort.SliceStable(unresolved, func(i, j int) bool {
+		alreadyI := !unresolved[i].needsUpdate
+		alreadyJ := !unresolved[j].needsUpdate
+		if alreadyI != alreadyJ {
+			return alreadyI
+		}
+		return unresolved[i].r.id < unresolved[j].r.id
+	})
+
+	// Detect which unresolved rows would produce a duplicate normalized key.
+	type dedupKey struct{ artistID, localDate, norm string }
+	seen := make(map[dedupKey]bool)
+	var toDelete []string
+	var toUpdate []struct{ id, name string }
+
+	for _, wn := range unresolved {
+		k := dedupKey{wn.r.artistID, wn.r.localDate, wn.norm}
+		if seen[k] {
+			// Another row already claims this (artistID, localDate, normalizedName).
+			// Delete this row — it is a true dedup candidate after normalization.
+			toDelete = append(toDelete, wn.r.id)
+		} else {
+			seen[k] = true
+			if wn.needsUpdate {
+				toUpdate = append(toUpdate, struct{ id, name string }{wn.r.id, wn.norm})
+			}
+		}
+	}
+
+	// Resolved rows are not covered by the partial index — update unconditionally.
+	for _, wn := range resolved {
+		if wn.needsUpdate {
+			toUpdate = append(toUpdate, struct{ id, name string }{wn.r.id, wn.norm})
+		}
+	}
+
+	// Delete duplicates first so subsequent UPDATEs don't collide.
+	for _, id := range toDelete {
+		if _, err := tx.Exec(ctx, `DELETE FROM staged_concerts WHERE id = $1`, id); err != nil {
+			return 0, 0, fmt.Errorf("delete duplicate staged_concerts row %s: %w", id, err)
+		}
+	}
+	for _, r := range toUpdate {
+		if _, err := tx.Exec(ctx, `UPDATE staged_concerts SET listed_venue_name = $1 WHERE id = $2`, r.name, r.id); err != nil {
+			return 0, 0, fmt.Errorf("update staged_concerts row %s: %w", r.id, err)
+		}
+	}
+
+	logger.Info(ctx, "staged_concerts normalization prepared",
+		slog.Int("to_update", len(toUpdate)),
+		slog.Int("to_delete", len(toDelete)),
+	)
+	return len(toUpdate), len(toDelete), nil
+}
+
+// normalizeEvents normalizes listed_venue_name in events. The events table has
+// no unique constraint on listed_venue_name, so no duplicate-key handling is needed.
+func normalizeEvents(ctx context.Context, tx pgx.Tx, logger *logging.Logger) (int, error) {
+	rows, err := tx.Query(ctx, `SELECT id, listed_venue_name FROM events WHERE listed_venue_name IS NOT NULL`)
+	if err != nil {
+		return 0, fmt.Errorf("query events: %w", err)
+	}
+
+	type row struct {
+		id   string
+		name string
+	}
+	var toUpdate []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.name); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan events row: %w", err)
+		}
+		normalized := entity.NormalizeVenueName(r.name)
+		if normalized != r.name {
+			toUpdate = append(toUpdate, row{id: r.id, name: normalized})
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate events rows: %w", err)
+	}
+
+	for _, r := range toUpdate {
+		if _, err := tx.Exec(ctx, `UPDATE events SET listed_venue_name = $1 WHERE id = $2`, r.name, r.id); err != nil {
+			return 0, fmt.Errorf("update events row %s: %w", r.id, err)
+		}
+	}
+
+	logger.Info(ctx, "events normalization prepared", slog.Int("to_update", len(toUpdate)))
+	return len(toUpdate), nil
+}

--- a/cmd/job/normalize-venue-names/main.go
+++ b/cmd/job/normalize-venue-names/main.go
@@ -1,11 +1,12 @@
 // Package main provides a one-time migration job that normalizes listed_venue_name
-// values in staged_concerts and events tables by applying entity.NormalizeVenueName.
+// values in venues, staged_concerts, and events tables by applying entity.NormalizeVenueName.
 package main
 
 import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/signal"
 	"sort"
 	"syscall"
@@ -22,6 +23,7 @@ func main() {
 	if err := run(); err != nil {
 		logger, _ := logging.New()
 		logger.Error(context.Background(), "normalize-venue-names migration failed", err)
+		os.Exit(1)
 	}
 }
 
@@ -51,13 +53,22 @@ func run() error {
 	shutdown.Init(logger)
 	shutdown.AddDatastorePhase(db)
 
-	// Run both tables inside a single transaction so a mid-migration crash
-	// leaves neither table in a partially-normalized state.
+	// Run all three tables inside a single transaction so a mid-migration crash
+	// leaves no table in a partially-normalized state.
 	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin migration transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+
+	// venues must be normalized first: resolveOrCreateVenue looks up venues by
+	// their listed_venue_name, so an un-normalized venues row would cause a miss
+	// after staged_concerts is normalized (new concerts stage with a normalized
+	// name that no longer matches the old raw-value venues row).
+	venuesUpdated, err := normalizeVenues(ctx, tx, logger)
+	if err != nil {
+		return fmt.Errorf("normalize venues: %w", err)
+	}
 
 	stagedUpdated, stagedDeleted, err := normalizeStagedConcerts(ctx, tx, logger)
 	if err != nil {
@@ -74,12 +85,54 @@ func run() error {
 	}
 
 	logger.Info(ctx, "normalize-venue-names migration complete",
+		slog.Int("venues_updated", venuesUpdated),
 		slog.Int("staged_concerts_updated", stagedUpdated),
 		slog.Int("staged_concerts_deleted_duplicates", stagedDeleted),
 		slog.Int("events_updated", eventsUpdated),
 	)
 
 	return nil
+}
+
+// normalizeVenues normalizes listed_venue_name in venues. This must run before
+// staged_concerts so that the GetByListedName SQL equality lookup keeps working
+// after the write-path normalization is deployed: a staged concert with a
+// normalized name must find its existing venue row by the same normalized key.
+func normalizeVenues(ctx context.Context, tx pgx.Tx, logger *logging.Logger) (int, error) {
+	rows, err := tx.Query(ctx, `SELECT id, listed_venue_name FROM venues WHERE listed_venue_name IS NOT NULL`)
+	if err != nil {
+		return 0, fmt.Errorf("query venues: %w", err)
+	}
+
+	type row struct {
+		id   string
+		name string
+	}
+	var toUpdate []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.name); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan venues row: %w", err)
+		}
+		normalized := entity.NormalizeVenueName(r.name)
+		if normalized != r.name {
+			toUpdate = append(toUpdate, row{id: r.id, name: normalized})
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate venues rows: %w", err)
+	}
+
+	for _, r := range toUpdate {
+		if _, err := tx.Exec(ctx, `UPDATE venues SET listed_venue_name = $1 WHERE id = $2`, r.name, r.id); err != nil {
+			return 0, fmt.Errorf("update venues row %s: %w", r.id, err)
+		}
+	}
+
+	logger.Info(ctx, "venues normalization prepared", slog.Int("to_update", len(toUpdate)))
+	return len(toUpdate), nil
 }
 
 // normalizeStagedConcerts normalizes listed_venue_name in staged_concerts.

--- a/internal/infrastructure/maps/google/client.go
+++ b/internal/infrastructure/maps/google/client.go
@@ -40,7 +40,8 @@ type Place struct {
 
 // textSearchRequest is the JSON body for the Places Text Search (New) API.
 type textSearchRequest struct {
-	TextQuery string `json:"textQuery"`
+	TextQuery    string `json:"textQuery"`
+	LanguageCode string `json:"languageCode,omitempty"`
 }
 
 // textSearchResponse is the JSON response from the Places Text Search (New) API.
@@ -94,7 +95,10 @@ func (c *Client) SearchPlace(ctx context.Context, name, adminArea string) (*Plac
 		query = fmt.Sprintf("%s %s", name, adminArea)
 	}
 
-	body, err := json.Marshal(textSearchRequest{TextQuery: query})
+	body, err := json.Marshal(textSearchRequest{
+		TextQuery:    query,
+		LanguageCode: adminAreaToLanguage(adminArea),
+	})
 	if err != nil {
 		return nil, apperr.Wrap(err, codes.Internal, "failed to marshal google maps request body")
 	}

--- a/internal/infrastructure/maps/google/language.go
+++ b/internal/infrastructure/maps/google/language.go
@@ -1,0 +1,35 @@
+package google
+
+import "strings"
+
+// countryCodeToLanguage maps an ISO 3166-1 alpha-2 country code to a BCP 47
+// language tag for use in Places API languageCode requests. It ensures Places
+// returns venue names in the locale of the venue's country.
+//
+// Only the most common venue-bearing countries are explicitly mapped; all
+// others default to "en" so results are always human-readable.
+func countryCodeToLanguage(cc string) string {
+	switch strings.ToUpper(cc) {
+	case "JP":
+		return "ja"
+	case "KR":
+		return "ko"
+	case "CN":
+		return "zh-CN"
+	case "TW":
+		return "zh-TW"
+	default:
+		return "en"
+	}
+}
+
+// adminAreaToLanguage extracts the ISO 3166-1 alpha-2 country code from an
+// ISO 3166-2 admin_area value (e.g. "JP-13") and returns the corresponding
+// BCP 47 language tag. Returns "en" when adminArea is empty.
+func adminAreaToLanguage(adminArea string) string {
+	if adminArea == "" {
+		return "en"
+	}
+	parts := strings.SplitN(adminArea, "-", 2)
+	return countryCodeToLanguage(parts[0])
+}

--- a/internal/infrastructure/maps/google/language_test.go
+++ b/internal/infrastructure/maps/google/language_test.go
@@ -1,0 +1,58 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountryCodeToLanguage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cc   string
+		want string
+	}{
+		{"japan", "JP", "ja"},
+		{"korea", "KR", "ko"},
+		{"china", "CN", "zh-CN"},
+		{"taiwan", "TW", "zh-TW"},
+		{"empty", "", "en"},
+		{"unknown_US", "US", "en"},
+		{"unknown_FR", "FR", "en"},
+		{"lowercase_jp", "jp", "ja"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, countryCodeToLanguage(tt.cc))
+		})
+	}
+}
+
+func TestAdminAreaToLanguage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		adminArea string
+		want      string
+	}{
+		{"japan_tokyo", "JP-13", "ja"},
+		{"japan_osaka", "JP-27", "ja"},
+		{"korea_seoul", "KR-11", "ko"},
+		{"china_beijing", "CN-BJ", "zh-CN"},
+		{"taiwan_taipei", "TW-TPE", "zh-TW"},
+		{"usa_california", "US-CA", "en"},
+		{"empty", "", "en"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, adminAreaToLanguage(tt.adminArea))
+		})
+	}
+}

--- a/internal/usecase/concert_creation_uc.go
+++ b/internal/usecase/concert_creation_uc.go
@@ -70,6 +70,7 @@ func (uc *concertCreationUseCase) CreateFromDiscovered(ctx context.Context, data
 	newPlaces := make(map[placeKey]*entity.VenuePlace)
 
 	for _, sc := range data.Concerts {
+		sc.ListedVenueName = entity.NormalizeVenueName(sc.ListedVenueName)
 		if sc.ListedVenueName == "" {
 			uc.logger.Warn(ctx, "skipping staged concert: empty venue name from Gemini",
 				slog.String("artist_id", data.ArtistID),
@@ -93,12 +94,12 @@ func (uc *concertCreationUseCase) CreateFromDiscovered(ctx context.Context, data
 			return fmt.Errorf("resolve venue %q: %w", sc.ListedVenueName, err)
 		}
 
-		// A nil place means Google Places could not resolve the venue. We still
-		// stage the concert (with its resolved-venue preview absent) so a
-		// developer can review a venue the searcher could not resolve.
-		if place != nil {
-			newPlaces[venueKey(sc.ListedVenueName, sc.AdminArea)] = place
-		} else {
+		// Cache the result (nil or not) so subsequent concerts in the same batch
+		// with the same normalized venue name skip the Places API entirely.
+		// A nil entry means "already tried, not found" — the concert is still staged
+		// for review with the resolved-venue preview absent.
+		newPlaces[venueKey(sc.ListedVenueName, sc.AdminArea)] = place
+		if place == nil {
 			uc.logger.Info(ctx, "staging concert with unresolved venue for review",
 				slog.String("artist_id", data.ArtistID),
 				slog.String("title", sc.Title),


### PR DESCRIPTION
## Summary

Venue names were always displayed in English because the Google Places API was called without a `languageCode` parameter, and `venue.name` (English canonical from Places) was unconditionally preferred over `listed_venue_name` (Japanese scraped by Gemini). This PR fixes the backend side of the issue.

## Changes

- **`internal/infrastructure/maps/google/`**: Added `countryCodeToLanguage` and `adminAreaToLanguage` helpers that map ISO 3166-2 `admin_area` values (e.g. `"JP-13"`) to BCP 47 language tags. `SearchPlace` now passes the derived `languageCode` in the Places API request body so newly resolved `venue.name` values are in the venue's locale.

- **`internal/usecase/concert_creation_uc.go`**: `listed_venue_name` is now normalized via `NormalizeVenueName` before storage (stripping prefecture-dot prefixes such as `"大阪・…"`), making it safe to use directly as a display value. The batch-local place cache now also stores `nil` results so unresolvable venues in the same batch don't redundantly re-call the Places API.

- **`cmd/job/normalize-venue-names/`**: One-time migration job that backfills existing `staged_concerts` and `events` rows. Runs inside a single transaction; handles the `uq_staged_concerts_by_listed_name` partial-index constraint by detecting and deleting duplicate unresolved rows whose normalized forms would collide before applying updates.

## Testing

- `internal/infrastructure/maps/google`: added unit tests for `countryCodeToLanguage` and `adminAreaToLanguage` covering JP, KR, CN, TW, empty, and unknown inputs
- All existing tests pass (`make check`)

close: #728
