### PR TITLE
chore(deps): bump Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: false
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Download dependencies
@@ -107,7 +107,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Run govulncheck
@@ -154,7 +154,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Download dependencies

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/liverty-music/backend
 
 go 1.26
 
-// Pin the minimum toolchain to 1.26.5, which fixes the Go stdlib advisory
-// GO-2026-5856 (crypto/tls) flagged by govulncheck — reachable via
-// pkg/httpx/retry.go — on top of the earlier GO-2026-5037 (crypto/x509) and
-// GO-2026-5039 (net/textproto). Every `go` invocation (local, CI) uses at
+// Pin the minimum toolchain to 1.26.6, which fixes the Go stdlib advisories
+// flagged by govulncheck: GO-2026-6089/GO-2026-5026 (net/http),
+// GO-2026-6090 (crypto/tls), GO-2026-6091 (html/template), GO-2026-6218
+// (net/url), GO-2026-6088 (encoding/xml) and GO-2026-5972 (encoding/asn1) —
+// on top of the earlier GO-2026-5856 (crypto/tls), GO-2026-5037 (crypto/x509)
+// and GO-2026-5039 (net/textproto). Every `go` invocation (local, CI) uses at
 // least this toolchain.
-toolchain go1.26.5
+toolchain go1.26.6
 
 tool (
 	github.com/bufbuild/buf/cmd/buf


### PR DESCRIPTION
## Why
govulncheck reddens **every open backend PR**: 7 Go standard-library advisories are flagged, all "Found in go1.26.5, Fixed in go1.26.6":

- `net/http` — GO-2026-6089, GO-2026-5026
- `crypto/tls` — GO-2026-6090
- `html/template` — GO-2026-6091
- `net/url` — GO-2026-6218
- `encoding/xml` — GO-2026-6088
- `encoding/asn1` — GO-2026-5972

## What
- `go.mod`: `toolchain go1.26.5 → go1.26.6` (+ updated advisory comment).
- CI `go-version: "1.26.5" → "1.26.6"` in `lint.yml` and `test.yml` (3 jobs).

Unblocks the merge queue (e.g. #385). No code changes.

Refs: #386