### PR TITLE
feat(notification): surface push delivery failures as logs and metrics

### DIFF
--- a/internal/infrastructure/telemetry/business_metrics.go
+++ b/internal/infrastructure/telemetry/business_metrics.go
@@ -17,9 +17,10 @@ var _ usecase.PushMetrics = (*BusinessMetrics)(nil)
 // BusinessMetrics provides OTel counters for key business operations.
 // It is injected into use cases that need to record business-level metrics.
 type BusinessMetrics struct {
-	concertSearch metric.Int64Counter
-	follow        metric.Int64Counter
-	pushSend      metric.Int64Counter
+	concertSearch   metric.Int64Counter
+	follow          metric.Int64Counter
+	pushSend        metric.Int64Counter
+	deliveryOutcome metric.Int64Counter
 }
 
 // NewBusinessMetrics creates a new BusinessMetrics with registered OTel instruments.
@@ -34,10 +35,14 @@ func NewBusinessMetrics() *BusinessMetrics {
 	pushSend, _ := meter.Int64Counter("push_notification.send.count",
 		metric.WithDescription("Push notification send operations by status"),
 	)
+	deliveryOutcome, _ := meter.Int64Counter("notification.delivery.count",
+		metric.WithDescription("Per-notification delivery outcomes by outcome and failure reason"),
+	)
 	return &BusinessMetrics{
-		concertSearch: concertSearch,
-		follow:        follow,
-		pushSend:      pushSend,
+		concertSearch:   concertSearch,
+		follow:          follow,
+		pushSend:        pushSend,
+		deliveryOutcome: deliveryOutcome,
 	}
 }
 
@@ -59,4 +64,13 @@ func (m *BusinessMetrics) RecordFollow(ctx context.Context, action string) {
 // RecordPushSend increments the push notification send counter.
 func (m *BusinessMetrics) RecordPushSend(ctx context.Context, status string) {
 	m.pushSend.Add(ctx, 1, metric.WithAttributes(attribute.String("status", status)))
+}
+
+// RecordDeliveryOutcome increments the per-notification delivery-outcome counter,
+// tagged by the terminal outcome and a low-cardinality failure-reason category.
+func (m *BusinessMetrics) RecordDeliveryOutcome(ctx context.Context, outcome, failureReason string) {
+	m.deliveryOutcome.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("outcome", outcome),
+		attribute.String("failure_reason", failureReason),
+	))
 }

