### PR TITLE
fix(zitadel): provision operators via User v2 API for passkey-only onboarding

### DIFF
--- a/internal/infrastructure/zitadel/organizer_provisioner.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner.go
@@ -11,8 +11,10 @@ import (
 	"github.com/zitadel/zitadel-go/v3/pkg/client/middleware"
 	zitadelconn "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel"
 	mgmtpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+	objectv2pb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/object/v2"
 	policypb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/policy"
 	userpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user"
+	userv2pb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user/v2"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
@@ -39,6 +41,7 @@ var _ usecase.OrganizerProvisioner = (*OrganizerProvisioner)(nil)
 // creating duplicates and never leaves the operator without an owner grant.
 type OrganizerProvisioner struct {
 	mgmt                      mgmtpb.ManagementServiceClient
+	userV2                    userv2pb.UserServiceClient
 	organizerConsoleProjectID string
 	logger                    *logging.Logger
 }
@@ -83,6 +86,7 @@ func NewOrganizerProvisioner(
 
 	return &OrganizerProvisioner{
 		mgmt:                      mgmtpb.NewManagementServiceClient(conn.ClientConn),
+		userV2:                    userv2pb.NewUserServiceClient(conn.ClientConn),
 		organizerConsoleProjectID: organizerConsoleProjectID,
 		logger:                    logger,
 	}, nil
@@ -129,7 +133,7 @@ func (p *OrganizerProvisioner) ProvisionTenant(ctx context.Context, organizerID,
 	}
 
 	// Step 4: create the initial operator human user in the tenant org.
-	operatorID, err := p.ensureOperatorUser(orgCtx, operatorEmail)
+	operatorID, err := p.ensureOperatorUser(orgCtx, zitadelOrgID, operatorEmail)
 	if err != nil {
 		return "", apperr.Wrap(err, codes.Internal, "ensure operator user")
 	}
@@ -278,19 +282,27 @@ func (p *OrganizerProvisioner) ensureProjectGrant(ctx context.Context, tenantOrg
 // report success, or the Organizer would go active with an operator who can
 // never sign in. On failure the caller leaves the row `provisioning` and the
 // reconciler retries; Zitadel accepts re-sending the passkey init link.
-func (p *OrganizerProvisioner) ensureOperatorUser(orgCtx context.Context, operatorEmail string) (string, error) {
-	userID, err := p.ensureHumanUser(orgCtx, operatorEmail)
+func (p *OrganizerProvisioner) ensureOperatorUser(orgCtx context.Context, zitadelOrgID, operatorEmail string) (string, error) {
+	userID, err := p.ensureHumanUser(orgCtx, zitadelOrgID, operatorEmail)
 	if err != nil {
 		return "", err
 	}
 
-	//nolint:staticcheck // SA1019: Zitadel Management API v1 is legacy but fully supported; v2 migration deferred until a live Zitadel is available to verify the provisioning saga (esp. the passkey registration email link).
-	if _, err := p.mgmt.SendPasswordlessRegistration(orgCtx, &mgmtpb.SendPasswordlessRegistrationRequest{
+	// Email the passkey-registration link via the User v2 API. The v2 create
+	// flow above sends NO password-init email (v2 AddHumanUser hardcodes
+	// allowInitMail=false), so this passkey link is the operator's only
+	// onboarding mail — matching the org's passwordless login policy. Scoped by
+	// user_id only (the org is derived from the user's write model). An empty
+	// SendLink uses Zitadel's default passwordless-registration URL.
+	if _, err := p.userV2.CreatePasskeyRegistrationLink(orgCtx, &userv2pb.CreatePasskeyRegistrationLinkRequest{
 		UserId: userID,
+		Medium: &userv2pb.CreatePasskeyRegistrationLinkRequest_SendLink{
+			SendLink: &userv2pb.SendPasskeyRegistrationLink{},
+		},
 	}); err != nil {
-		return "", fmt.Errorf("send passkey registration email: %w", err)
+		return "", fmt.Errorf("send passkey registration link: %w", err)
 	}
-	p.logger.Info(orgCtx, "operator passkey init link sent",
+	p.logger.Info(orgCtx, "operator passkey registration link sent",
 		slog.String("user_id", userID),
 		slog.String("email", operatorEmail),
 	)
@@ -299,19 +311,31 @@ func (p *OrganizerProvisioner) ensureOperatorUser(orgCtx context.Context, operat
 
 // ensureHumanUser creates the operator human user, or returns the id of the
 // existing user when one with operatorEmail is already present (idempotent).
-func (p *OrganizerProvisioner) ensureHumanUser(orgCtx context.Context, operatorEmail string) (string, error) {
-	//nolint:staticcheck // SA1019: Zitadel Management API v1 is legacy but fully supported; v2 migration deferred until a live Zitadel is available to verify the provisioning saga (esp. the passkey registration email link).
-	addResp, err := p.mgmt.AddHumanUser(orgCtx, &mgmtpb.AddHumanUserRequest{
-		UserName: operatorEmail,
-		Profile: &mgmtpb.AddHumanUserRequest_Profile{
-			FirstName:   "Operator",
-			LastName:    "Operator",
-			DisplayName: operatorEmail,
+func (p *OrganizerProvisioner) ensureHumanUser(orgCtx context.Context, zitadelOrgID, operatorEmail string) (string, error) {
+	// User v2 AddHumanUser with a verified email and NO password creates a
+	// passwordless operator and sends NO email: the v2 handler hardcodes
+	// allowInitMail=false, so — unlike v1 — no password-initialization mail is
+	// sent (which would contradict the org's passwordless login policy). The
+	// email MUST be verified here so the subsequent passkey-registration mail
+	// has a valid recipient; it targets verified_email, and an empty recipient
+	// is rejected by the SMTP provider (501). Org is scoped via the request
+	// organization field rather than the v1 context header.
+	//
+	//nolint:staticcheck // SA1019: v2 AddHumanUser is deprecated in favor of CreateUser, but on Zitadel v4.14.0 AddHumanUser is fully supported AND source-verified to hardcode allowInitMail=false (no password-init email) — the exact behavior this fix relies on. CreateUser's init-mail suppression is NOT verified for v4.14.0, so switching to it risks reintroducing the password-init email. Revisit when prod Zitadel is upgraded and CreateUser's behavior is confirmed.
+	addResp, err := p.userV2.AddHumanUser(orgCtx, &userv2pb.AddHumanUserRequest{
+		Organization: &objectv2pb.Organization{
+			Org: &objectv2pb.Organization_OrgId{OrgId: zitadelOrgID},
 		},
-		Email: &mgmtpb.AddHumanUserRequest_Email{
-			Email:           operatorEmail,
-			IsEmailVerified: false,
+		Profile: &userv2pb.SetHumanProfile{
+			GivenName:   "Operator",
+			FamilyName:  "Operator",
+			DisplayName: &operatorEmail,
 		},
+		Email: &userv2pb.SetHumanEmail{
+			Email:        operatorEmail,
+			Verification: &userv2pb.SetHumanEmail_IsVerified{IsVerified: true},
+		},
+		// No PasswordType → passwordless operator (passkey-only onboarding).
 	})
 	if err == nil {
 		return addResp.GetUserId(), nil

--- a/internal/infrastructure/zitadel/organizer_provisioner_test.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner_test.go
@@ -7,6 +7,7 @@ import (
 	mgmtpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	orgpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/org"
 	userpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user"
+	userv2pb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user/v2"
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -37,13 +38,6 @@ type stubMgmt struct {
 	// addProjectGrantReqs records all AddProjectGrant calls for inspection.
 	addProjectGrantReqs []*mgmtpb.AddProjectGrantRequest
 	addProjectGrantErr  error
-
-	// addHumanUserResp/addHumanUserErr controls AddHumanUser.
-	addHumanUserResp *mgmtpb.AddHumanUserResponse
-	addHumanUserErr  error
-
-	// sendPasswordlessRegistrationErr controls SendPasswordlessRegistration.
-	sendPasswordlessRegistrationErr error
 
 	// addUserGrantReqs records all AddUserGrant calls for inspection.
 	addUserGrantReqs []*mgmtpb.AddUserGrantRequest
@@ -81,14 +75,6 @@ func (s *stubMgmt) AddProjectGrant(_ context.Context, in *mgmtpb.AddProjectGrant
 	return &mgmtpb.AddProjectGrantResponse{}, s.addProjectGrantErr
 }
 
-func (s *stubMgmt) AddHumanUser(_ context.Context, _ *mgmtpb.AddHumanUserRequest, _ ...grpc.CallOption) (*mgmtpb.AddHumanUserResponse, error) {
-	return s.addHumanUserResp, s.addHumanUserErr
-}
-
-func (s *stubMgmt) SendPasswordlessRegistration(_ context.Context, _ *mgmtpb.SendPasswordlessRegistrationRequest, _ ...grpc.CallOption) (*mgmtpb.SendPasswordlessRegistrationResponse, error) {
-	return &mgmtpb.SendPasswordlessRegistrationResponse{}, s.sendPasswordlessRegistrationErr
-}
-
 func (s *stubMgmt) AddUserGrant(_ context.Context, in *mgmtpb.AddUserGrantRequest, _ ...grpc.CallOption) (*mgmtpb.AddUserGrantResponse, error) {
 	s.addUserGrantReqs = append(s.addUserGrantReqs, in)
 	return &mgmtpb.AddUserGrantResponse{}, s.addUserGrantErr
@@ -118,14 +104,40 @@ func (s *stubMgmt) RemoveUser(_ context.Context, in *mgmtpb.RemoveUserRequest, _
 	return &mgmtpb.RemoveUserResponse{}, nil
 }
 
-// newTestProvisioner builds an OrganizerProvisioner wired to the given stub
+// stubUserV2 is a test double for the User v2 UserServiceClient. It embeds the
+// interface so only the methods OrganizerProvisioner uses need overriding;
+// un-overridden methods panic if called, surfacing unexpected dependencies.
+type stubUserV2 struct {
+	userv2pb.UserServiceClient
+
+	// addHumanUserResp/addHumanUserErr controls AddHumanUser (v2).
+	addHumanUserResp *userv2pb.AddHumanUserResponse
+	addHumanUserErr  error
+
+	// createPasskeyLinkErr controls CreatePasskeyRegistrationLink.
+	createPasskeyLinkErr error
+}
+
+func (s *stubUserV2) AddHumanUser(_ context.Context, _ *userv2pb.AddHumanUserRequest, _ ...grpc.CallOption) (*userv2pb.AddHumanUserResponse, error) {
+	return s.addHumanUserResp, s.addHumanUserErr
+}
+
+func (s *stubUserV2) CreatePasskeyRegistrationLink(_ context.Context, _ *userv2pb.CreatePasskeyRegistrationLinkRequest, _ ...grpc.CallOption) (*userv2pb.CreatePasskeyRegistrationLinkResponse, error) {
+	return &userv2pb.CreatePasskeyRegistrationLinkResponse{}, s.createPasskeyLinkErr
+}
+
+// newTestProvisioner builds an OrganizerProvisioner wired to the given stubs
 // instead of a live Zitadel connection.
-func newTestProvisioner(t *testing.T, stub *stubMgmt) *OrganizerProvisioner {
+func newTestProvisioner(t *testing.T, stub *stubMgmt, userV2 *stubUserV2) *OrganizerProvisioner {
 	t.Helper()
 	logger, err := logging.New()
 	require.NoError(t, err)
+	if userV2 == nil {
+		userV2 = &stubUserV2{}
+	}
 	return &OrganizerProvisioner{
 		mgmt:                      stub,
+		userV2:                    userV2,
 		organizerConsoleProjectID: "proj-1",
 		logger:                    logger,
 	}
@@ -146,6 +158,7 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 		name      string
 		args      args
 		stub      *stubMgmt
+		userV2    *stubUserV2
 		wantOrgID string
 		wantErr   bool
 		check     func(t *testing.T, stub *stubMgmt)
@@ -158,8 +171,10 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 				operatorEmail: "op@acme.com",
 			},
 			stub: &stubMgmt{
-				addOrgResp:       &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"},
-				addHumanUserResp: &mgmtpb.AddHumanUserResponse{UserId: "operator-user-1"},
+				addOrgResp: &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"},
+			},
+			userV2: &stubUserV2{
+				addHumanUserResp: &userv2pb.AddHumanUserResponse{UserId: "operator-user-1"},
 			},
 			wantOrgID: "zitadel-org-xyz",
 			check: func(t *testing.T, stub *stubMgmt) {
@@ -195,26 +210,30 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 				// Simulate all create-steps returning AlreadyExists on a retry.
 				addCustomLoginPolicyErr: grpcstatus.Error(grpccodes.AlreadyExists, "policy exists"),
 				addProjectGrantErr:      grpcstatus.Error(grpccodes.AlreadyExists, "grant exists"),
-				// AddHumanUser AlreadyExists triggers lookup by email via ListUsers.
-				addHumanUserErr: grpcstatus.Error(grpccodes.AlreadyExists, "user exists"),
+				// AddHumanUser AlreadyExists (v2) triggers lookup by email via ListUsers (v1).
 				listUsersResp: &mgmtpb.ListUsersResponse{
 					Result: []*userpb.User{{Id: "existing-operator-id"}},
 				},
 				addUserGrantErr: grpcstatus.Error(grpccodes.AlreadyExists, "grant exists"),
 			},
+			userV2: &stubUserV2{
+				addHumanUserErr: grpcstatus.Error(grpccodes.AlreadyExists, "user exists"),
+			},
 			wantOrgID: "zitadel-org-existing",
 		},
 		{
-			name: "FATAL: SendPasswordlessRegistration failure returns error",
+			name: "FATAL: CreatePasskeyRegistrationLink failure returns error",
 			args: args{
 				organizerID:   "org-abc12345",
 				name:          "Fail Label",
 				operatorEmail: "op@fail.com",
 			},
 			stub: &stubMgmt{
-				addOrgResp:                      &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"},
-				addHumanUserResp:                &mgmtpb.AddHumanUserResponse{UserId: "op-1"},
-				sendPasswordlessRegistrationErr: grpcstatus.Error(grpccodes.Internal, "email delivery failed"),
+				addOrgResp: &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"},
+			},
+			userV2: &stubUserV2{
+				addHumanUserResp:     &userv2pb.AddHumanUserResponse{UserId: "op-1"},
+				createPasskeyLinkErr: grpcstatus.Error(grpccodes.Internal, "email delivery failed"),
 			},
 			wantErr: true,
 		},
@@ -238,7 +257,9 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 				operatorEmail: "op@fail.com",
 			},
 			stub: &stubMgmt{
-				addOrgResp:      &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"},
+				addOrgResp: &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"},
+			},
+			userV2: &stubUserV2{
 				addHumanUserErr: grpcstatus.Error(grpccodes.Internal, "create user failed"),
 			},
 			wantErr: true,
@@ -248,7 +269,7 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			p := newTestProvisioner(t, tt.stub)
+			p := newTestProvisioner(t, tt.stub, tt.userV2)
 
 			got, err := p.ProvisionTenant(ctx, tt.args.organizerID, tt.args.name, tt.args.operatorEmail)
 
@@ -375,7 +396,7 @@ func TestOrganizerProvisioner_DeactivateOperators(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			p := newTestProvisioner(t, tt.stub)
+			p := newTestProvisioner(t, tt.stub, nil)
 
 			err := p.DeactivateOperators(ctx, tt.zitadelOrgID)
 


### PR DESCRIPTION
## Why

Verifying organizer-accounts **6.3** in prod surfaced two onboarding defects (both distinct from the notification-deadlock fix in cloud-provisioning#437):

1. The v1 `AddHumanUser` creates a no-password operator, which makes Zitadel email a **password-initialization link** ("Activate User → set password") — contradicting the org's passwordless login policy (`allow_username_password=false`, `passwordless_type=allowed`). The operator would set a password they can never use.
2. The v1 `SendPasswordlessRegistration` (passkey) email **failed** with `501 bad recipient` because it targets `verified_email`, which was empty (operator created with `IsEmailVerified:false`).

## What

Migrate operator creation to the **User v2 API** (best-practice per Zitadel; the v1 human APIs are deprecated):

- **`AddHumanUser` (v2)** with a verified email and **no password** → passwordless operator. The v2 handler hardcodes `allowInitMail=false` (source-verified at v4.14.0, `internal/api/grpc/user/v2/user.go:25`), so **no password-init email** is sent (unlike v1). The verified email gives the passkey mail a valid recipient (fixes the 501).
- **`CreatePasskeyRegistrationLink` (v2, `send_link`)** emails the passkey-registration link, deep-linking to the passwordless-registration page. Replaces v1 `SendPasswordlessRegistration`.
- Org scoping: v2 request `organization` field (create) / `user_id` only (passkey link), replacing the v1 `x-zitadel-orgID` context header.

Grant + deactivation stay on the v1 Management API (no v2 equivalent for user grants; deactivation works as-is).

### Note on `AddHumanUser` vs `CreateUser`
`AddHumanUser` is deprecated in zitadel-go in favor of `CreateUser`, but it is **fully supported on our prod v4.14.0** and **source-verified to suppress the password-init email** (`allowInitMail=false`). `CreateUser`'s init-mail suppression is unverified for v4.14.0, so switching risks reintroducing the password email — kept `AddHumanUser` with a documented `//nolint:staticcheck` (matching the existing v1 nolint pattern), to revisit on a Zitadel upgrade.

## Verification

- `make check` green (lint 0 issues; all tests pass, including the updated provisioner unit tests: v2 stub, happy-path, idempotent AlreadyExists→ListUsers, passkey-link failure).
- Post-release prod check: create an organizer → operator receives **only** the passkey-registration email (no password-init mail) → registers a passkey → signs into their org (org-pinned).

Refs: #759