### PR TITLE
fix(organizer): serve ArtistService on the admin server for admin console search

### DIFF
--- a/internal/di/provider.go
+++ b/internal/di/provider.go
@@ -264,6 +264,19 @@ func InitializeApp(ctx context.Context) (*App, error) {
 				opts...,
 			)
 		},
+		// Mount the consumer ArtistService on the admin server so the admin
+		// console can reuse ArtistService.Search (to pick an artist to
+		// associate) via the admin host + admin token, instead of a
+		// cross-origin call to the consumer API. Per design D2, the
+		// higher-privilege admin server may additionally mount consumer
+		// handlers as needed; the server-wide RequireRoleInterceptor(admin)
+		// gates every method here.
+		func(opts ...connect.HandlerOption) (string, http.Handler) {
+			return artistconnect.NewArtistServiceHandler(
+				rpc.NewArtistHandler(artistUC, logger),
+				opts...,
+			)
+		},
 	}
 
 	// Consumer RPC handlers (protected by authn middleware)


### PR DESCRIPTION
## Problem

The admin organizer screen reuses `ArtistService.Search` to pick an artist to associate. Frontend #531 called the **public** `ArtistService.Search` on the **consumer host** (`api.liverty-music.app`) cross-origin from `admin.liverty-music.app`, which the consumer API's CORS deliberately rejects:

```
Access to fetch at 'https://api.liverty-music.app/.../ArtistService/Search' from origin
'https://admin.liverty-music.app' has been blocked by CORS policy
```

So artist search is broken in the prod admin console (blocks organizer↔artist association).

## Fix (design-D2-aligned)

Mount the consumer `ArtistService` on the **admin** Connect server (`api.admin`) as well, so the admin console reaches `Search` over its own **authenticated admin transport** instead of a cross-origin call to the consumer API. Per organizer-accounts **design D2**, the higher-privilege admin server may additionally mount consumer handlers as needed; the server-wide `RequireRoleInterceptor(admin)` gates every method. The consumer server keeps serving `ArtistService.Search` publicly for fans — unchanged.

Pairs with the frontend change (repoints the admin artist-search transport to `api.admin`). **Deploy backend first** so the admin server serves Search before the frontend calls it.

## Verification

- `make check` — golangci-lint + schema lint + tests pass.

Refs: #759