### PR TITLE
ci: pin golangci-lint to v2.12.2 (v2.13.0 hangs, reddens all PRs)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,12 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          # Pinned (was `latest`): golangci-lint v2.13.0 (released 2026-08-19)
+          # hangs on `golangci-lint run` for this module — it blows past its own
+          # 3m `run.timeout` and wedges until the 10m job timeout, reddening every
+          # backend PR. v2.12.2 is the last release that lints in ~1m37s. Bump
+          # deliberately once upstream fixes the regression.
+          version: v2.12.2
           install-only: true
       - name: Run make lint
         run: make lint


### PR DESCRIPTION
## Problem
golangci-lint **v2.13.0** (released 2026-08-19) **hangs** on `golangci-lint run` for this module — it ignores its own 3m `run.timeout` and wedges until the **10-minute job timeout**. Because `lint.yml` used `version: latest`, every backend PR's **Lint** check now fails (observed **3 consecutive 10m03s timeouts** on #396, which only touches a workflow YAML).

## Fix
Pin `golangci-lint-action` to **v2.12.2** — the last release that lints this repo in ~1m37s. This PR's own Lint run uses the pinned version, so it should go green (self-validating). Bump deliberately once upstream fixes the v2.13.0 regression.

## Impact
Unblocks all backend PRs (repo-wide CI fix). No Go/code change.

Refs: #799