### PR TITLE
ci: rename backend API image to audience-neutral `api` (unify-workload-naming)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,15 +83,14 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - name: server
-            target: server
-          # fan-api: audience-tier successor to `server` (unify-workload-naming).
-          # Built from the SAME `server` Docker target and dual-published as
-          # `backend/fan-api` alongside `backend/server` during the migration, so
-          # the new fan-api workload (and admin-console-api, which shares this
-          # binary) can pull it while the live `server-app` keeps pulling
-          # `backend/server`. The `server` entry is removed at delete-old.
-          - name: fan-api
+          # api: the shared Connect-RPC API-server image (unify-workload-naming).
+          # Built from the `server` Docker target. Named audience-NEUTRAL (`api`,
+          # tier only) because the SAME binary backs multiple workloads —
+          # `fan-api` and `admin-console-api` — differentiated by runtime config,
+          # not code. Both pull this one image (no version drift), mirroring how
+          # `consumer` backs the `event-consumer` workload. Successor to the
+          # retired `server`/`fan-api` image names.
+          - name: api
             target: server
           - name: consumer
             target: consumer


### PR DESCRIPTION
## Summary
Collapse the dual-published `server` + `fan-api` build-matrix entries into a single **`api`** image (built from the `server` Docker target).

The image is named **audience-neutral** (`api`, tier only) because ONE binary backs multiple workloads — `fan-api` and `admin-console-api` — differentiated by runtime config, not code. Both pull this one image, eliminating the version drift that two separately-built images of the same source allow (their digests already diverge). Mirrors how `consumer` backs `event-consumer`: **image == binary/tier, workload == deployment identity**.

## Effect
Matrix-driven `image.name` publishes `backend/api` (dev push + prod retag) and stops building `backend/server` / `backend/fan-api`.

## Safety
Prod is unaffected by this merge — it pins existing immutable tags (`backend/fan-api:v1.35.0`, `backend/server:v1.35.0`) which remain in prod AR. Dev is intentionally stopped.

## Coordination (follow-up, in order)
1. **This PR** → dev builds `backend/api`.
2. cloud-provisioning prep: `bump-prod-pin` backend list `server`→`api` + inert `backend/api` prod-overlay pin (so the release's pin-bump resolves).
3. **Backend release** → publishes `backend/api` to prod AR.
4. cloud-provisioning repoint: `fan-api` + `admin-console-api` base → `backend/api`; remove old pins; dev image-updater `backend/server`→`backend/api`. ArgoCD repoints both (zero-downtime, `maxUnavailable=0`).

Refs: #799