### PR TITLE
feat(notification): deep-link new-concert push to earliest matched concert

### DIFF
--- a/internal/entity/concert.go
+++ b/internal/entity/concert.go
@@ -278,6 +278,47 @@ func (c *Concert) ProximityTo(home *Home) Proximity {
 	return ProximityAway
 }
 
+// EarliestConcert returns the earliest concert in the slice, ordered by local
+// date ascending and tie-broken by start time ascending. A known start time
+// precedes an unknown (nil) one on the same date; any remaining tie is broken by
+// ID so the result is deterministic. Nil elements are skipped. Returns nil for
+// an empty slice or a slice of only nil elements.
+//
+// This is the deep-link target for a new-concert push notification: the earliest
+// concert of the recipient's hype-matched subset.
+func EarliestConcert(concerts []*Concert) *Concert {
+	var earliest *Concert
+	for _, c := range concerts {
+		if c == nil {
+			continue
+		}
+		if earliest == nil || concertEarlier(c, earliest) {
+			earliest = c
+		}
+	}
+	return earliest
+}
+
+// concertEarlier reports whether concert a sorts before concert b under the
+// [EarliestConcert] ordering: local date asc, then start time asc (known before
+// unknown), then ID asc as a stable final tie-break.
+func concertEarlier(a, b *Concert) bool {
+	if !a.LocalDate.Equal(b.LocalDate) {
+		return a.LocalDate.Before(b.LocalDate)
+	}
+	switch as, bs := a.StartTime, b.StartTime; {
+	case as != nil && bs != nil:
+		if !as.Equal(*bs) {
+			return as.Before(*bs)
+		}
+	case as != nil && bs == nil:
+		return true
+	case as == nil && bs != nil:
+		return false
+	}
+	return a.ID < b.ID
+}
+
 // ProximityGroup contains concerts for a single calendar date, classified into
 // three geographic proximity buckets relative to the user's home area.
 type ProximityGroup struct {

--- a/internal/entity/earliest_concert_test.go
+++ b/internal/entity/earliest_concert_test.go
@@ -1,0 +1,107 @@
+package entity_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/liverty-music/backend/internal/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEarliestConcert(t *testing.T) {
+	t.Parallel()
+
+	date := func(y int, m time.Month, d int) time.Time {
+		return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	}
+	at := func(h, min int) *time.Time {
+		v := time.Date(2000, 1, 1, h, min, 0, 0, time.UTC)
+		return &v
+	}
+
+	sep3 := &entity.Concert{Event: entity.Event{ID: "sep3", LocalDate: date(2026, 9, 3)}}
+	sep10 := &entity.Concert{Event: entity.Event{ID: "sep10", LocalDate: date(2026, 9, 10)}}
+
+	sameDay1800 := &entity.Concert{Event: entity.Event{ID: "d-1800", LocalDate: date(2026, 9, 3), StartTime: at(18, 0)}}
+	sameDay1930 := &entity.Concert{Event: entity.Event{ID: "d-1930", LocalDate: date(2026, 9, 3), StartTime: at(19, 30)}}
+	sameDayNoStart := &entity.Concert{Event: entity.Event{ID: "d-none", LocalDate: date(2026, 9, 3)}}
+
+	tieA := &entity.Concert{Event: entity.Event{ID: "aaa", LocalDate: date(2026, 9, 3)}}
+	tieB := &entity.Concert{Event: entity.Event{ID: "bbb", LocalDate: date(2026, 9, 3)}}
+
+	tests := []struct {
+		name     string
+		concerts []*entity.Concert
+		want     *entity.Concert
+	}{
+		{
+			name:     "empty slice returns nil",
+			concerts: nil,
+			want:     nil,
+		},
+		{
+			name:     "slice of only nil elements returns nil",
+			concerts: []*entity.Concert{nil, nil},
+			want:     nil,
+		},
+		{
+			name:     "earlier local date wins regardless of input order",
+			concerts: []*entity.Concert{sep10, sep3},
+			want:     sep3,
+		},
+		{
+			name:     "same-day concerts tie-broken by earliest start time",
+			concerts: []*entity.Concert{sameDay1930, sameDay1800},
+			want:     sameDay1800,
+		},
+		{
+			name:     "a known start time precedes an unknown one on the same date",
+			concerts: []*entity.Concert{sameDayNoStart, sameDay1800},
+			want:     sameDay1800,
+		},
+		{
+			name:     "fully-tied concerts fall back to ascending ID",
+			concerts: []*entity.Concert{tieB, tieA},
+			want:     tieA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Same(t, tt.want, entity.EarliestConcert(tt.concerts))
+		})
+	}
+}
+
+// TestEarliestConcert_HomeRecipientSubset covers the deep-link contract for a
+// home-hype recipient: the deep-link target is the earliest concert of the
+// recipient's *matched subset*, not the globally earliest new concert. Here the
+// globally earliest concert is out-of-area (Osaka, 2026-09-01) and must NOT be
+// chosen; the in-area Tokyo concert (2026-09-05) is the correct target.
+func TestEarliestConcert_HomeRecipientSubset(t *testing.T) {
+	t.Parallel()
+
+	tokyoLevel1 := "JP-13"
+	tokyoHome := &entity.Home{CountryCode: "JP", Level1: tokyoLevel1}
+	osakaLevel1 := "JP-27"
+
+	osakaEarlier := &entity.Concert{Event: entity.Event{
+		ID:        "osaka-0901",
+		LocalDate: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		Venue:     &entity.Venue{AdminArea: &osakaLevel1},
+	}}
+	tokyoLater := &entity.Concert{Event: entity.Event{
+		ID:        "tokyo-0905",
+		LocalDate: time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC),
+		Venue:     &entity.Venue{AdminArea: &tokyoLevel1},
+	}}
+
+	all := []*entity.Concert{osakaEarlier, tokyoLater}
+
+	subset := entity.HypeHome.MatchingConcerts(tokyoHome, all)
+	got := entity.EarliestConcert(subset)
+
+	assert.Same(t, tokyoLater, got, "home recipient must deep-link to their in-area concert, not the globally earliest")
+}

