### PR TITLE
fix(organizer): grant app-schema access to admin-console-api IAM DB user

### DIFF
--- a/k8s/atlas/base/kustomization.yaml
+++ b/k8s/atlas/base/kustomization.yaml
@@ -78,3 +78,4 @@ configMapGenerator:
   - migrations/20260626120000_add_notifications_table.sql
   - migrations/20260806120000_drop_blockchain_ticket_system.sql
   - migrations/20260814010000_create_organizer_tables.sql
+  - migrations/20260816000000_grant_admin_console_api_app_schema.sql

--- a/k8s/atlas/base/migrations/20260816000000_grant_admin_console_api_app_schema.sql
+++ b/k8s/atlas/base/migrations/20260816000000_grant_admin_console_api_app_schema.sql
@@ -1,0 +1,34 @@
+-- Grant app-schema privileges to Cloud SQL IAM service-account users added after
+-- the original bootstrap (20250726000000_bootstrap_app_schema.sql).
+--
+-- The isolated `admin-console-api` workload authenticates to Cloud SQL as its own
+-- IAM DB user (`admin-console-api@<project>.iam`, created by Pulumi in
+-- postgres.ts) rather than reusing `backend-app`. It runs the same backend binary
+-- and needs the same app-schema access to serve the admin Organizer RPCs and run
+-- the provisioning reconciler.
+--
+-- The bootstrap migration only set ALTER DEFAULT PRIVILEGES for the IAM roles that
+-- existed at that time, so a newly-added IAM user receives no privileges on the
+-- already-created tables (organizers, organizer_artists, ...) and nothing on
+-- future ones. This re-runs the grant over every current IAM role, covering BOTH
+-- existing objects (GRANT ... ON ALL ... IN SCHEMA app) and future ones
+-- (ALTER DEFAULT PRIVILEGES). It is idempotent for backend-app.
+--
+-- Runs as the postgres (cloudsqlsuperuser) user via the Atlas Operator. The
+-- admin-console-api Cloud SQL IAM user must already exist (Pulumi `pulumi up`
+-- creates it before this migration applies); the loop simply skips any IAM role
+-- that is not yet present.
+DO $$
+DECLARE
+  iam_role TEXT;
+BEGIN
+  -- Cloud SQL registers IAM service-account users as `<name>@<project>.iam`.
+  FOR iam_role IN SELECT rolname FROM pg_roles WHERE rolname LIKE '%@%.iam' LOOP
+    EXECUTE format('GRANT USAGE ON SCHEMA app TO %I', iam_role);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app TO %I', iam_role);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA app TO %I', iam_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', iam_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT USAGE, SELECT ON SEQUENCES TO %I', iam_role);
+  END LOOP;
+END
+$$;

--- a/k8s/atlas/base/migrations/atlas.sum
+++ b/k8s/atlas/base/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zduU72dCB6l3IoDk3etUr7D3V4TUwNd7F7UV7C8gP2k=
+h1:pOmmoc/OrQVIljcCxgTs9vNVU3Yjbt/ilQwbtmVoDFw=
 20250726000000_bootstrap_app_schema.sql h1:nKAFSMmbY+9pdhajenyx25jK6t5SAHc5x/JpNt9EgFM=
 20250726081442_initial_schema.sql h1:cWOx1AMHpgE784lJBtFmEj1oXRBkeqv56bKw1XV8ThI=
 20250726101741_add_foreign_key_to_posts.sql h1:Yq6yocwX7/UQHaMneA16MoHzImLamXDe7PvGYiGWudw=
@@ -64,3 +64,4 @@ h1:zduU72dCB6l3IoDk3etUr7D3V4TUwNd7F7UV7C8gP2k=
 20260626120000_add_notifications_table.sql h1:m/TskL3nQi5UgrWCUA/UMCqy5yZFWfm2H+SggBKi7UM=
 20260806120000_drop_blockchain_ticket_system.sql h1:7f7lEDxxiZQn/V2+zPk928uG+W+SQemC/drYcTSaUiY=
 20260814010000_create_organizer_tables.sql h1:hhBH/diKbOZA+4H2rrm/e0cK1tismOG6BXTk1699WYQ=
+20260816000000_grant_admin_console_api_app_schema.sql h1:f3YziWG8dBlnfO74CtQHZT8D3ObjLviy6uqm33sB1Jg=


### PR DESCRIPTION
## Problem

The isolated `admin-console-api` workload authenticates to Cloud SQL as its **own** IAM DB user (`admin-console-api@<project>.iam`, created in cloud-provisioning liverty-music/cloud-provisioning#405) instead of reusing `backend-app`. The bootstrap migration (`20250726000000`) set app-schema privileges via `ALTER DEFAULT PRIVILEGES` only for the IAM roles present at that time, so the new user has **no** access to the existing `organizers` / `organizer_artists` tables (or future ones) — the admin Organizer RPCs and the provisioning reconciler would fail with permission-denied.

## Fix

New migration `20260816000000` re-runs the grant loop over every current `%@%.iam` role, covering **both** existing objects (`GRANT ... ON ALL ... IN SCHEMA app`) and future ones (`ALTER DEFAULT PRIVILEGES`). Idempotent for `backend-app`; safely skips any IAM role not yet present.

## Deploy ordering

Apply **after** the cloud-provisioning PR's `pulumi up` creates the `admin-console-api` Cloud SQL IAM user, so the grant loop picks it up (otherwise it's a no-op for that role and would need a re-run).

## Verification

- `make check` passes; `atlas migrate apply --env local` applies the migration cleanly (no-op locally — no `%@%.iam` roles in the test DB).
- Added to `k8s/atlas/base/kustomization.yaml` + `atlas migrate hash`.

Refs: #759