### PR TITLE
build(deps): bump BSR schema to v0.51.0 (post-blockchain-removal)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ tool (
 )
 
 require (
-	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260804051029-4abcaa9a23ce.1
-	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260804051029-4abcaa9a23ce.1
+	buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260806093416-c338244b0fbc.1
+	buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260806093416-c338244b0fbc.1
 	cloud.google.com/go/cloudsqlconn v1.20.0
 	connectrpc.com/authn v0.2.0
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,10 @@ buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57
 buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57e197.1/go.mod h1:eGjb9P6sl1irS46NKyXnxkyozT2aWs3BF4tbYWQuCsw=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1 h1:q+tABqEH2Cpcp8fO9TBZlvKok7zorHGy+/UyywXaAKo=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.9-20250903170917-c4be0f57e197.1/go.mod h1:Y3m+VD8IH6JTgnFYggPHvFul/ry6dL3QDliy8xH7610=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260804051029-4abcaa9a23ce.1 h1:ZHPERDzr8PIIB2/EwTXtLOmZbqF//M6G+U8AFbGLBgg=
-buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260804051029-4abcaa9a23ce.1/go.mod h1:8C7jlcMLHK7BP6irAJi8LO6GikFaOsc+tiPSElUre0A=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260804051029-4abcaa9a23ce.1 h1:XaL8Cjrhbn5TAgtl3EJFhcWctVzNQgqO6CBoVtl7z7k=
-buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260804051029-4abcaa9a23ce.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260806093416-c338244b0fbc.1 h1:q1oXNTHW3/tyRQRmWLr+vy8kT5AP8uL1T9lipCes2F4=
+buf.build/gen/go/liverty-music/schema/connectrpc/go v1.20.0-20260806093416-c338244b0fbc.1/go.mod h1:Aj41b1vitTEFXNfpJXqmgcHgBwNXgVSlLRI/xusB/n4=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260806093416-c338244b0fbc.1 h1:HTah4qjXXadTeOsbOPCMJnFuyIIQagAqV7KegW0B2nA=
+buf.build/gen/go/liverty-music/schema/protocolbuffers/go v1.36.11-20260806093416-c338244b0fbc.1/go.mod h1:PQHl79fcweITJ6a9TldAMvhSrJT0S5KNeSAHBdqCbUM=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1 h1:KuP+b+in6LGh2ukof5KgDCD8hPXotEq6EVOo13Wg1pE=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1/go.mod h1:dV1Kz6zdmyXt7QWm5OXby44OFpyLemllUDBUG5HMLio=
 buf.build/go/app v0.1.0 h1:nlqD/h0rhIN73ZoiDElprrPiO2N6JV+RmNK34K29Ihg=


### PR DESCRIPTION
Bumps the generated `buf.build/gen/go/liverty-music/schema` packages to the v0.51.0 BSR release that dropped TicketService / EntryService / the on-chain Ticket entity / Event.merkle_root. Backend no longer references them, so this prunes the now-unused generated code. `make check` GREEN against the reduced schema.

Follow-up to #382 (Phase 7 of the blockchain removal). Refs: liverty-music/specification#741