### PR TITLE
fix(organizer): delete initial-state operators on deactivation

### DIFF
--- a/internal/infrastructure/zitadel/organizer_provisioner.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner.go
@@ -147,9 +147,14 @@ func (p *OrganizerProvisioner) ProvisionTenant(ctx context.Context, organizerID,
 	return zitadelOrgID, nil
 }
 
-// DeactivateOperators lists every human user in the tenant org and deactivates
-// each one. It is idempotent: deactivating an already-inactive user is treated
-// as success.
+// DeactivateOperators lists every human user in the tenant org and turns each
+// one off so it can no longer act. It is idempotent: an already-inactive user
+// is treated as success. Operators still in Zitadel's `initial` state (created
+// but never completed first sign-in — e.g. the passkey init link was never
+// used) are DELETED rather than deactivated, because Zitadel rejects
+// deactivating an initial user ("User with state initial can only be deleted
+// not deactivated") — and such a user has no credentials/session to disable
+// anyway, so removing it fully satisfies the off-switch intent.
 func (p *OrganizerProvisioner) DeactivateOperators(ctx context.Context, zitadelOrgID string) error {
 	orgCtx := middleware.SetOrgID(ctx, zitadelOrgID)
 
@@ -170,6 +175,24 @@ func (p *OrganizerProvisioner) DeactivateOperators(ctx context.Context, zitadelO
 	}
 
 	for _, u := range resp.GetResult() {
+		if u.GetState() == userpb.UserState_USER_STATE_INITIAL {
+			// Initial user: never onboarded (no password/passkey), and Zitadel
+			// forbids deactivating it — delete instead.
+			//nolint:staticcheck // SA1019: Zitadel Management API v1 is legacy but fully supported; v2 migration deferred until a live Zitadel instance is available to verify the provisioning saga.
+			if _, err := p.mgmt.RemoveUser(orgCtx, &mgmtpb.RemoveUserRequest{Id: u.GetId()}); err != nil {
+				if isNotFound(err) {
+					// Already gone — idempotent, skip.
+					continue
+				}
+				return apperr.Wrap(err, codes.Internal, fmt.Sprintf("remove initial operator %s", u.GetId()))
+			}
+			p.logger.Info(ctx, "initial operator removed",
+				slog.String("zitadel_org_id", zitadelOrgID),
+				slog.String("user_id", u.GetId()),
+			)
+			continue
+		}
+
 		//nolint:staticcheck // SA1019: Zitadel Management API v1 is legacy but fully supported; v2 migration deferred until a live Zitadel is available to verify the provisioning saga (esp. the passkey registration email link).
 		_, err := p.mgmt.DeactivateUser(orgCtx, &mgmtpb.DeactivateUserRequest{
 			Id: u.GetId(),
@@ -391,4 +414,11 @@ func isAlreadyExists(err error) bool {
 func isAlreadyInState(err error) bool {
 	st, ok := status.FromError(err)
 	return ok && st.Code() == grpccodes.FailedPrecondition
+}
+
+// isNotFound reports whether the gRPC error represents a NotFound status —
+// treated as idempotent success when removing a user that is already gone.
+func isNotFound(err error) bool {
+	st, ok := status.FromError(err)
+	return ok && st.Code() == grpccodes.NotFound
 }

--- a/internal/infrastructure/zitadel/organizer_provisioner_test.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner_test.go
@@ -57,6 +57,11 @@ type stubMgmt struct {
 	deactivateUserCallIDs []string
 	// deactivateUserErrs maps user id → error; nil entry means success.
 	deactivateUserErrs map[string]error
+
+	// removeUserCallIDs records the user ids passed to RemoveUser.
+	removeUserCallIDs []string
+	// removeUserErrs maps user id → error; nil entry means success.
+	removeUserErrs map[string]error
 }
 
 func (s *stubMgmt) AddOrg(_ context.Context, in *mgmtpb.AddOrgRequest, _ ...grpc.CallOption) (*mgmtpb.AddOrgResponse, error) {
@@ -101,6 +106,16 @@ func (s *stubMgmt) DeactivateUser(_ context.Context, in *mgmtpb.DeactivateUserRe
 		}
 	}
 	return &mgmtpb.DeactivateUserResponse{}, nil
+}
+
+func (s *stubMgmt) RemoveUser(_ context.Context, in *mgmtpb.RemoveUserRequest, _ ...grpc.CallOption) (*mgmtpb.RemoveUserResponse, error) {
+	s.removeUserCallIDs = append(s.removeUserCallIDs, in.GetId())
+	if s.removeUserErrs != nil {
+		if err, ok := s.removeUserErrs[in.GetId()]; ok {
+			return nil, err
+		}
+	}
+	return &mgmtpb.RemoveUserResponse{}, nil
 }
 
 // newTestProvisioner builds an OrganizerProvisioner wired to the given stub
@@ -256,12 +271,43 @@ func TestOrganizerProvisioner_DeactivateOperators(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name          string
-		zitadelOrgID  string
-		stub          *stubMgmt
-		wantErr       bool
-		wantCallCount int
+		name            string
+		zitadelOrgID    string
+		stub            *stubMgmt
+		wantErr         bool
+		wantCallCount   int
+		wantRemoveCount int
 	}{
+		{
+			name:         "initial-state operator is removed, active operator is deactivated",
+			zitadelOrgID: "zitadel-org-mixed",
+			stub: &stubMgmt{
+				listUsersResp: &mgmtpb.ListUsersResponse{
+					Result: []*userpb.User{
+						{Id: "user-initial", State: userpb.UserState_USER_STATE_INITIAL},
+						{Id: "user-active", State: userpb.UserState_USER_STATE_ACTIVE},
+					},
+				},
+			},
+			wantCallCount:   1, // only the active user hits DeactivateUser
+			wantRemoveCount: 1, // the initial user is deleted instead
+		},
+		{
+			name:         "RemoveUser NotFound on an initial operator is idempotent",
+			zitadelOrgID: "zitadel-org-1",
+			stub: &stubMgmt{
+				listUsersResp: &mgmtpb.ListUsersResponse{
+					Result: []*userpb.User{
+						{Id: "user-gone", State: userpb.UserState_USER_STATE_INITIAL},
+					},
+				},
+				removeUserErrs: map[string]error{
+					"user-gone": grpcstatus.Error(grpccodes.NotFound, "user not found"),
+				},
+			},
+			wantErr:         false,
+			wantRemoveCount: 1,
+		},
 		{
 			name:         "deactivate all users returned by ListUsers",
 			zitadelOrgID: "zitadel-org-1",
@@ -339,6 +385,7 @@ func TestOrganizerProvisioner_DeactivateOperators(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Len(t, tt.stub.deactivateUserCallIDs, tt.wantCallCount)
+			assert.Len(t, tt.stub.removeUserCallIDs, tt.wantRemoveCount)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the Organizer **Deactivate** off-switch failing when an operator never completed first sign-in — surfaced during `organizer-accounts` 6.3 prod verification.

## Problem

Clicking Deactivate on a freshly-provisioned Organizer returned an error:

```
deactivate operator <id>: rpc error: code = NotFound desc =
User with state initial can only be deleted not deactivated (COMMAND-ke0fw)
```

`DeactivateOperators` calls `DeactivateUser` on every operator, but Zitadel **rejects deactivating a user in the `initial` state** (created but never onboarded — e.g. the passkey init link was never used). So the whole `Deactivate` RPC failed. This is the common case for a new Organizer whose operator hasn't signed in yet.

## Fix

In `DeactivateOperators`, branch on the operator's Zitadel state:
- `USER_STATE_INITIAL` → **`RemoveUser`** (delete). An initial user has no credentials/session to disable, so removing it fully satisfies the off-switch intent (D6). `RemoveUser` `NotFound` is treated idempotently.
- otherwise → `DeactivateUser` as before (already-inactive `FailedPrecondition` still swallowed).

## Testing

- `make check` — golangci-lint + schema lint + all tests pass.
- New unit tests: mixed initial+active operators (initial removed, active deactivated) and idempotent `RemoveUser` NotFound.

Refs: #759