--- a/internal/entity/follow.go
+++ b/internal/entity/follow.go
@@ -40,48 +40,71 @@ func (h Hype) IsValid() bool {
 	}
 }
 
-// ShouldNotify reports whether a follower with hype level h should receive a
-// push notification for a newly discovered concert, given the follower's home
-// area, the venue's admin areas, and the list of concerts.
+// MatchingConcerts narrows a batch of newly created concerts to the subset that
+// satisfies this hype level's predicate for a follower with the given home area.
+// The subset drives both the notification body count and the deep-link target,
+// so it must reflect exactly what the recipient's hype tier promised them.
 //
-// Decision rules (evaluated in order):
-//  1. HypeWatch → false (dashboard-only, no push).
-//  2. HypeHome → true only when home is non-nil, home.Level1 is non-empty, and
-//     home.Level1 exists in venueAreas.
-//  3. HypeNearby → true only when home is non-nil and at least one concert in
-//     concerts has proximity ProximityHome or ProximityNearby relative to home.
-//  4. HypeAway → true (all concerts nationwide).
-//  5. Anything else → false.
-func (h Hype) ShouldNotify(home *Home, venueAreas map[string]struct{}, concerts []*Concert) bool {
+// Selection rules:
+//  1. HypeWatch → empty (dashboard-only, no push).
+//  2. HypeHome → concerts whose venue admin area matches the recipient's home
+//     area (ProximityHome); empty when home is nil or home.Level1 is empty.
+//  3. HypeNearby → concerts within range of the home centroid (ProximityHome or
+//     ProximityNearby); empty when home is nil.
+//  4. HypeAway → all concerts nationwide.
+//  5. Anything else → empty.
+//
+// The returned slice preserves the input order and shares no backing array with
+// concerts, so callers may sort or filter it freely. Returns nil (not a zero
+// slice) when nothing matches.
+func (h Hype) MatchingConcerts(home *Home, concerts []*Concert) []*Concert {
 	switch h {
 	case HypeWatch:
-		return false
+		return nil
 
 	case HypeHome:
 		if home == nil || home.Level1 == "" {
-			return false
+			return nil
 		}
-		_, ok := venueAreas[home.Level1]
-		return ok
+		var matched []*Concert
+		for _, c := range concerts {
+			if c.ProximityTo(home) == ProximityHome {
+				matched = append(matched, c)
+			}
+		}
+		return matched
 
 	case HypeNearby:
 		if home == nil {
-			return false
+			return nil
 		}
+		var matched []*Concert
 		for _, c := range concerts {
-			p := c.ProximityTo(home)
-			if p == ProximityHome || p == ProximityNearby {
-				return true
+			if p := c.ProximityTo(home); p == ProximityHome || p == ProximityNearby {
+				matched = append(matched, c)
 			}
 		}
-		return false
+		return matched
 
 	case HypeAway:
-		return true
+		if len(concerts) == 0 {
+			return nil
+		}
+		matched := make([]*Concert, len(concerts))
+		copy(matched, concerts)
+		return matched
 
 	default:
-		return false
+		return nil
 	}
+}
+
+// ShouldNotify reports whether a follower with hype level h should receive a
+// push notification for the given newly created concerts, given the follower's
+// home area. It is defined as "the hype-matched subset is non-empty" — see
+// [Hype.MatchingConcerts] for the per-tier predicate.
+func (h Hype) ShouldNotify(home *Home, concerts []*Concert) bool {
+	return len(h.MatchingConcerts(home, concerts)) > 0
 }
 
 // Follow represents the write model for a user-artist follow relationship.

--- a/internal/entity/follow_test.go
+++ b/internal/entity/follow_test.go
@@ -61,22 +61,23 @@ func TestHype_IsValid(t *testing.T) {
 	}
 }
 
-func TestHype_ShouldNotify(t *testing.T) {
-	t.Parallel()
-
+// hypeTestFixture builds the shared home + per-proximity concerts used by both
+// the MatchingConcerts and ShouldNotify tests. Concerts carry stable IDs so the
+// subset assertions can check identity, not just length.
+func hypeTestFixture() (tokyoHome *entity.Home, tokyo, yokohama, osaka *entity.Concert) {
 	// Tokyo (JP-13): lat 35.6762, lng 139.6503
 	tokyoLevel1 := "JP-13"
 	tokyoCentroid := &entity.Coordinates{Latitude: 35.6762, Longitude: 139.6503}
 
 	// Yokohama (JP-14): lat 35.4437, lng 139.6380 — ~30 km from Tokyo (NEARBY)
 	yokohamaLevel1 := "JP-14"
-	yokohama := &entity.Coordinates{Latitude: 35.4437, Longitude: 139.6380}
+	yokohamaCoords := &entity.Coordinates{Latitude: 35.4437, Longitude: 139.6380}
 
 	// Osaka (JP-27): lat 34.6937, lng 135.5023 — ~400 km from Tokyo (AWAY)
 	osakaLevel1 := "JP-27"
-	osaka := &entity.Coordinates{Latitude: 34.6937, Longitude: 135.5023}
+	osakaCoords := &entity.Coordinates{Latitude: 34.6937, Longitude: 135.5023}
 
-	tokyoHome := &entity.Home{
+	tokyoHome = &entity.Home{
 		CountryCode: "JP",
 		Level1:      tokyoLevel1,
 		Centroid:    tokyoCentroid,
@@ -85,8 +86,9 @@ func TestHype_ShouldNotify(t *testing.T) {
 	date := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
 
 	// A concert at a Tokyo venue (HOME proximity).
-	tokyoConcert := &entity.Concert{
+	tokyo = &entity.Concert{
 		Event: entity.Event{
+			ID:        "concert-tokyo",
 			LocalDate: date,
 			Venue: &entity.Venue{
 				AdminArea:   &tokyoLevel1,
@@ -96,141 +98,120 @@ func TestHype_ShouldNotify(t *testing.T) {
 	}
 
 	// A concert at a Yokohama venue — no admin-area match but within 200 km (NEARBY).
-	yokohamaConcert := &entity.Concert{
+	yokohama = &entity.Concert{
 		Event: entity.Event{
+			ID:        "concert-yokohama",
 			LocalDate: date,
 			Venue: &entity.Venue{
 				AdminArea:   &yokohamaLevel1,
-				Coordinates: yokohama,
+				Coordinates: yokohamaCoords,
 			},
 		},
 	}
 
 	// A concert at an Osaka venue — no admin-area match and >200 km (AWAY).
-	osakaConcert := &entity.Concert{
+	osaka = &entity.Concert{
 		Event: entity.Event{
+			ID:        "concert-osaka",
 			LocalDate: date,
 			Venue: &entity.Venue{
 				AdminArea:   &osakaLevel1,
-				Coordinates: osaka,
+				Coordinates: osakaCoords,
 			},
 		},
 	}
+	return tokyoHome, tokyo, yokohama, osaka
+}
 
-	type args struct {
-		hype       entity.Hype
-		home       *entity.Home
-		venueAreas map[string]struct{}
-		concerts   []*entity.Concert
-	}
+func TestHype_MatchingConcerts(t *testing.T) {
+	t.Parallel()
+
+	tokyoHome, tokyo, yokohama, osaka := hypeTestFixture()
+	all := []*entity.Concert{tokyo, yokohama, osaka}
+
 	tests := []struct {
-		name string
-		args args
-		want bool
+		name     string
+		hype     entity.Hype
+		home     *entity.Home
+		concerts []*entity.Concert
+		want     []*entity.Concert
 	}{
 		{
-			name: "return false for HypeWatch regardless of home",
-			args: args{
-				hype:       entity.HypeWatch,
-				home:       tokyoHome,
-				venueAreas: map[string]struct{}{tokyoLevel1: {}},
-				concerts:   []*entity.Concert{tokyoConcert},
-			},
-			want: false,
+			name:     "HypeWatch matches nothing",
+			hype:     entity.HypeWatch,
+			home:     tokyoHome,
+			concerts: all,
+			want:     nil,
 		},
 		{
-			name: "return true for HypeHome when home level1 matches venue area",
-			args: args{
-				hype:       entity.HypeHome,
-				home:       tokyoHome,
-				venueAreas: map[string]struct{}{tokyoLevel1: {}},
-				concerts:   []*entity.Concert{tokyoConcert},
-			},
-			want: true,
+			name:     "HypeHome selects only in-area concerts",
+			hype:     entity.HypeHome,
+			home:     tokyoHome,
+			concerts: all,
+			want:     []*entity.Concert{tokyo},
 		},
 		{
-			name: "return false for HypeHome when home level1 does not match any venue area",
-			args: args{
-				hype:       entity.HypeHome,
-				home:       tokyoHome,
-				venueAreas: map[string]struct{}{osakaLevel1: {}},
-				concerts:   []*entity.Concert{osakaConcert},
-			},
-			want: false,
+			name:     "HypeHome matches nothing when no concert is in-area",
+			hype:     entity.HypeHome,
+			home:     tokyoHome,
+			concerts: []*entity.Concert{yokohama, osaka},
+			want:     nil,
 		},
 		{
-			name: "return false for HypeHome when home is nil",
-			args: args{
-				hype:       entity.HypeHome,
-				home:       nil,
-				venueAreas: map[string]struct{}{tokyoLevel1: {}},
-				concerts:   []*entity.Concert{tokyoConcert},
-			},
-			want: false,
+			name:     "HypeHome matches nothing when home is nil",
+			hype:     entity.HypeHome,
+			home:     nil,
+			concerts: all,
+			want:     nil,
 		},
 		{
-			name: "return false for HypeHome when home level1 is empty",
-			args: args{
-				hype: entity.HypeHome,
-				home: &entity.Home{
-					CountryCode: "JP",
-					Level1:      "",
-					Centroid:    tokyoCentroid,
-				},
-				venueAreas: map[string]struct{}{tokyoLevel1: {}},
-				concerts:   []*entity.Concert{tokyoConcert},
-			},
-			want: false,
+			name:     "HypeHome matches nothing when home level1 is empty",
+			hype:     entity.HypeHome,
+			home:     &entity.Home{CountryCode: "JP", Level1: ""},
+			concerts: all,
+			want:     nil,
 		},
 		{
-			name: "return true for HypeNearby when a concert is nearby",
-			args: args{
-				hype:       entity.HypeNearby,
-				home:       tokyoHome,
-				venueAreas: map[string]struct{}{yokohamaLevel1: {}},
-				concerts:   []*entity.Concert{yokohamaConcert},
-			},
-			want: true,
+			name:     "HypeNearby selects in-area and in-range concerts",
+			hype:     entity.HypeNearby,
+			home:     tokyoHome,
+			concerts: all,
+			want:     []*entity.Concert{tokyo, yokohama},
 		},
 		{
-			name: "return false for HypeNearby when all concerts are away",
-			args: args{
-				hype:       entity.HypeNearby,
-				home:       tokyoHome,
-				venueAreas: map[string]struct{}{osakaLevel1: {}},
-				concerts:   []*entity.Concert{osakaConcert},
-			},
-			want: false,
+			name:     "HypeNearby matches nothing when all concerts are away",
+			hype:     entity.HypeNearby,
+			home:     tokyoHome,
+			concerts: []*entity.Concert{osaka},
+			want:     nil,
 		},
 		{
-			name: "return false for HypeNearby when home is nil",
-			args: args{
-				hype:       entity.HypeNearby,
-				home:       nil,
-				venueAreas: map[string]struct{}{yokohamaLevel1: {}},
-				concerts:   []*entity.Concert{yokohamaConcert},
-			},
-			want: false,
+			name:     "HypeNearby matches nothing when home is nil",
+			hype:     entity.HypeNearby,
+			home:     nil,
+			concerts: all,
+			want:     nil,
 		},
 		{
-			name: "return true for HypeAway regardless of proximity",
-			args: args{
-				hype:       entity.HypeAway,
-				home:       tokyoHome,
-				venueAreas: map[string]struct{}{osakaLevel1: {}},
-				concerts:   []*entity.Concert{osakaConcert},
-			},
-			want: true,
+			name:     "HypeAway selects all concerts",
+			hype:     entity.HypeAway,
+			home:     tokyoHome,
+			concerts: all,
+			want:     []*entity.Concert{tokyo, yokohama, osaka},
 		},
 		{
-			name: "return false for unknown hype value",
-			args: args{
-				hype:       entity.Hype("unknown"),
-				home:       tokyoHome,
-				venueAreas: map[string]struct{}{tokyoLevel1: {}},
-				concerts:   []*entity.Concert{tokyoConcert},
-			},
-			want: false,
+			name:     "HypeAway matches nothing for an empty batch",
+			hype:     entity.HypeAway,
+			home:     tokyoHome,
+			concerts: nil,
+			want:     nil,
+		},
+		{
+			name:     "unknown hype matches nothing",
+			hype:     entity.Hype("unknown"),
+			home:     tokyoHome,
+			concerts: all,
+			want:     nil,
 		},
 	}
 
@@ -238,7 +219,66 @@ func TestHype_ShouldNotify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tt.args.hype.ShouldNotify(tt.args.home, tt.args.venueAreas, tt.args.concerts)
+			got := tt.hype.MatchingConcerts(tt.home, tt.concerts)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHype_ShouldNotify(t *testing.T) {
+	t.Parallel()
+
+	tokyoHome, tokyo, _, osaka := hypeTestFixture()
+
+	tests := []struct {
+		name     string
+		hype     entity.Hype
+		home     *entity.Home
+		concerts []*entity.Concert
+		want     bool
+	}{
+		{
+			name:     "false for HypeWatch",
+			hype:     entity.HypeWatch,
+			home:     tokyoHome,
+			concerts: []*entity.Concert{tokyo},
+			want:     false,
+		},
+		{
+			name:     "true for HypeHome with an in-area concert",
+			hype:     entity.HypeHome,
+			home:     tokyoHome,
+			concerts: []*entity.Concert{tokyo},
+			want:     true,
+		},
+		{
+			name:     "false for HypeHome with only out-of-area concerts",
+			hype:     entity.HypeHome,
+			home:     tokyoHome,
+			concerts: []*entity.Concert{osaka},
+			want:     false,
+		},
+		{
+			name:     "true for HypeAway with any concert",
+			hype:     entity.HypeAway,
+			home:     tokyoHome,
+			concerts: []*entity.Concert{osaka},
+			want:     true,
+		},
+		{
+			name:     "false for unknown hype",
+			hype:     entity.Hype("unknown"),
+			home:     tokyoHome,
+			concerts: []*entity.Concert{tokyo},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.hype.ShouldNotify(tt.home, tt.concerts)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/infrastructure/database/rdb/concert_repo.go
+++ b/internal/infrastructure/database/rdb/concert_repo.go
@@ -178,7 +178,7 @@ const (
 	deleteEventQuery = `DELETE FROM events WHERE id = $1`
 
 	// listConcertsByIDsQuery includes venue lat/lng because NotifyNewConcerts
-	// feeds the result into HypeNearby.ShouldNotify, which calls ProximityTo
+	// feeds the result into HypeNearby.MatchingConcerts, which calls ProximityTo
 	// on Venue.Coordinates. Without the coordinates, ProximityTo returns
 	// ProximityAway for every concert and HypeNearby followers are silently
 	// excluded from every new-concert push notification.

--- a/internal/usecase/push_notification_uc.go
+++ b/internal/usecase/push_notification_uc.go
@@ -156,11 +156,16 @@ func (uc *pushNotificationUseCase) Delete(ctx context.Context, userID, endpoint 
 // filtered by each follower's hype level. Only the concerts identified in data
 // are used for hype filtering and payload computation.
 //
-// Filtering rules:
-//   - WATCH: no notification.
-//   - HOME: notify only when at least one concert venue adminArea matches the follower's home.
-//   - NEARBY: notify only when at least one concert venue is within 200km of the follower's home centroid.
-//   - AWAY: always notify.
+// For each follower the new-concert set is narrowed to that recipient's
+// hype-matched subset (see [entity.Hype.MatchingConcerts]):
+//   - WATCH: empty subset → no notification.
+//   - HOME: concerts whose venue adminArea matches the follower's home area.
+//   - NEARBY: concerts within 200km of the follower's home centroid.
+//   - AWAY: all concerts.
+//
+// A recipient is notified only when their subset is non-empty. The body count is
+// the subset size, and the deep-link (data.url) targets the earliest concert of
+// the subset (local date asc, tie-broken by start time asc).
 //
 // Individual delivery failures are logged but do not cause the method to return an error.
 func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data ConcertCreatedData) error {
@@ -221,10 +226,10 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 
 	// Drop orphan concerts from the working slice. The membership check
 	// skipped them above so they don't abort the batch, but if they
-	// stayed in `concerts` they would still feed venueAreas and the
-	// ShouldNotify input — qualifying a follower for HypeHome /
-	// HypeNearby on a concert whose performer membership was never
-	// confirmed (orphan event_performers state).
+	// stayed in `concerts` they would still feed MatchingConcerts —
+	// qualifying a follower for HypeHome / HypeNearby (or padding the
+	// HypeAway count and deep-link) on a concert whose performer
+	// membership was never confirmed (orphan event_performers state).
 	if len(orphanConcerts) > 0 {
 		kept := concerts[:0]
 		for _, c := range concerts {
@@ -237,9 +242,9 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 
 	// If every concert was an orphan, there's nothing real to notify
 	// about — short-circuit before the hype loop. Without this guard,
-	// HypeAway.ShouldNotify returns true unconditionally and every
-	// HypeAway follower receives a push with a "0 new concerts" payload
-	// (concertNotificationBody formats the count from len(concerts)).
+	// HypeAway.MatchingConcerts would return an empty subset for every
+	// recipient (so no push is sent), but short-circuiting here also skips
+	// the follower lookup entirely.
 	if len(concerts) == 0 {
 		return nil
 	}
@@ -253,43 +258,18 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 		return nil
 	}
 
-	// 2. Collect unique venue admin areas from concerts for HOME filtering.
-	venueAreas := make(map[string]struct{})
-	for _, c := range concerts {
-		if c.Venue != nil && c.Venue.AdminArea != nil {
-			venueAreas[*c.Venue.AdminArea] = struct{}{}
-		}
-	}
-
-	// 3. Filter followers by hype level and collect eligible user IDs, recording
-	//    each recipient's resolved language for per-user copy localization.
-	var userIDs []string
-	langByUser := make(map[string]string)
+	// 2. For each follower, narrow the new-concert set to that recipient's
+	//    hype-matched subset, then record and dispatch one notification per
+	//    eligible recipient through the notification service. Every recipient
+	//    gets a durable record and a delivery outcome; the service resolves each
+	//    recipient's push subscriptions, performs the send, cleans up gone (410)
+	//    endpoints, and records delivered/failed.
+	//
+	//    Both the body count and the deep-link target are computed from the
+	//    per-recipient subset — never from the unfiltered new-concert set — so a
+	//    home-hype fan sees an area-accurate count and lands on a concert that
+	//    actually matched their hype tier.
 	for _, f := range followers {
-		// f.User may be nil if the join with users dropped a row (e.g.
-		// orphaned follow). Skip the whole follower in that case — the
-		// subsequent f.User.ID dereference would panic for any non-Watch
-		// hype tier because HypeAway.ShouldNotify always returns true and
-		// HypeHome may return true without ever reading f.User.Home.
-		if f.User == nil {
-			continue
-		}
-		if !f.Hype.ShouldNotify(f.User.Home, venueAreas, concerts) {
-			continue
-		}
-		userIDs = append(userIDs, f.User.ID)
-		langByUser[f.User.ID] = f.User.PreferredLanguage
-	}
-	if len(userIDs) == 0 {
-		return nil
-	}
-
-	// 4. Record and dispatch one notification per eligible recipient through the
-	//    notification service, so every recipient gets a durable record and a
-	//    delivery outcome. The service resolves each recipient's push
-	//    subscriptions, performs the send, cleans up gone (410) endpoints, and
-	//    records delivered/failed. Copy is localized per recipient by language.
-	for _, userID := range userIDs {
 		// Honour context cancellation before each recipient.
 		select {
 		case <-ctx.Done():
@@ -297,21 +277,40 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 		default:
 		}
 
+		// f.User may be nil if the join with users dropped a row (e.g. an
+		// orphaned follow). Skip the whole follower in that case — the
+		// MatchingConcerts call reads f.User.Home and the dispatch reads
+		// f.User.ID, both of which would panic on a nil user.
+		if f.User == nil {
+			continue
+		}
+
+		subset := f.Hype.MatchingConcerts(f.User.Home, concerts)
+		if len(subset) == 0 {
+			continue
+		}
+
+		earliest := entity.EarliestConcert(subset)
+		if earliest == nil {
+			// Defensive: a non-empty subset should always yield an earliest
+			// concert. Skip rather than emit a notification with no deep-link.
+			continue
+		}
+
 		payload := entity.NewNotificationPayload(
 			artist.Name,
-			concertNotificationBody(len(concerts), langByUser[userID]),
-			// Deep-link to the dashboard (the fan's home, which lists their
-			// followed-artist concerts). The former "/concerts?artist=<id>" had
-			// no matching frontend route and 404'd on tap; there is no per-artist
-			// concert list route yet, so land on the dashboard.
-			"/dashboard",
+			concertNotificationBody(len(subset), f.User.PreferredLanguage),
+			// Deep-link to the earliest hype-matched concert. The frontend's
+			// canonical concert-detail URL routes to the dashboard and opens the
+			// concert's detail sheet, filtered to its artist.
+			fmt.Sprintf("/concerts/%s", earliest.ID),
 			fmt.Sprintf("concert-%s", artist.ID),
 		)
-		if _, err := uc.notificationUC.Notify(ctx, userID, entity.NotificationTypeNewConcerts, payload); err != nil {
+		if _, err := uc.notificationUC.Notify(ctx, f.User.ID, entity.NotificationTypeNewConcerts, payload); err != nil {
 			// Record-create failure ("no record => no send"): surface so the
 			// consumer's at-least-once retry re-drives the batch. Repeat web
 			// pushes are deduplicated browser-side by the per-artist Tag.
-			return fmt.Errorf("failed to notify user %s of new concerts for artist %s: %w", userID, artist.ID, err)
+			return fmt.Errorf("failed to notify user %s of new concerts for artist %s: %w", f.User.ID, artist.ID, err)
 		}
 	}
 

--- a/internal/usecase/push_notification_uc_test.go
+++ b/internal/usecase/push_notification_uc_test.go
@@ -3,6 +3,7 @@ package usecase_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/liverty-music/backend/internal/entity"
 	"github.com/liverty-music/backend/internal/entity/mocks"
@@ -740,5 +741,88 @@ func TestNotifyNewConcerts_PluralBodyPerLanguage(t *testing.T) {
 		Once()
 
 	err := d.uc.NotifyNewConcerts(ctx, usecase.ConcertCreatedData{ArtistID: "artist-1", ConcertIDs: []string{"c1", "c2"}})
+	assert.NoError(t, err)
+}
+
+// payloadURL extracts the deep-link URL from a notification payload's data map.
+func payloadURL(p *entity.NotificationPayload) string {
+	return p.Data[entity.NotificationDataKeyURL]
+}
+
+// TestNotifyNewConcerts_DeepLinksToEarliestMatched verifies that an AWAY
+// recipient's notification deep-links to the earliest concert of the batch,
+// regardless of the order the concerts arrive in.
+func TestNotifyNewConcerts_DeepLinksToEarliestMatched(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	d := newPushNotificationTestDeps(t)
+
+	tokyoArea := "JP-13"
+	date := func(day int) time.Time { return time.Date(2026, 9, day, 0, 0, 0, 0, time.UTC) }
+	// The later concert is listed first to prove ordering is by date, not slice order.
+	concerts := []*entity.Concert{
+		{Event: entity.Event{ID: "c-late", LocalDate: date(10), Venue: &entity.Venue{AdminArea: &tokyoArea}}, Performers: []*entity.Artist{{ID: "artist-1"}}},
+		{Event: entity.Event{ID: "c-early", LocalDate: date(3), Venue: &entity.Venue{AdminArea: &tokyoArea}}, Performers: []*entity.Artist{{ID: "artist-1"}}},
+	}
+	artist := &entity.Artist{ID: "artist-1", Name: "Test Artist"}
+	followers := []*entity.Follower{
+		{ArtistID: "artist-1", User: &entity.User{ID: "user-away"}, Hype: entity.HypeAway},
+	}
+
+	d.artistRepo.EXPECT().Get(ctx, "artist-1").Return(artist, nil).Once()
+	d.concertRepo.EXPECT().ListByIDs(ctx, []string{"c-late", "c-early"}).Return(concerts, nil).Once()
+	d.followRepo.EXPECT().ListFollowers(ctx, "artist-1").Return(followers, nil).Once()
+
+	deliveredNotif := &entity.Notification{ID: "notif-1", DeliveryStatus: entity.NotificationDeliveryStatusDelivered}
+	d.notificationUC.EXPECT().
+		Notify(anyCtx, "user-away", entity.NotificationTypeNewConcerts,
+			mock.MatchedBy(func(p *entity.NotificationPayload) bool {
+				return payloadURL(p) == "/concerts/c-early" && p.Body == "2 new concerts found"
+			})).
+		Return(deliveredNotif, nil).
+		Once()
+
+	err := d.uc.NotifyNewConcerts(ctx, usecase.ConcertCreatedData{ArtistID: "artist-1", ConcertIDs: []string{"c-late", "c-early"}})
+	assert.NoError(t, err)
+}
+
+// TestNotifyNewConcerts_HomeRecipientSubsetCountAndDeepLink verifies the spec's
+// home-hype scenario: with 3 new concerts (1 in JP-13, 2 in JP-40), a home
+// recipient in JP-13 sees a count of 1 and deep-links to the in-area concert —
+// never the earlier, out-of-area JP-40 concert.
+func TestNotifyNewConcerts_HomeRecipientSubsetCountAndDeepLink(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	d := newPushNotificationTestDeps(t)
+
+	tokyoArea := "JP-13"
+	aichiArea := "JP-40"
+	date := func(day int) time.Time { return time.Date(2026, 9, day, 0, 0, 0, 0, time.UTC) }
+	concerts := []*entity.Concert{
+		{Event: entity.Event{ID: "aichi-early", LocalDate: date(1), Venue: &entity.Venue{AdminArea: &aichiArea}}, Performers: []*entity.Artist{{ID: "artist-1"}}},
+		{Event: entity.Event{ID: "tokyo-later", LocalDate: date(5), Venue: &entity.Venue{AdminArea: &tokyoArea}}, Performers: []*entity.Artist{{ID: "artist-1"}}},
+		{Event: entity.Event{ID: "aichi-early2", LocalDate: date(2), Venue: &entity.Venue{AdminArea: &aichiArea}}, Performers: []*entity.Artist{{ID: "artist-1"}}},
+	}
+	artist := &entity.Artist{ID: "artist-1", Name: "Test Artist"}
+	followers := []*entity.Follower{
+		{ArtistID: "artist-1", User: &entity.User{ID: "user-home-tokyo", Home: &entity.Home{Level1: "JP-13"}}, Hype: entity.HypeHome},
+	}
+
+	d.artistRepo.EXPECT().Get(ctx, "artist-1").Return(artist, nil).Once()
+	d.concertRepo.EXPECT().ListByIDs(ctx, []string{"aichi-early", "tokyo-later", "aichi-early2"}).Return(concerts, nil).Once()
+	d.followRepo.EXPECT().ListFollowers(ctx, "artist-1").Return(followers, nil).Once()
+
+	deliveredNotif := &entity.Notification{ID: "notif-1", DeliveryStatus: entity.NotificationDeliveryStatusDelivered}
+	d.notificationUC.EXPECT().
+		Notify(anyCtx, "user-home-tokyo", entity.NotificationTypeNewConcerts,
+			mock.MatchedBy(func(p *entity.NotificationPayload) bool {
+				return payloadURL(p) == "/concerts/tokyo-later" && p.Body == "1 new concert found"
+			})).
+		Return(deliveredNotif, nil).
+		Once()
+
+	err := d.uc.NotifyNewConcerts(ctx, usecase.ConcertCreatedData{ArtistID: "artist-1", ConcertIDs: []string{"aichi-early", "tokyo-later", "aichi-early2"}})
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Why

Tapping a new-concert push notification landed the fan on a bare `/dashboard` with no context. Two defects compounded: the deep-link dropped the artist filter, and it never targeted the concert that triggered the hype match. See #753.

## What changed

- **`Hype.MatchingConcerts(home, concerts)`** — new per-recipient subset selector: `watch`→∅, `home`→in-area (ProximityHome), `nearby`→in-range (Home/Nearby), `away`→all. `ShouldNotify` now delegates to `len(subset) > 0`.
- **`EarliestConcert(concerts)`** — deterministic deep-link target: local date asc, tie-broken by start time asc (known before unknown), ID as final stable tie-break.
- **`push_notification_uc.go`** — computes the subset once per recipient; gates delivery on a non-empty subset; sets the body **count to `len(subset)`** (fixes the pre-existing `home`-hype over-count); sets **`data.url = "/concerts/<earliestId>"`**.

## Behavioral change (BREAKING, intended)

`home`-hype recipients now see an **area-accurate count** (only their in-area new concerts), not the count of all new concerts.

## No proto change

`data.url` is a runtime Web Push payload field (`NotificationDataKeyURL`) and the count is a formatting concern — confirmed no schema/BSR change needed.

## Tests

- `Hype.MatchingConcerts`: home in/out-of-area, nearby in/out-of-range, away-all, watch-empty, nil-home, empty-batch.
- `EarliestConcert`: date ordering, same-day start-time tie-break, known-before-unknown, ID tie-break, home-recipient "in-area, not globally-earliest".
- Usecase: deep-links to earliest matched; home-recipient subset count=1 + in-area deep-link.
- `make check` green (lint + unit + integration).

Refs: #753