--- a/internal/usecase/concert_creation_uc_test.go
+++ b/internal/usecase/concert_creation_uc_test.go
@@ -294,9 +294,10 @@ func newTestLogger(t *testing.T) *logging.Logger {
 // for use in unit tests that do not assert on metric recording.
 type noopMetrics struct{}
 
-func (noopMetrics) RecordConcertSearch(_ context.Context, _ string) {}
-func (noopMetrics) RecordFollow(_ context.Context, _ string)        {}
-func (noopMetrics) RecordPushSend(_ context.Context, _ string)      {}
+func (noopMetrics) RecordConcertSearch(_ context.Context, _ string)      {}
+func (noopMetrics) RecordFollow(_ context.Context, _ string)             {}
+func (noopMetrics) RecordPushSend(_ context.Context, _ string)           {}
+func (noopMetrics) RecordDeliveryOutcome(_ context.Context, _, _ string) {}
 
 // --- tests ---
 

--- a/internal/usecase/metrics.go
+++ b/internal/usecase/metrics.go
@@ -14,7 +14,16 @@ type FollowMetrics interface {
 
 // PushMetrics records observability signals for push notification send operations.
 type PushMetrics interface {
+	// RecordPushSend increments the per-endpoint send counter, tagging the send
+	// outcome via status ("success", "error", "gone").
 	RecordPushSend(ctx context.Context, status string)
+
+	// RecordDeliveryOutcome increments the per-notification delivery-outcome
+	// counter. outcome is the terminal delivery status ("delivered" or "failed")
+	// and failureReason is a low-cardinality category ("none" on success, or one
+	// of the bounded delivery-failure categories) so the signal stays cheap to
+	// aggregate and safe to alert on.
+	RecordDeliveryOutcome(ctx context.Context, outcome, failureReason string)
 }
 
 // AnalyticsConsumerMetrics records observability signals for the

--- a/internal/usecase/notification_uc.go
+++ b/internal/usecase/notification_uc.go
@@ -65,6 +65,20 @@ type NotificationUseCase interface {
 // not worth retrying) from a transient send error.
 const NotificationFailureReasonNoSubscription = "no active push subscription"
 
+// Bounded delivery-failure categories. They are the *label* attached to the
+// delivery-outcome metric and the WARNING failure log, kept deliberately small so
+// the signal stays low-cardinality and safe for a log-based-metric alert (the raw
+// reason string carries the unbounded diagnostic detail separately).
+const (
+	deliveryFailureReasonNone           = "none"
+	deliveryFailureReasonNoSubscription = "no_subscription"
+	deliveryFailureReasonGone           = "gone"
+	deliveryFailureReasonSendError      = "send_error"
+	deliveryFailureReasonListFailed     = "list_failed"
+	deliveryFailureReasonMarshalFailed  = "marshal_failed"
+	deliveryFailureReasonCancelled      = "cancelled"
+)
+
 // notificationUseCase implements NotificationUseCase.
 type notificationUseCase struct {
 	notificationRepo entity.NotificationRepository
@@ -126,7 +140,24 @@ func (uc *notificationUseCase) Notify(ctx context.Context, userID string, typ en
 	payload.Data[entity.NotificationDataKeyNotificationID] = n.ID
 
 	// 3. Dispatch to the web-push channel and 4. record the outcome.
-	status, deliveredAt, reason := uc.dispatch(ctx, n, payload)
+	status, deliveredAt, reason, reasonCategory := uc.dispatch(ctx, n, payload)
+
+	// Surface the outcome as an operational signal so a systemic delivery failure
+	// is detectable without querying the notifications table. The metric is emitted
+	// for every outcome (the alert needs a failed-vs-total ratio); a failed
+	// delivery is additionally logged at WARNING, with the bounded failure_reason
+	// as a label and the unbounded detail kept separate for debugging.
+	uc.metrics.RecordDeliveryOutcome(ctx, string(status), reasonCategory)
+	if status == entity.NotificationDeliveryStatusFailed {
+		uc.logger.Warn(ctx, "notification delivery failed",
+			slog.String("notification_id", n.ID),
+			slog.String("user_id", userID),
+			slog.String("notification_type", string(typ)),
+			slog.String("failure_reason", reasonCategory),
+			slog.String("failure_detail", reason),
+		)
+	}
+
 	if err := uc.notificationRepo.UpdateDelivery(ctx, n.ID, status, deliveredAt, reason); err != nil {
 		// Non-fatal: the send has already happened (or failed) and the record
 		// exists. The delivery-state column may lag but the notification is not
@@ -163,31 +194,33 @@ func (uc *notificationUseCase) Notify(ctx context.Context, userID string, typ en
 // dispatch sends the rendered payload to every web-push subscription the user
 // has, cleaning up gone (410) subscriptions, and returns the terminal delivery
 // outcome: delivered when at least one send was accepted, otherwise failed (with
-// a reason). It never returns an error — a failed dispatch is a recorded outcome,
-// not a lost notification.
-func (uc *notificationUseCase) dispatch(ctx context.Context, n *entity.Notification, payload *entity.NotificationPayload) (entity.NotificationDeliveryStatus, *time.Time, string) {
+// a human-readable reason and a bounded reason category for metric/log labels).
+// It never returns an error — a failed dispatch is a recorded outcome, not a lost
+// notification.
+func (uc *notificationUseCase) dispatch(ctx context.Context, n *entity.Notification, payload *entity.NotificationPayload) (status entity.NotificationDeliveryStatus, deliveredAt *time.Time, reason, reasonCategory string) {
 	subs, err := uc.pushSubRepo.ListByUserIDs(ctx, []string{n.UserID})
 	if err != nil {
 		uc.logger.Error(ctx, "failed to list push subscriptions for notification", err,
 			slog.String("notification_id", n.ID),
 			slog.String("user_id", n.UserID),
 		)
-		return entity.NotificationDeliveryStatusFailed, nil, "failed to list push subscriptions: " + err.Error()
+		return entity.NotificationDeliveryStatusFailed, nil, "failed to list push subscriptions: " + err.Error(), deliveryFailureReasonListFailed
 	}
 	if len(subs) == 0 {
 		// The record still exists for the in-app inbox; the push channel simply
 		// had no endpoint to deliver to. Recorded as failed for delivery audit.
-		return entity.NotificationDeliveryStatusFailed, nil, NotificationFailureReasonNoSubscription
+		return entity.NotificationDeliveryStatusFailed, nil, NotificationFailureReasonNoSubscription, deliveryFailureReasonNoSubscription
 	}
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return entity.NotificationDeliveryStatusFailed, nil, "failed to marshal payload: " + err.Error()
+		return entity.NotificationDeliveryStatusFailed, nil, "failed to marshal payload: " + err.Error(), deliveryFailureReasonMarshalFailed
 	}
 
 	var (
 		atLeastOneSuccess bool
 		lastErr           string
+		lastCategory      string
 	)
 	for _, sub := range subs {
 		// Stop dispatching the moment the context is cancelled: record the cause
@@ -195,6 +228,7 @@ func (uc *notificationUseCase) dispatch(ctx context.Context, n *entity.Notificat
 		// keep the notification's delivered outcome; otherwise it is failed.
 		if err := ctx.Err(); err != nil {
 			lastErr = err.Error()
+			lastCategory = deliveryFailureReasonCancelled
 			break
 		}
 
@@ -209,6 +243,7 @@ func (uc *notificationUseCase) dispatch(ctx context.Context, n *entity.Notificat
 					)
 				}
 				lastErr = "push subscription gone (410)"
+				lastCategory = deliveryFailureReasonGone
 			} else {
 				uc.metrics.RecordPushSend(ctx, "error")
 				uc.logger.Error(ctx, "failed to send push notification", err,
@@ -216,6 +251,7 @@ func (uc *notificationUseCase) dispatch(ctx context.Context, n *entity.Notificat
 					slog.String("user_id", sub.UserID),
 				)
 				lastErr = err.Error()
+				lastCategory = deliveryFailureReasonSendError
 			}
 		} else {
 			uc.metrics.RecordPushSend(ctx, "success")
@@ -225,9 +261,9 @@ func (uc *notificationUseCase) dispatch(ctx context.Context, n *entity.Notificat
 
 	if atLeastOneSuccess {
 		now := time.Now().UTC()
-		return entity.NotificationDeliveryStatusDelivered, &now, ""
+		return entity.NotificationDeliveryStatusDelivered, &now, "", deliveryFailureReasonNone
 	}
-	return entity.NotificationDeliveryStatusFailed, nil, lastErr
+	return entity.NotificationDeliveryStatusFailed, nil, lastErr, lastCategory
 }
 
 // MarkRead implements [NotificationUseCase].

--- a/internal/usecase/notification_uc_test.go
+++ b/internal/usecase/notification_uc_test.go
@@ -1,13 +1,17 @@
 package usecase_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/pannpers/go-apperr/apperr"
 	"github.com/pannpers/go-apperr/apperr/codes"
+	"github.com/pannpers/go-logging/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -17,6 +21,35 @@ import (
 	"github.com/liverty-music/backend/internal/usecase"
 	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 )
+
+// deliveryOutcomeCall captures one RecordDeliveryOutcome invocation.
+type deliveryOutcomeCall struct{ outcome, reason string }
+
+// captureMetrics is a PushMetrics spy that records delivery-outcome calls so a
+// test can assert the operational signal was emitted with the right labels.
+type captureMetrics struct {
+	outcomes []deliveryOutcomeCall
+}
+
+func (m *captureMetrics) RecordPushSend(_ context.Context, _ string) {}
+
+func (m *captureMetrics) RecordDeliveryOutcome(_ context.Context, outcome, reason string) {
+	m.outcomes = append(m.outcomes, deliveryOutcomeCall{outcome: outcome, reason: reason})
+}
+
+// newCaptureLogger returns a JSON logger writing into the returned buffer so a
+// test can assert on emitted log lines.
+func newCaptureLogger(t *testing.T) (*logging.Logger, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	logger, err := logging.New(
+		logging.WithFormat(logging.FormatJSON),
+		logging.WithLevel(slog.LevelInfo),
+		logging.WithWriter(buf),
+	)
+	require.NoError(t, err)
+	return logger, buf
+}
 
 func buildNotificationUC(
 	t *testing.T,
@@ -241,6 +274,81 @@ func TestNotify_NilPayloadRejected(t *testing.T) {
 
 	require.ErrorIs(t, err, apperr.ErrInvalidArgument)
 	notifRepo.AssertNotCalled(t, "Create")
+}
+
+// Observability: a failed delivery emits the WARNING log (with the bounded
+// failure_reason label) AND the delivery-outcome metric, so the failure is
+// detectable without querying the notifications table.
+func TestNotify_FailedDeliveryEmitsWarningLogAndMetric(t *testing.T) {
+	t.Parallel()
+
+	notifRepo := entitymocks.NewMockNotificationRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+
+	notifRepo.EXPECT().
+		Create(anyCtx, mock.Anything).
+		Run(func(_ context.Context, n *entity.Notification) { n.ID = "id-obs" }).
+		Return(nil)
+	// No subscriptions ⇒ failed with the "no active push subscription" reason.
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-1"}).
+		Return([]*entity.PushSubscription{}, nil)
+	notifRepo.EXPECT().
+		UpdateDelivery(anyCtx, "id-obs", entity.NotificationDeliveryStatusFailed, (*time.Time)(nil), "no active push subscription").
+		Return(nil)
+
+	metrics := &captureMetrics{}
+	logger, buf := newCaptureLogger(t)
+	uc := usecase.NewNotificationUseCase(notifRepo, pushSubRepo, sender, ucmocks.NewMockEventPublisher(t), metrics, logger)
+
+	_, err := uc.Notify(context.Background(), "user-1", entity.NotificationTypeNewConcerts, notifPayload())
+	require.NoError(t, err)
+
+	// Metric: failed outcome with the bounded no_subscription reason.
+	require.Contains(t, metrics.outcomes, deliveryOutcomeCall{outcome: "failed", reason: "no_subscription"})
+
+	// Log: a WARNING line naming the failure and carrying the bounded label.
+	logs := buf.String()
+	assert.Contains(t, logs, `"level":"WARN"`)
+	assert.Contains(t, logs, "notification delivery failed")
+	assert.Contains(t, logs, `"failure_reason":"no_subscription"`)
+	assert.Contains(t, logs, `"notification_id":"id-obs"`)
+}
+
+// Observability: the success path stays quiet — it emits the delivered metric
+// but produces no WARNING delivery-failure log.
+func TestNotify_SuccessEmitsNoWarningLog(t *testing.T) {
+	t.Parallel()
+
+	notifRepo := entitymocks.NewMockNotificationRepository(t)
+	pushSubRepo := entitymocks.NewMockPushSubscriptionRepository(t)
+	sender := entitymocks.NewMockPushNotificationSender(t)
+
+	notifRepo.EXPECT().
+		Create(anyCtx, mock.Anything).
+		Run(func(_ context.Context, n *entity.Notification) { n.ID = "id-ok" }).
+		Return(nil)
+	pushSubRepo.EXPECT().
+		ListByUserIDs(anyCtx, []string{"user-1"}).
+		Return([]*entity.PushSubscription{sub("user-1", "https://push/1")}, nil)
+	sender.EXPECT().Send(anyCtx, mock.Anything, mock.Anything).Return(nil)
+	notifRepo.EXPECT().
+		UpdateDelivery(anyCtx, "id-ok", entity.NotificationDeliveryStatusDelivered, mock.AnythingOfType("*time.Time"), "").
+		Return(nil)
+	publisher := ucmocks.NewMockEventPublisher(t)
+	publisher.EXPECT().PublishEvent(anyCtx, entity.SubjectNotificationDelivered, mock.Anything).Return(nil).Once()
+
+	metrics := &captureMetrics{}
+	logger, buf := newCaptureLogger(t)
+	uc := usecase.NewNotificationUseCase(notifRepo, pushSubRepo, sender, publisher, metrics, logger)
+
+	_, err := uc.Notify(context.Background(), "user-1", entity.NotificationTypeNewConcerts, notifPayload())
+	require.NoError(t, err)
+
+	require.Contains(t, metrics.outcomes, deliveryOutcomeCall{outcome: "delivered", reason: "none"})
+	assert.NotContains(t, buf.String(), "notification delivery failed")
+	assert.False(t, strings.Contains(buf.String(), `"level":"WARN"`), "success path must not warn")
 }
 
 // Read idempotency: MarkRead loads the record, confirms ownership, and delegates

--- a/internal/usecase/push_notification_uc.go
+++ b/internal/usecase/push_notification_uc.go
@@ -246,6 +246,10 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 	// recipient (so no push is sent), but short-circuiting here also skips
 	// the follower lookup entirely.
 	if len(concerts) == 0 {
+		uc.logger.Info(ctx, "new-concert fan-out sent nothing: no deliverable concerts",
+			slog.String("artist_id", data.ArtistID),
+			slog.String("reason", "no_deliverable_concerts"),
+		)
 		return nil
 	}
 
@@ -255,6 +259,10 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 		return fmt.Errorf("failed to list followers for artist %s: %w", artist.ID, err)
 	}
 	if len(followers) == 0 {
+		uc.logger.Info(ctx, "new-concert fan-out sent nothing: artist has no followers",
+			slog.String("artist_id", artist.ID),
+			slog.String("reason", "no_followers"),
+		)
 		return nil
 	}
 
@@ -269,6 +277,7 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 	//    per-recipient subset — never from the unfiltered new-concert set — so a
 	//    home-hype fan sees an area-accurate count and lands on a concert that
 	//    actually matched their hype tier.
+	dispatched := 0
 	for _, f := range followers {
 		// Honour context cancellation before each recipient.
 		select {
@@ -312,6 +321,19 @@ func (uc *pushNotificationUseCase) NotifyNewConcerts(ctx context.Context, data C
 			// pushes are deduplicated browser-side by the per-artist Tag.
 			return fmt.Errorf("failed to notify user %s of new concerts for artist %s: %w", f.User.ID, artist.ID, err)
 		}
+		dispatched++
+	}
+
+	// The artist has followers, but none was eligible after hype filtering (every
+	// recipient's matched subset was empty). Log the empty outcome so "processed
+	// the event but sent nothing" is diagnosable from logs alone, rather than
+	// returning silently.
+	if dispatched == 0 {
+		uc.logger.Info(ctx, "new-concert fan-out sent nothing: no eligible recipients after hype filtering",
+			slog.String("artist_id", artist.ID),
+			slog.String("reason", "no_eligible_recipients"),
+			slog.Int("follower_count", len(followers)),
+		)
 	}
 
 	return nil

--- a/internal/usecase/push_notification_uc_test.go
+++ b/internal/usecase/push_notification_uc_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/liverty-music/backend/internal/usecase"
 	ucmocks "github.com/liverty-music/backend/internal/usecase/mocks"
 	"github.com/pannpers/go-apperr/apperr"
+	"github.com/pannpers/go-logging/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // pushNotificationTestDeps holds all dependencies for PushNotificationUseCase tests.
@@ -742,6 +744,94 @@ func TestNotifyNewConcerts_PluralBodyPerLanguage(t *testing.T) {
 
 	err := d.uc.NotifyNewConcerts(ctx, usecase.ConcertCreatedData{ArtistID: "artist-1", ConcertIDs: []string{"c1", "c2"}})
 	assert.NoError(t, err)
+}
+
+// newPushNotificationUCWithLogger builds the use case with a capture logger so a
+// test can assert on the zero-recipient early-return logs.
+func newPushNotificationUCWithLogger(t *testing.T, d *pushNotificationTestDeps, logger *logging.Logger) usecase.PushNotificationUseCase {
+	t.Helper()
+	return usecase.NewPushNotificationUseCase(
+		d.artistRepo,
+		d.concertRepo,
+		d.followRepo,
+		d.pushSubRepo,
+		d.publisher,
+		d.notificationUC,
+		logger,
+	)
+}
+
+// TestNotifyNewConcerts_ZeroRecipientPathsAreLogged verifies each zero-dispatch
+// early-return emits a diagnostic log with its reason and the artist id, instead
+// of returning silently.
+func TestNotifyNewConcerts_ZeroRecipientPathsAreLogged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tokyoArea := "JP-13"
+	artist := &entity.Artist{ID: "artist-1", Name: "Test Artist"}
+	concert := []*entity.Concert{
+		{Event: entity.Event{ID: "c1", Venue: &entity.Venue{AdminArea: &tokyoArea}}, Performers: []*entity.Artist{{ID: "artist-1"}}},
+	}
+
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, d *pushNotificationTestDeps)
+		wantReason string
+	}{
+		{
+			name: "no followers",
+			setup: func(t *testing.T, d *pushNotificationTestDeps) {
+				t.Helper()
+				d.artistRepo.EXPECT().Get(ctx, "artist-1").Return(artist, nil).Once()
+				d.concertRepo.EXPECT().ListByIDs(ctx, []string{"c1"}).Return(concert, nil).Once()
+				d.followRepo.EXPECT().ListFollowers(ctx, "artist-1").Return([]*entity.Follower{}, nil).Once()
+			},
+			wantReason: `"reason":"no_followers"`,
+		},
+		{
+			name: "no eligible recipients after hype filtering",
+			setup: func(t *testing.T, d *pushNotificationTestDeps) {
+				t.Helper()
+				d.artistRepo.EXPECT().Get(ctx, "artist-1").Return(artist, nil).Once()
+				d.concertRepo.EXPECT().ListByIDs(ctx, []string{"c1"}).Return(concert, nil).Once()
+				// A WATCH follower is never eligible ⇒ zero dispatches.
+				d.followRepo.EXPECT().ListFollowers(ctx, "artist-1").Return([]*entity.Follower{
+					{ArtistID: "artist-1", User: &entity.User{ID: "user-watch"}, Hype: entity.HypeWatch},
+				}, nil).Once()
+			},
+			wantReason: `"reason":"no_eligible_recipients"`,
+		},
+		{
+			name: "no deliverable concerts (all orphans)",
+			setup: func(t *testing.T, d *pushNotificationTestDeps) {
+				t.Helper()
+				d.artistRepo.EXPECT().Get(ctx, "artist-1").Return(artist, nil).Once()
+				// The only concert has no performers ⇒ dropped as an orphan ⇒ empty set.
+				d.concertRepo.EXPECT().ListByIDs(ctx, []string{"c1"}).Return([]*entity.Concert{
+					{Event: entity.Event{ID: "c1", Venue: &entity.Venue{AdminArea: &tokyoArea}}},
+				}, nil).Once()
+			},
+			wantReason: `"reason":"no_deliverable_concerts"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d := newPushNotificationTestDeps(t)
+			tt.setup(t, d)
+			logger, buf := newCaptureLogger(t)
+			uc := newPushNotificationUCWithLogger(t, d, logger)
+
+			err := uc.NotifyNewConcerts(ctx, usecase.ConcertCreatedData{ArtistID: "artist-1", ConcertIDs: []string{"c1"}})
+			require.NoError(t, err)
+
+			logs := buf.String()
+			assert.Contains(t, logs, tt.wantReason)
+			assert.Contains(t, logs, `"artist_id":"artist-1"`)
+		})
+	}
 }
 
 // payloadURL extracts the deep-link URL from a notification payload's data map.


### PR DESCRIPTION
## Summary

New-concert push notifications silently stopped reaching every follower in production for ~2 weeks. The pipeline (approve → `CONCERT.created` → consumer → follower/hype match → notification record) was healthy; delivery failed only at the final Web Push send because **no push subscription existed** for recipients. It stayed invisible because per-notification delivery failures were recorded only in the database — never surfaced as logs, metrics, or alerts.

This is the **backend** half of the fix: make delivery failures observable so a repeat outage is caught in minutes, not weeks.

## Changes

- **WARNING log on every failed delivery** (`notification_uc.go`): logs the failure with a bounded `failure_reason` category (`no_subscription` / `gone` / `send_error` / `list_failed` / `marshal_failed` / `cancelled`) plus the raw `failure_detail`, and the `notification_id` / `user_id` / `notification_type`.
- **Delivery-outcome metric** (`notification.delivery.count`): a counter labelled by `outcome` and the bounded `failure_reason`, emitted for every outcome (delivered and failed) so a failure-vs-total ratio is derivable. Kept low-cardinality (raw detail carries the unbounded text separately).
- **Zero-recipient fan-out logs** (`push_notification_uc.go` `NotifyNewConcerts`): the three empty-outcome early-returns (no followers / no eligible recipients after hype filtering / no deliverable concerts) now log the reason + artist id instead of returning silently.

The bounded `failure_reason` label is the field the cloud-provisioning log-based metric + alert policy extract on. No schema/proto change; the success path stays quiet.

## Testing

- New unit tests: a failed delivery emits the WARNING log **and** the metric; each zero-recipient path logs its reason; the success path stays quiet.
- `make check` passes (lint + full unit + DB integration suite).

## Related

Refs: liverty-music/specification#789
