### PR TITLE
feat(ci): dual-publish fan-api image + grant fan-api app-schema (unify-workload-naming 2b)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,14 @@ jobs:
         image:
           - name: server
             target: server
+          # fan-api: audience-tier successor to `server` (unify-workload-naming).
+          # Built from the SAME `server` Docker target and dual-published as
+          # `backend/fan-api` alongside `backend/server` during the migration, so
+          # the new fan-api workload (and admin-console-api, which shares this
+          # binary) can pull it while the live `server-app` keeps pulling
+          # `backend/server`. The `server` entry is removed at delete-old.
+          - name: fan-api
+            target: server
           - name: consumer
             target: consumer
           - name: concert-discovery

--- a/k8s/atlas/base/kustomization.yaml
+++ b/k8s/atlas/base/kustomization.yaml
@@ -80,3 +80,4 @@ configMapGenerator:
   - migrations/20260814010000_create_organizer_tables.sql
   - migrations/20260816000000_grant_admin_console_api_app_schema.sql
   - migrations/20260817000000_add_suppressed_concerts.sql
+  - migrations/20260817010000_grant_fan_api_app_schema.sql

--- a/k8s/atlas/base/migrations/20260817010000_grant_fan_api_app_schema.sql
+++ b/k8s/atlas/base/migrations/20260817010000_grant_fan_api_app_schema.sql
@@ -1,0 +1,32 @@
+-- Grant app-schema privileges to the `fan-api` Cloud SQL IAM service-account user.
+--
+-- `fan-api` is the audience-tier successor to `backend-app` (unify-workload-naming).
+-- It authenticates to Cloud SQL as its own IAM DB user (`fan-api@<project>.iam`,
+-- created by Pulumi in postgres.ts) and runs the same backend binary, so it needs
+-- the same app-schema access as backend-app before `DATABASE_USER` flips to fan-api
+-- at the fan cutover.
+--
+-- The earlier grant migrations (bootstrap + 20260816000000_grant_admin_console_api…)
+-- only granted the IAM roles that existed when they ran. `fan-api@<project>.iam` was
+-- created afterwards, so it holds no privileges on the existing tables or future
+-- ones. This re-runs the same generic, idempotent grant loop over every current IAM
+-- role, covering BOTH existing objects (GRANT ... ON ALL ... IN SCHEMA app) and
+-- future ones (ALTER DEFAULT PRIVILEGES). It is a no-op for roles already granted.
+--
+-- Runs as the postgres (cloudsqlsuperuser) user via the Atlas Operator. The fan-api
+-- Cloud SQL IAM user must already exist (Pulumi `pulumi up` creates it before this
+-- migration applies); the loop simply skips any IAM role that is not yet present.
+DO $$
+DECLARE
+  iam_role TEXT;
+BEGIN
+  -- Cloud SQL registers IAM service-account users as `<name>@<project>.iam`.
+  FOR iam_role IN SELECT rolname FROM pg_roles WHERE rolname LIKE '%@%.iam' LOOP
+    EXECUTE format('GRANT USAGE ON SCHEMA app TO %I', iam_role);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app TO %I', iam_role);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA app TO %I', iam_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', iam_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT USAGE, SELECT ON SEQUENCES TO %I', iam_role);
+  END LOOP;
+END
+$$;

--- a/k8s/atlas/base/migrations/atlas.sum
+++ b/k8s/atlas/base/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4kScthZ9zi4alJNUDtqi4F7MrFwancAnBfMbRThL6Tk=
+h1:E1EiW8jfAOJIApTykUz962O9AKgc7cjdfC/NWKstJh4=
 20250726000000_bootstrap_app_schema.sql h1:nKAFSMmbY+9pdhajenyx25jK6t5SAHc5x/JpNt9EgFM=
 20250726081442_initial_schema.sql h1:cWOx1AMHpgE784lJBtFmEj1oXRBkeqv56bKw1XV8ThI=
 20250726101741_add_foreign_key_to_posts.sql h1:Yq6yocwX7/UQHaMneA16MoHzImLamXDe7PvGYiGWudw=
@@ -66,3 +66,4 @@ h1:4kScthZ9zi4alJNUDtqi4F7MrFwancAnBfMbRThL6Tk=
 20260814010000_create_organizer_tables.sql h1:hhBH/diKbOZA+4H2rrm/e0cK1tismOG6BXTk1699WYQ=
 20260816000000_grant_admin_console_api_app_schema.sql h1:f3YziWG8dBlnfO74CtQHZT8D3ObjLviy6uqm33sB1Jg=
 20260817000000_add_suppressed_concerts.sql h1:OuEMM0xkQn9CcIzjwG/3OlJ3upFXcYB4jOb7oWPgsLo=
+20260817010000_grant_fan_api_app_schema.sql h1:MmWFjBR3MOTMgI9qtz2Kicfm5WVsHO2iS3MJBp6g1ls=


### PR DESCRIPTION
## Summary

Phase 2b of `unify-workload-naming` (fan audience). Prepares the **image** and **DB access** for the `fan-api` workload **additively**, before any k8s cutover.

- **deploy.yml** — add a `fan-api` build-matrix entry built from the **same `server` Docker target**, so CI **dual-publishes** `backend/fan-api` alongside `backend/server`. The live `server-app` keeps pulling `backend/server`; the new fan-api workload (and `admin-console-api`, which shares this binary) will pull `backend/fan-api`. The `server` entry is removed at delete-old. Retag-to-prod and dev push are matrix-driven, so fan-api is covered automatically; the cloud-provisioning `bump-prod-pin` image list is intentionally **not** touched here (added in 2c when the overlay image blocks exist).
- **k8s/atlas** — new migration `20260817000000_grant_fan_api_app_schema.sql` granting app-schema privileges to the `fan-api@<project>.iam` Cloud SQL IAM user (created by cloud-provisioning #408, verified in prod). It re-runs the same generic, idempotent grant loop as the admin-console-api grant, so fan-api gets existing + future table access before `DATABASE_USER` flips at cutover. No-op for already-granted roles.

## ⚠️ Merge = prod DB mutation

Merging syncs the migration via ArgoCD → Atlas Operator applies the grant to the **prod** DB (dev is stopped). It is additive (GRANT only) and fan-api is not yet serving traffic, so it is safe, but it is a prod-touching step.

## Test plan

- `make check` passes locally (lint + lint-schema + modernize + tests); `atlas migrate apply --env local` applies the new migration cleanly (the IAM-role loop is a no-op locally — no `%@%.iam` roles).

Refs: #799