### PR TITLE
feat(organizer): send operator onboarding via Zitadel invite, not passkey link

### DIFF
--- a/internal/infrastructure/zitadel/organizer_provisioner.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner.go
@@ -309,11 +309,18 @@ func (p *OrganizerProvisioner) ensureProjectGrant(ctx context.Context, tenantOrg
 // org and has a pending Zitadel invite (the onboarding email). It returns the
 // user id.
 //
-// The invite is (re)created on every call — fresh or existing — and its failure
-// is FATAL: a provisioning that cannot deliver the operator's onboarding email
-// must not report success, or the Organizer would go active with an operator who
-// can never sign in. On failure the caller leaves the row `provisioning` and the
-// reconciler retries; Zitadel accepts re-creating the invite.
+// The invite is (re)created on every call. Its failure is FATAL — a provisioning
+// that cannot deliver the operator's onboarding email must not report success,
+// or the Organizer would go active with an operator who can never sign in — with
+// ONE exception: if the operator has already completed onboarding, Zitadel
+// rejects re-inviting them (they are past the invitable state) and that is
+// benign. The invite is only the email transport; Login v2 auto-onboards a
+// no-auth verified-email operator without a pre-created invite (design D5), so an
+// already-onboarded operator can already sign in and the re-invite is moot. We
+// therefore treat that specific rejection as success so the idempotent saga can
+// proceed to the owner grant instead of the reconciler re-failing forever. On any
+// other failure the caller leaves the row `provisioning` and the reconciler
+// retries.
 func (p *OrganizerProvisioner) ensureOperatorUser(orgCtx context.Context, zitadelOrgID, operatorEmail string) (string, error) {
 	userID, err := p.ensureHumanUser(orgCtx, zitadelOrgID, operatorEmail)
 	if err != nil {
@@ -343,6 +350,22 @@ func (p *OrganizerProvisioner) ensureOperatorUser(orgCtx context.Context, zitade
 			},
 		},
 	}); err != nil {
+		// Idempotency: an operator who already completed onboarding is past the
+		// invitable state, and Zitadel rejects re-inviting them
+		// (FailedPrecondition / AlreadyExists). That is benign for this
+		// compensating saga — the operator can already sign in, and the invite is
+		// only the email transport — so treat it as success and let provisioning
+		// proceed to the owner grant, rather than wedging the row in
+		// `provisioning` on every reconciler sweep. Any other code (a genuine
+		// delivery/transient failure that would leave a not-yet-onboarded operator
+		// unable to sign in) stays FATAL.
+		if isAlreadyInState(err) || isAlreadyExists(err) {
+			p.logger.Info(orgCtx, "operator already onboarded; skipping re-invite",
+				slog.String("user_id", userID),
+				slog.String("email", operatorEmail),
+			)
+			return userID, nil
+		}
 		return "", fmt.Errorf("send operator invite: %w", err)
 	}
 	p.logger.Info(orgCtx, "operator invite sent",

--- a/internal/infrastructure/zitadel/organizer_provisioner.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner.go
@@ -327,20 +327,33 @@ func (p *OrganizerProvisioner) ensureOperatorUser(orgCtx context.Context, zitade
 		return "", err
 	}
 
-	// Create a pending Zitadel invite and let Zitadel send the "Invitation to
-	// Zitadel Login" email via its own SMTP. The url_template points the "Accept
-	// invite" link at the organizer console (org pinned via org_id), which starts
-	// the OIDC flow; Login v2 then detects the pending invite and drives the
-	// passkey ceremony WITHIN the auth request, landing on /welcome.
+	// Create a pending Zitadel invite purely as the EMAIL TRANSPORT: Zitadel
+	// sends the "Invitation to Zitadel Login" email via its own SMTP (the backend
+	// has no SMTP of its own), and its "Accept invite" link opens the organizer
+	// console, which starts the OIDC flow. Login v2 then auto-onboards a
+	// no-auth-method operator whose email is verified — routing loginname →
+	// /verify (invite) → /authenticator/set (passkey) with the requestId threaded
+	// through, landing on /welcome (source-verified apps/login/src@v4.14.0; design
+	// D5). A pre-created invite is NOT a functional prerequisite; it is only how
+	// we get the branded email out.
 	//
 	// This replaces CreatePasskeyRegistrationLink, whose bare passkey/set link is
 	// a dead-end: single-use-on-failure (upstream #12499) and outside any OIDC
 	// context. The v2 AddHumanUser flow above sends no mail (allowInitMail=false),
-	// so this invite is the operator's only onboarding email. Scoped by user_id
-	// (the org is derived from the user's write model). url_template placeholders
-	// are limited to UserID/OrgID/Code — no email — so login_hint cannot be
-	// carried here; the operator enters their email once at Login v2.
-	inviteURL := fmt.Sprintf("%s/?org_id={{.OrgID}}", p.consoleBaseURL)
+	// so this invite is the operator's only onboarding email.
+	//
+	// url_template is a fully-formed literal (no Zitadel {{...}} placeholders):
+	// both the tenant org id and the operator email are known here, so we bake
+	// org_id (org-pinned entry) and login_hint (pre-fills AND auto-submits the
+	// loginname step, so the operator never types their email) directly, both
+	// percent-encoded. {{.Code}} is deliberately OMITTED — no credential in the
+	// link; the invite code stays IdP-side and is delivered/consumed on Zitadel.
+	inviteURL := fmt.Sprintf(
+		"%s/?org_id=%s&login_hint=%s",
+		p.consoleBaseURL,
+		url.QueryEscape(zitadelOrgID),
+		url.QueryEscape(operatorEmail),
+	)
 	if _, err := p.userV2.CreateInviteCode(orgCtx, &userv2pb.CreateInviteCodeRequest{
 		UserId: userID,
 		Verification: &userv2pb.CreateInviteCodeRequest_SendCode{

--- a/internal/infrastructure/zitadel/organizer_provisioner.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
+	"strings"
 
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/middleware"
@@ -18,6 +20,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/liverty-music/backend/internal/usecase"
 	"github.com/pannpers/go-apperr/apperr"
@@ -43,7 +46,11 @@ type OrganizerProvisioner struct {
 	mgmt                      mgmtpb.ManagementServiceClient
 	userV2                    userv2pb.UserServiceClient
 	organizerConsoleProjectID string
-	logger                    *logging.Logger
+	// consoleBaseURL is the organizer console origin (e.g.
+	// https://organizer.dev.liverty-music.app), derived from the issuer. It is
+	// the base of the operator invite link's url_template.
+	consoleBaseURL string
+	logger         *logging.Logger
 }
 
 // NewOrganizerProvisioner creates an OrganizerProvisioner that authenticates
@@ -62,6 +69,11 @@ func NewOrganizerProvisioner(
 	apiEndpoint, err := grpcEndpoint(issuerURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse zitadel domain: %w", err)
+	}
+
+	consoleBaseURL, err := consoleBaseURLFromIssuer(issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("derive organizer console base url: %w", err)
 	}
 
 	connOpts := []zitadelconn.Option{
@@ -88,8 +100,27 @@ func NewOrganizerProvisioner(
 		mgmt:                      mgmtpb.NewManagementServiceClient(conn.ClientConn),
 		userV2:                    userv2pb.NewUserServiceClient(conn.ClientConn),
 		organizerConsoleProjectID: organizerConsoleProjectID,
+		consoleBaseURL:            consoleBaseURL,
 		logger:                    logger,
 	}, nil
+}
+
+// consoleBaseURLFromIssuer derives the organizer console origin from the Zitadel
+// issuer URL by swapping the `auth.` host prefix for `organizer.`:
+// `https://auth.dev.liverty-music.app` → `https://organizer.dev.liverty-music.app`.
+// The console and the issuer share the same base domain per environment
+// (see cloud-provisioning `baseDomainMap` / the organizer-console host), so this
+// avoids threading a separate console-URL config through DI.
+func consoleBaseURLFromIssuer(issuerURL string) (string, error) {
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return "", fmt.Errorf("parse issuer url %q: %w", issuerURL, err)
+	}
+	host, ok := strings.CutPrefix(u.Host, "auth.")
+	if !ok {
+		return "", fmt.Errorf("issuer host %q does not start with 'auth.'", u.Host)
+	}
+	return fmt.Sprintf("%s://organizer.%s", u.Scheme, host), nil
 }
 
 // ProvisionTenant provisions an isolated Zitadel tenant for the Organizer. It
@@ -275,36 +306,49 @@ func (p *OrganizerProvisioner) ensureProjectGrant(ctx context.Context, tenantOrg
 }
 
 // ensureOperatorUser ensures the initial operator human user exists in the tenant
-// org and has been sent a passkey-registration init link. It returns the user id.
+// org and has a pending Zitadel invite (the onboarding email). It returns the
+// user id.
 //
-// The init link is (re)sent on every call — fresh or existing — and its failure
-// is FATAL: a provisioning that cannot deliver the operator's init link must not
-// report success, or the Organizer would go active with an operator who can
-// never sign in. On failure the caller leaves the row `provisioning` and the
-// reconciler retries; Zitadel accepts re-sending the passkey init link.
+// The invite is (re)created on every call — fresh or existing — and its failure
+// is FATAL: a provisioning that cannot deliver the operator's onboarding email
+// must not report success, or the Organizer would go active with an operator who
+// can never sign in. On failure the caller leaves the row `provisioning` and the
+// reconciler retries; Zitadel accepts re-creating the invite.
 func (p *OrganizerProvisioner) ensureOperatorUser(orgCtx context.Context, zitadelOrgID, operatorEmail string) (string, error) {
 	userID, err := p.ensureHumanUser(orgCtx, zitadelOrgID, operatorEmail)
 	if err != nil {
 		return "", err
 	}
 
-	// Email the passkey-registration link via the User v2 API. The v2 create
-	// flow above sends NO password-init email (v2 AddHumanUser hardcodes
-	// allowInitMail=false), so this passkey link is the operator's only
-	// onboarding mail — matching the org's passwordless login policy. Scoped by
-	// user_id only (the org is derived from the user's write model). An empty
-	// SendLink uses Zitadel's default passwordless-registration URL.
-	if _, err := p.userV2.CreatePasskeyRegistrationLink(orgCtx, &userv2pb.CreatePasskeyRegistrationLinkRequest{
+	// Create a pending Zitadel invite and let Zitadel send the "Invitation to
+	// Zitadel Login" email via its own SMTP. The url_template points the "Accept
+	// invite" link at the organizer console (org pinned via org_id), which starts
+	// the OIDC flow; Login v2 then detects the pending invite and drives the
+	// passkey ceremony WITHIN the auth request, landing on /welcome.
+	//
+	// This replaces CreatePasskeyRegistrationLink, whose bare passkey/set link is
+	// a dead-end: single-use-on-failure (upstream #12499) and outside any OIDC
+	// context. The v2 AddHumanUser flow above sends no mail (allowInitMail=false),
+	// so this invite is the operator's only onboarding email. Scoped by user_id
+	// (the org is derived from the user's write model). url_template placeholders
+	// are limited to UserID/OrgID/Code — no email — so login_hint cannot be
+	// carried here; the operator enters their email once at Login v2.
+	inviteURL := fmt.Sprintf("%s/?org_id={{.OrgID}}", p.consoleBaseURL)
+	if _, err := p.userV2.CreateInviteCode(orgCtx, &userv2pb.CreateInviteCodeRequest{
 		UserId: userID,
-		Medium: &userv2pb.CreatePasskeyRegistrationLinkRequest_SendLink{
-			SendLink: &userv2pb.SendPasskeyRegistrationLink{},
+		Verification: &userv2pb.CreateInviteCodeRequest_SendCode{
+			SendCode: &userv2pb.SendInviteCode{
+				UrlTemplate:     proto.String(inviteURL),
+				ApplicationName: proto.String("Liverty Organizer"),
+			},
 		},
 	}); err != nil {
-		return "", fmt.Errorf("send passkey registration link: %w", err)
+		return "", fmt.Errorf("send operator invite: %w", err)
 	}
-	p.logger.Info(orgCtx, "operator passkey registration link sent",
+	p.logger.Info(orgCtx, "operator invite sent",
 		slog.String("user_id", userID),
 		slog.String("email", operatorEmail),
+		slog.String("invite_url", inviteURL),
 	)
 	return userID, nil
 }

--- a/internal/infrastructure/zitadel/organizer_provisioner_test.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner_test.go
@@ -324,12 +324,19 @@ func TestOrganizerProvisioner_ProvisionTenant_sendsConsolePointedInvite(t *testi
 	require.NoError(t, err)
 
 	// The operator onboarding email is a Zitadel invite whose link points at the
-	// console (org pinned via org_id template), NOT a Zitadel setup page.
+	// console with org_id + login_hint baked in as percent-encoded literals (NOT
+	// a Zitadel setup page, and NOT a {{...}} template — both values are known at
+	// provisioning). No {{.Code}} → no credential in the link.
 	require.NotNil(t, userV2.createInviteReq)
 	assert.Equal(t, "operator-user-1", userV2.createInviteReq.GetUserId())
 	send := userV2.createInviteReq.GetSendCode()
 	require.NotNil(t, send, "invite must be SendCode (Zitadel-sent email), not ReturnCode")
-	assert.Equal(t, "https://organizer.test.local/?org_id={{.OrgID}}", send.GetUrlTemplate())
+	assert.Equal(t,
+		"https://organizer.test.local/?org_id=zitadel-org-xyz&login_hint=op%40acme.com",
+		send.GetUrlTemplate(),
+	)
+	assert.NotContains(t, send.GetUrlTemplate(), "{{", "url_template must be a literal, no Zitadel placeholders")
+	assert.NotContains(t, send.GetUrlTemplate(), "Code", "invite link must not carry the invite code")
 	assert.Equal(t, "Liverty Organizer", send.GetApplicationName())
 }
 

--- a/internal/infrastructure/zitadel/organizer_provisioner_test.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner_test.go
@@ -242,6 +242,29 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "idempotent: CreateInviteCode FailedPrecondition (operator already onboarded) is benign, saga proceeds to grant",
+			args: args{
+				organizerID:   "org-abc12345",
+				name:          "Onboarded Label",
+				operatorEmail: "op@onboarded.com",
+			},
+			stub: &stubMgmt{
+				addOrgResp: &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"},
+			},
+			userV2: &stubUserV2{
+				addHumanUserResp: &userv2pb.AddHumanUserResponse{UserId: "op-onboarded"},
+				// Zitadel rejects re-inviting an already-initialized operator; the
+				// saga must treat that as benign and still apply the owner grant.
+				createInviteErr: grpcstatus.Error(grpccodes.FailedPrecondition, "user already initialized"),
+			},
+			wantOrgID: "zitadel-org-xyz",
+			check: func(t *testing.T, stub *stubMgmt) {
+				t.Helper()
+				require.Len(t, stub.addUserGrantReqs, 1)
+				assert.Equal(t, "op-onboarded", stub.addUserGrantReqs[0].GetUserId())
+			},
+		},
+		{
 			name: "AddOrg non-AlreadyExists error returns error",
 			args: args{
 				organizerID:   "org-abc12345",

--- a/internal/infrastructure/zitadel/organizer_provisioner_test.go
+++ b/internal/infrastructure/zitadel/organizer_provisioner_test.go
@@ -114,16 +114,19 @@ type stubUserV2 struct {
 	addHumanUserResp *userv2pb.AddHumanUserResponse
 	addHumanUserErr  error
 
-	// createPasskeyLinkErr controls CreatePasskeyRegistrationLink.
-	createPasskeyLinkErr error
+	// createInviteErr controls CreateInviteCode.
+	createInviteErr error
+	// createInviteReq captures the last CreateInviteCode request for assertions.
+	createInviteReq *userv2pb.CreateInviteCodeRequest
 }
 
 func (s *stubUserV2) AddHumanUser(_ context.Context, _ *userv2pb.AddHumanUserRequest, _ ...grpc.CallOption) (*userv2pb.AddHumanUserResponse, error) {
 	return s.addHumanUserResp, s.addHumanUserErr
 }
 
-func (s *stubUserV2) CreatePasskeyRegistrationLink(_ context.Context, _ *userv2pb.CreatePasskeyRegistrationLinkRequest, _ ...grpc.CallOption) (*userv2pb.CreatePasskeyRegistrationLinkResponse, error) {
-	return &userv2pb.CreatePasskeyRegistrationLinkResponse{}, s.createPasskeyLinkErr
+func (s *stubUserV2) CreateInviteCode(_ context.Context, req *userv2pb.CreateInviteCodeRequest, _ ...grpc.CallOption) (*userv2pb.CreateInviteCodeResponse, error) {
+	s.createInviteReq = req
+	return &userv2pb.CreateInviteCodeResponse{}, s.createInviteErr
 }
 
 // newTestProvisioner builds an OrganizerProvisioner wired to the given stubs
@@ -139,6 +142,7 @@ func newTestProvisioner(t *testing.T, stub *stubMgmt, userV2 *stubUserV2) *Organ
 		mgmt:                      stub,
 		userV2:                    userV2,
 		organizerConsoleProjectID: "proj-1",
+		consoleBaseURL:            "https://organizer.test.local",
 		logger:                    logger,
 	}
 }
@@ -222,7 +226,7 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 			wantOrgID: "zitadel-org-existing",
 		},
 		{
-			name: "FATAL: CreatePasskeyRegistrationLink failure returns error",
+			name: "FATAL: CreateInviteCode failure returns error",
 			args: args{
 				organizerID:   "org-abc12345",
 				name:          "Fail Label",
@@ -232,8 +236,8 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 				addOrgResp: &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"},
 			},
 			userV2: &stubUserV2{
-				addHumanUserResp:     &userv2pb.AddHumanUserResponse{UserId: "op-1"},
-				createPasskeyLinkErr: grpcstatus.Error(grpccodes.Internal, "email delivery failed"),
+				addHumanUserResp: &userv2pb.AddHumanUserResponse{UserId: "op-1"},
+				createInviteErr:  grpcstatus.Error(grpccodes.Internal, "email delivery failed"),
 			},
 			wantErr: true,
 		},
@@ -282,6 +286,54 @@ func TestOrganizerProvisioner_ProvisionTenant(t *testing.T) {
 			if tt.check != nil {
 				tt.check(t, tt.stub)
 			}
+		})
+	}
+}
+
+func TestOrganizerProvisioner_ProvisionTenant_sendsConsolePointedInvite(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubMgmt{addOrgResp: &mgmtpb.AddOrgResponse{Id: "zitadel-org-xyz"}}
+	userV2 := &stubUserV2{addHumanUserResp: &userv2pb.AddHumanUserResponse{UserId: "operator-user-1"}}
+	p := newTestProvisioner(t, stub, userV2)
+
+	_, err := p.ProvisionTenant(context.Background(), "org-abc12345", "Acme Label", "op@acme.com")
+	require.NoError(t, err)
+
+	// The operator onboarding email is a Zitadel invite whose link points at the
+	// console (org pinned via org_id template), NOT a Zitadel setup page.
+	require.NotNil(t, userV2.createInviteReq)
+	assert.Equal(t, "operator-user-1", userV2.createInviteReq.GetUserId())
+	send := userV2.createInviteReq.GetSendCode()
+	require.NotNil(t, send, "invite must be SendCode (Zitadel-sent email), not ReturnCode")
+	assert.Equal(t, "https://organizer.test.local/?org_id={{.OrgID}}", send.GetUrlTemplate())
+	assert.Equal(t, "Liverty Organizer", send.GetApplicationName())
+}
+
+func TestConsoleBaseURLFromIssuer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		issuer  string
+		want    string
+		wantErr bool
+	}{
+		{name: "prod", issuer: "https://auth.liverty-music.app", want: "https://organizer.liverty-music.app"},
+		{name: "dev", issuer: "https://auth.dev.liverty-music.app", want: "https://organizer.dev.liverty-music.app"},
+		{name: "issuer host not prefixed with auth.", issuer: "https://id.example.com", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := consoleBaseURLFromIssuer(tt.issuer)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/specification#759

<!-- Completes task 4.3 of the `organizer-console` OpenSpec change (roadmap step ①).
     No proto changes; standalone backend change. -->

## 📝 Summary of Changes

**Motivation.** After idle onboarding investigation (2026-08-21), the operator
invitation email was a dead-end: the provisioner sent a bare
`CreatePasskeyRegistrationLink` (`passkey/set`) link, which is single-use even on
failure (upstream [zitadel/zitadel#12499](https://github.com/zitadel/zitadel/issues/12499))
and lives outside any OIDC context — so a failed first passkey ceremony can never
be retried, and a success dead-ends on Zitadel's `signedin` page with no path back
to the console.

**Fix.** Replace it in the operator provisioning saga with
`CreateInviteCode(SendInviteCode)`. Zitadel sends the "Invitation to Zitadel Login"
email via its own SMTP, and the `url_template` points the "Accept invite" link at
the **organizer console** (`https://organizer.{base}/?org_id={{.OrgID}}`), which
starts the OIDC flow. Login v2 then detects the pending invite and drives the
passkey ceremony **within the auth request**, finalising it to `/auth/callback` →
`/welcome`. This is the same invite-driven flow the earlier org-test-7 onboarding
succeeded with — made explicit and console-pointed.

**Technical approach.**
- `CreateInviteCode(SendInviteCode{UrlTemplate, ApplicationName})` replaces
  `CreatePasskeyRegistrationLink(SendLink)` in `ensureOperatorUser`.
- The console base URL is derived from the issuer (`auth.{base}` → `organizer.{base}`)
  — no new config threaded through DI (console + issuer share the base domain per env).
- `url_template` placeholders are limited to `UserID/OrgID/Code` (no email), so
  `login_hint` is not carried in the Zitadel-sent invite; the operator enters their
  email once at Login v2. The shipped frontend `login_hint` remains for re-issued /
  admin-copied console links.
- Invite send stays **FATAL** on failure — provisioning must not report success if
  the operator cannot be onboarded (the reconciler retries).

No custom backend email (an earlier design assumption): the backend has no direct
email/Postmark infrastructure — its only email path is *through* Zitadel — so
letting Zitadel send the invite via `SendInviteCode` reuses its configured SMTP
with no new backend email code.

## 📋 Commit Log

```
feat(organizer): send operator onboarding via Zitadel invite, not passkey link
```

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have added or updated tests (invite request shape + `consoleBaseURLFromIssuer` derivation; FATAL case retargeted).
- [x] I have updated the relevant documentation (OpenSpec `organizer-console` design D5 + spec + tasks, separate specification PR).
- [x] I have run `make lint` (0 issues) and `make check` (pre-commit hook) locally — all pass.
- [x] My code follows the architecture and style guidelines of the project.

## 📸 Screenshots or Logs

Prod verification (fresh org → invite email → console → passkey → `/welcome`)
will be run after this deploys, per task 4.3 / design D5 "Open validation".
